### PR TITLE
Support plugin seealso

### DIFF
--- a/changelogs/fragments/8-seealso-plugin.yml
+++ b/changelogs/fragments/8-seealso-plugin.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Support plugin ``seealso`` from the `semantic markup specification <https://hackmd.io/VjN60QSoRSSeRfvGmOH1lQ?both>`__ (https://github.com/ansible-community/antsibull-docs/pull/8)."

--- a/src/antsibull_docs/data/docsite/plugin.rst.j2
+++ b/src/antsibull_docs/data/docsite/plugin.rst.j2
@@ -281,11 +281,17 @@ See Also
 
 {% for item in doc['seealso'] %}
 {%   if item.module is defined and item.description %}
-   @{ ('M(' + item['module'] + ')') | rst_ify }@
+   @{ reference_plugin_rst(item['module'], 'module') }@
        @{ item['description'] | rst_ify }@
 {%   elif item.module is defined %}
-   @{ ('M(' + item['module'] + ')') | rst_ify }@
+   @{ reference_plugin_rst(item['module'], 'module') }@
       The official documentation on the **@{ item['module'] }@** module.
+{%   elif item.plugin is defined and item.plugin_type is defined and item.description %}
+   @{ reference_plugin_rst(item['plugin'], item['plugin_type']) }@ @{ item['plugin_type'] }@ plugin
+       @{ item['description'] | rst_ify }@
+{%   elif item.plugin is defined and item.plugin_type is defined %}
+   @{ reference_plugin_rst(item['plugin'], item['plugin_type']) }@ @{ item['plugin_type'] }@ plugin
+      The official documentation on the **@{ item['plugin'] }@** @{ item['plugin_type'] }@ plugin.
 {%   elif item.name is defined and item.link is defined and item.description %}
    `@{ item['name'] }@ <@{ item['link'] }@>`_
        @{ item['description'] | rst_ify }@

--- a/src/antsibull_docs/data/docsite/role.rst.j2
+++ b/src/antsibull_docs/data/docsite/role.rst.j2
@@ -156,11 +156,17 @@ See Also
 
 {%     for item in ep_doc['seealso'] %}
 {%       if item.module is defined and item.description %}
-   @{ ('M(' + item['module'] + ')') | rst_ify }@
+   @{ reference_plugin_rst(item['module'], 'module') }@
        @{ item['description'] | rst_ify }@
 {%       elif item.module is defined %}
-   @{ ('M(' + item['module'] + ')') | rst_ify }@
+   @{ reference_plugin_rst(item['module'], 'module') }@
       The official documentation on the **@{ item['module'] }@** module.
+{%       elif item.plugin is defined and item.plugin_type is defined and item.description %}
+   @{ reference_plugin_rst(item['plugin'], item['plugin_type']) }@ @{ item['plugin_type'] }@ plugin
+       @{ item['description'] | rst_ify }@
+{%       elif item.plugin is defined and item.plugin_type is defined %}
+   @{ reference_plugin_rst(item['plugin'], item['plugin_type']) }@ @{ item['plugin_type'] }@ plugin
+      The official documentation on the **@{ item['plugin'] }@** @{ item['plugin_type'] }@ plugin.
 {%       elif item.name is defined and item.link is defined and item.description %}
    `@{ item['name'] }@ <@{ item['link'] }@>`_
        @{ item['description'] | rst_ify }@

--- a/src/antsibull_docs/jinja2/environment.py
+++ b/src/antsibull_docs/jinja2/environment.py
@@ -31,6 +31,11 @@ def from_kludge_ns(key):
     return NS_MAP[key]
 
 
+def reference_plugin_rst(plugin_name: str, plugin_type: str) -> str:
+    fqcn = f'{plugin_name}'
+    return f"\\ :ref:`{rst_escape(fqcn)} <ansible_collections.{fqcn}_{plugin_type}>`\\ "
+
+
 def doc_environment(template_location):
     if isinstance(template_location, str) and os.path.exists(template_location):
         loader = FileSystemLoader(template_location)
@@ -54,6 +59,7 @@ def doc_environment(template_location):
     # with <Jinja-2.10
     env.globals['to_kludge_ns'] = to_kludge_ns
     env.globals['from_kludge_ns'] = from_kludge_ns
+    env.globals['reference_plugin_rst'] = reference_plugin_rst
     if 'max' not in env.filters:
         # Jinja < 2.10
         env.filters['max'] = do_max

--- a/src/antsibull_docs/schemas/docs/base.py
+++ b/src/antsibull_docs/schemas/docs/base.py
@@ -440,6 +440,12 @@ class SeeAlsoModSchema(BaseModel):
     description: str = ""
 
 
+class SeeAlsoPluginSchema(BaseModel):
+    plugin: str
+    plugin_type: str
+    description: str = ""
+
+
 class SeeAlsoRefSchema(BaseModel):
     description: str
     ref: str
@@ -505,7 +511,10 @@ class DocSchema(BaseModel):
     filename: str = ''
     notes: t.List[str] = []
     requirements: t.List[str] = []
-    seealso: t.List[t.Union[SeeAlsoModSchema, SeeAlsoRefSchema, SeeAlsoLinkSchema]] = []
+    seealso: t.List[t.Union[SeeAlsoModSchema,
+                            SeeAlsoPluginSchema,
+                            SeeAlsoRefSchema,
+                            SeeAlsoLinkSchema]] = []
     todo: t.List[str] = []
     version_added: str = 'historical'
     version_added_collection: str = COLLECTION_NAME_F


### PR DESCRIPTION
Defined in semantic markup spec: https://hackmd.io/VjN60QSoRSSeRfvGmOH1lQ?both

This is needed for https://github.com/ansible/ansible/pull/77687. It can mainly be used by plugins that are not validated by ansible-test's validate-modules, i.e. test and filter plugins.