### PR TITLE
Normalize RST labels to remove duplicates (for one option)

### DIFF
--- a/changelogs/fragments/7-label-normalization.yml
+++ b/changelogs/fragments/7-label-normalization.yml
@@ -1,2 +1,3 @@
 bugfixes:
   - "Make sure that aliases of module/plugin options and return values that result in identical RST labels under docutil's normalization are only emitted once (https://github.com/ansible-community/antsibull-docs/pull/7)."
+  - "Properly escape module/plugin option and return value slugs in generated HTML (https://github.com/ansible-community/antsibull-docs/pull/7)."

--- a/changelogs/fragments/7-label-normalization.yml
+++ b/changelogs/fragments/7-label-normalization.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Make sure that aliases of module/plugin options and return values that result in identical RST labels under docutil's normalization are only emitted once (https://github.com/ansible-community/antsibull-docs/pull/7)."

--- a/src/antsibull_docs/augment_docs.py
+++ b/src/antsibull_docs/augment_docs.py
@@ -44,6 +44,9 @@ def add_full_key(options_data: t.Mapping[str, t.Any], suboption_entry: str,
                 full_keys_k.extend([fk + [alias] for fk in _full_keys])
         entry['full_key'] = full_key_k
         entry['full_keys'] = full_keys_k
+        entry['full_keys_rst'] = sorted({
+            tuple(' '.join(p.lower().split()) for p in fk) for fk in full_keys_k
+        })
 
         # Process suboptions
         suboptions = entry.get(suboption_entry)

--- a/src/antsibull_docs/data/docsite/macros/parameters.rst.j2
+++ b/src/antsibull_docs/data/docsite/macros/parameters.rst.j2
@@ -18,7 +18,7 @@
 
         {% for i in range(1, loop.depth) %}<div class="ansible-option-indent"></div>{% endfor %}<div class="ansible-option-cell">
 {% for full_key in value['full_keys'] %}
-        <div class="ansibleOptionAnchor" id="parameter-@{ parameter_html_prefix }@{% for part in full_key %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}"></div>
+        <div class="ansibleOptionAnchor" id="parameter-@{ parameter_html_prefix }@{% for part in full_key %}@{ part | urlencode }@{% if not loop.last %}/{% endif %}{% endfor %}"></div>
 {% endfor %}
 
 {% for full_key in value['full_keys'] %}
@@ -31,7 +31,7 @@
 
       .. raw:: html
 
-        <a class="ansibleOptionLink" href="#parameter-@{ parameter_html_prefix }@{% for part in value['full_key'] %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}" title="Permalink to this option"></a>
+        <a class="ansibleOptionLink" href="#parameter-@{ parameter_html_prefix }@{% for part in value['full_key'] %}@{ part | urlencode }@{% if not loop.last %}/{% endif %}{% endfor %}" title="Permalink to this option"></a>
 {%   if value['aliases'] %}
 
       .. rst-class:: ansible-option-type-line
@@ -191,10 +191,10 @@
   <tr class="row-@{ row_class.next() }@">
     <td>{% for i in range(1, loop.depth) %}<div class="ansible-option-indent"></div>{% endfor %}<div class="ansible-option-cell">
 {%   for full_key in value['full_keys'] %}
-      <div class="ansibleOptionAnchor" id="parameter-@{ parameter_html_prefix }@{% for part in full_key %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}"></div>
+      <div class="ansibleOptionAnchor" id="parameter-@{ parameter_html_prefix }@{% for part in full_key %}@{ part | urlencode }@{% if not loop.last %}/{% endif %}{% endfor %}"></div>
 {%   endfor %}
       <p class="ansible-option-title"><strong>@{ key | escape }@</strong></p>
-      <a class="ansibleOptionLink" href="#parameter-@{ parameter_html_prefix }@{% for part in value['full_key'] %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}" title="Permalink to this option"></a>
+      <a class="ansibleOptionLink" href="#parameter-@{ parameter_html_prefix }@{% for part in value['full_key'] %}@{ part | urlencode }@{% if not loop.last %}/{% endif %}{% endfor %}" title="Permalink to this option"></a>
 {%   if value['aliases'] %}
       <p class="ansible-option-type-line"><span class="ansible-option-aliases">aliases: @{ value['aliases']|join(', ') }@</span></p>
 {%   endif %}

--- a/src/antsibull_docs/data/docsite/macros/parameters.rst.j2
+++ b/src/antsibull_docs/data/docsite/macros/parameters.rst.j2
@@ -21,7 +21,7 @@
         <div class="ansibleOptionAnchor" id="parameter-@{ parameter_html_prefix }@{% for part in full_key %}@{ part | urlencode }@{% if not loop.last %}/{% endif %}{% endfor %}"></div>
 {% endfor %}
 
-{% for full_key in value['full_keys'] %}
+{% for full_key in value['full_keys_rst'] %}
       .. _ansible_collections.@{plugin_name}@_@{plugin_type}@__parameter-@{ parameter_rst_prefix }@{% for part in full_key %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}:
 {% endfor %}
 

--- a/src/antsibull_docs/data/docsite/macros/returnvalues.rst.j2
+++ b/src/antsibull_docs/data/docsite/macros/returnvalues.rst.j2
@@ -18,7 +18,7 @@
         <div class="ansibleOptionAnchor" id="return-{% for part in full_key %}@{ part | urlencode }@{% if not loop.last %}/{% endif %}{% endfor %}"></div>
 {% endfor %}
 
-{% for full_key in value['full_keys'] %}
+{% for full_key in value['full_keys_rst'] %}
       .. _ansible_collections.@{plugin_name}@_@{plugin_type}@__return-{% for part in full_key %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}:
 {% endfor %}
 

--- a/src/antsibull_docs/data/docsite/macros/returnvalues.rst.j2
+++ b/src/antsibull_docs/data/docsite/macros/returnvalues.rst.j2
@@ -15,7 +15,7 @@
 
         {% for i in range(1, loop.depth) %}<div class="ansible-option-indent"></div>{% endfor %}<div class="ansible-option-cell">
 {% for full_key in value['full_keys'] %}
-        <div class="ansibleOptionAnchor" id="return-{% for part in full_key %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}"></div>
+        <div class="ansibleOptionAnchor" id="return-{% for part in full_key %}@{ part | urlencode }@{% if not loop.last %}/{% endif %}{% endfor %}"></div>
 {% endfor %}
 
 {% for full_key in value['full_keys'] %}
@@ -28,7 +28,7 @@
 
       .. raw:: html
 
-        <a class="ansibleOptionLink" href="#return-{% for part in value['full_key'] %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}" title="Permalink to this return value"></a>
+        <a class="ansibleOptionLink" href="#return-{% for part in value['full_key'] %}@{ part | urlencode }@{% if not loop.last %}/{% endif %}{% endfor %}" title="Permalink to this return value"></a>
 
       .. rst-class:: ansible-option-type-line
 
@@ -119,10 +119,10 @@
   <tr class="row-@{ row_class.next() }@">
     <td>{% for i in range(1, loop.depth) %}<div class="ansible-option-indent"></div>{% endfor %}<div class="ansible-option-cell">
 {%   for full_key in value['full_keys'] %}
-      <div class="ansibleOptionAnchor" id="return-{% for part in full_key %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}"></div>
+      <div class="ansibleOptionAnchor" id="return-{% for part in full_key %}@{ part | urlencode }@{% if not loop.last %}/{% endif %}{% endfor %}"></div>
 {%   endfor %}
       <p class="ansible-option-title"><strong>@{ key | escape }@</strong></p>
-      <a class="ansibleOptionLink" href="#return-{% for part in value['full_key'] %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}" title="Permalink to this return value"></a>
+      <a class="ansibleOptionLink" href="#return-{% for part in value['full_key'] %}@{ part | urlencode }@{% if not loop.last %}/{% endif %}{% endfor %}" title="Permalink to this return value"></a>
       <p class="ansible-option-type-line">
         <span class="ansible-option-type">@{ value['type'] | documented_type }@</span>
 {%   if value['type'] == 'list' and value['elements'] is not none %}


### PR DESCRIPTION
docutils normalizes labels to targets by making them lowercase and normalizing whitespace. We do this for all labels for an option to avoid collisions. (You can still have collisions if you have two distinct options that differ by case, for example.)