### PR TITLE
Add support for newer rstcheck versions

### DIFF
--- a/changelogs/fragments/13-rstcheck.yml
+++ b/changelogs/fragments/13-rstcheck.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "Mark rstcheck 4.x and 5.x as compatible (https://github.com/ansible-community/antsibull-docs/pull/13)."
+  - "Mark rstcheck 4.x and 5.x as compatible. Support rstcheck 6.x as well (https://github.com/ansible-community/antsibull-docs/pull/13)."

--- a/changelogs/fragments/13-rstcheck.yml
+++ b/changelogs/fragments/13-rstcheck.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Mark rstcheck 4.x and 5.x as compatible (https://github.com/ansible-community/antsibull-docs/pull/13)."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ antsibull-core = ">= 1.0.0, < 2.0.0"
 asyncio-pool = "*"
 docutils = "*"
 jinja2 = "*"
-rstcheck = "^3"
+rstcheck = ">= 3.0.0, < 6.0.0"
 sphinx = "*"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ antsibull-core = ">= 1.0.0, < 2.0.0"
 asyncio-pool = "*"
 docutils = "*"
 jinja2 = "*"
-rstcheck = ">= 3.0.0, < 6.0.0"
+rstcheck = ">= 3.0.0, < 7.0.0"
 sphinx = "*"
 
 [tool.poetry.dev-dependencies]

--- a/src/antsibull_docs/lint_extra_docs.py
+++ b/src/antsibull_docs/lint_extra_docs.py
@@ -10,9 +10,6 @@ import os.path
 import re
 import typing as t
 
-import docutils.utils
-import rstcheck
-
 from antsibull_core.yaml import load_yaml_file
 
 from .extra_docs import (
@@ -21,6 +18,7 @@ from .extra_docs import (
     load_extra_docs_index,
     ExtraDocsIndexError,
 )
+from .rstcheck import check_rst_content
 
 
 _RST_LABEL_DEFINITION = re.compile(r'''^\.\. _([^:]+):''')
@@ -53,10 +51,7 @@ def lint_optional_conditions(content: str, path: str, collection_name: str
 
     Return a list of errors.
     '''
-    results = rstcheck.check(
-        content, filename=path,
-        report_level=docutils.utils.Reporter.WARNING_LEVEL)
-    return [(result[0], 0, result[1]) for result in results]
+    return check_rst_content(content, filename=path)
 
 
 def lint_collection_extra_docs_files(path_to_collection: str

--- a/src/antsibull_docs/rstcheck.py
+++ b/src/antsibull_docs/rstcheck.py
@@ -1,0 +1,48 @@
+# coding: utf-8
+# Author: Felix Fontein <felix@fontein.de>
+# License: GPLv3+
+# Copyright: Ansible Project, 2022
+"""Handle rstcheck."""
+
+import os.path
+import pathlib
+import tempfile
+import typing as t
+
+# rstcheck >= 6.0.0 depends on rstcheck-core
+try:
+    import rstcheck_core.checker
+    import rstcheck_core.config
+    HAS_RSTCHECK_CORE = True
+except ImportError:
+    HAS_RSTCHECK_CORE = False
+    import docutils.utils
+    import rstcheck
+
+
+def check_rst_content(content: str, filename: t.Optional[str] = None
+                      ) -> t.List[t.Tuple[int, int, str]]:
+    '''
+    Check the content with rstcheck. Return list of errors and warnings.
+
+    The entries in the return list are tuples with line number, column number, and
+    error/warning message.
+    '''
+    if HAS_RSTCHECK_CORE:
+        filename = os.path.basename(filename or 'file.rst') or 'file.rst'
+        with tempfile.TemporaryDirectory() as tempdir:
+            rst_path = os.path.join(tempdir, filename)
+            with open(rst_path, 'w', encoding='utf-8') as f:
+                f.write(content)
+            config = rstcheck_core.config.RstcheckConfig(
+                report_level=rstcheck_core.config.ReportLevel.WARNING,
+            )
+            core_results = rstcheck_core.checker.check_file(pathlib.Path(rst_path), config)
+            return [(result.line_number, 0, result.message) for result in core_results]
+    else:
+        results = rstcheck.check(
+            content,
+            filename=filename,
+            report_level=docutils.utils.Reporter.WARNING_LEVEL,
+        )
+        return [(result[0], 0, result[1]) for result in results]

--- a/stubs/rstcheck.pyi
+++ b/stubs/rstcheck.pyi
@@ -1,10 +1,10 @@
 import docutils.utils
 
-from typing import List, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 
 def check(source: str,
-          filename: str = ...,
-          report_level: docutils.utils.Reporter = ...,
+          filename: Optional[str] = ...,
+          report_level: Union[docutils.utils.Reporter, int] = ...,
           ignore: Union[dict, None] = ...,
           debug: bool = ...) -> List[Tuple[int, str]]: ...

--- a/stubs/rstcheck_core/checker.pyi
+++ b/stubs/rstcheck_core/checker.pyi
@@ -1,0 +1,13 @@
+import enum
+import pathlib
+
+from typing import List, Optional, Tuple, Union
+
+from . import config, types
+
+
+def check_file(
+    source_file: pathlib.Path,
+    rstcheck_config: config.RstcheckConfig,
+    overwrite_with_file_config: bool = True,
+) -> List[types.LintError]: ...

--- a/stubs/rstcheck_core/config.pyi
+++ b/stubs/rstcheck_core/config.pyi
@@ -1,0 +1,15 @@
+import enum
+
+from typing import List, Optional, Tuple, Union
+
+
+class ReportLevel(enum.Enum):
+    INFO = 1
+    WARNING = 2
+    ERROR = 3
+    SEVERE = 4
+    NONE = 5
+
+
+class RstcheckConfig:
+    def __init__(self, report_level: Optional[ReportLevel] = ...): ...

--- a/stubs/rstcheck_core/types.pyi
+++ b/stubs/rstcheck_core/types.pyi
@@ -1,0 +1,10 @@
+import enum
+import pathlib
+
+from typing import Literal, Union
+
+
+class LintError:
+    source_origin: Union[pathlib.Path, Literal["<string>"], Literal["<stdin>"]]
+    line_number: int
+    message: str


### PR DESCRIPTION
Versions 4.x and 5.x are compatible as well. With 6.0.0 rstcheck was split into a library and CLI program (https://github.com/rstcheck/rstcheck/issues/104#issuecomment-1140295726). Switching the dependency from rstcheck to rstcheck-core will be a breaking change.