### PR TITLE
Stop using EOL Node in CI

### DIFF
--- a/.github/workflows/build-css.yml
+++ b/.github/workflows/build-css.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 16.x
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Currently the Build CSS CI fails, probably because it uses an EOL Node version (12). See https://github.com/ansible-community/antsibull-docs/runs/7174589387?check_suite_focus=true.