### PR TITLE
Avoid repeating input argument when it is mentioned as positional

### DIFF
--- a/changelogs/fragments/10-filter-test-input-positional.yml
+++ b/changelogs/fragments/10-filter-test-input-positional.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Make sure that ``_input`` does not show up twice for test or filter arguments when the plugin mentions it in ``positional`` (https://github.com/ansible-community/antsibull-docs/pull/10)."

--- a/src/antsibull_docs/data/docsite/plugin.rst.j2
+++ b/src/antsibull_docs/data/docsite/plugin.rst.j2
@@ -202,7 +202,7 @@ This describes the input of the test, the value before ``is @{plugin_name}@`` or
 
 {% endif %}
 
-{% if doc['positional'] and plugin_type in ['lookup', 'filter', 'test'] %}
+{% if doc['positional'] and plugin_type in ['lookup', 'filter', 'test'] and doc['positional'] != ['_input'] %}
 {%   set options_to_skip = options_to_skip + doc['positional'] %}
 
 .. Positional
@@ -217,9 +217,9 @@ This describes positional parameters of the test. These are the values ``positio
 {%   endif %}
 
 {%   if use_html_blobs %}
-@{     parameters_html(doc['options'] | extract_options_from_list(doc['positional']), suboption_key='suboptions') }@
+@{     parameters_html(doc['options'] | extract_options_from_list(doc['positional'], options_to_ignore=['_input']), suboption_key='suboptions') }@
 {%   else %}
-@{     parameters_rst(doc['options'] | extract_options_from_list(doc['positional']), suboption_key='suboptions') }@
+@{     parameters_rst(doc['options'] | extract_options_from_list(doc['positional'], options_to_ignore=['_input']), suboption_key='suboptions') }@
 {%   endif %}
 
 {% endif %}

--- a/src/antsibull_docs/jinja2/filters.py
+++ b/src/antsibull_docs/jinja2/filters.py
@@ -197,9 +197,16 @@ def massage_author_name(value):
 
 
 def extract_options_from_list(options: t.Dict[str, t.Any],
-                              options_to_extract: t.List[str]) -> t.List[t.Tuple[str, t.Any]]:
+                              options_to_extract: t.List[str],
+                              options_to_ignore: t.Optional[t.List[str]] = None
+                              ) -> t.List[t.Tuple[str, t.Any]]:
     ''' return list of tuples (option, option_data) with option from options_to_extract '''
-    return [(option, options[option]) for option in options_to_extract if option in options]
+    if options_to_ignore is None:
+        options_to_ignore = []
+    return [
+        (option, options[option]) for option in options_to_extract
+        if option in options and option not in options_to_ignore
+    ]
 
 
 def remove_options_from_list(options: t.Dict[str, t.Any],


### PR DESCRIPTION
Basically fixes https://github.com/ansible/ansible/pull/77725 on our side. (I still think this is wrong and should be highlighted by a linter, but there is no linter and if core doesn't change it, we have to accept it as-is...)