### PR TITLE
Fix JSON string escaping

### DIFF
--- a/changelogs/fragments/18-json.yml
+++ b/changelogs/fragments/18-json.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "Do not escape ``<``, ``>``, ``&``, and ``'`` in JSONified defaults and examples as the `Jinja2 tojson filter <https://jinja.palletsprojects.com/en/2.11.x/templates/#tojson>`_ does. Also improve formatting by making sure ``,`` is followed by a space (https://github.com/ansible-community/antsibull-docs/pull/18)."

--- a/src/antsibull_docs/data/docsite/macros/parameters.rst.j2
+++ b/src/antsibull_docs/data/docsite/macros/parameters.rst.j2
@@ -111,7 +111,7 @@
 
       .. rst-class:: ansible-option-line
 
-      :ansible-option-default-bold:`Default:` :ansible-option-default:`@{ value['default'] | tojson | rst_escape(escape_ending_whitespace=true) | indent(6) }@`
+      :ansible-option-default-bold:`Default:` :ansible-option-default:`@{ value['default'] | antsibull_to_json | rst_escape(escape_ending_whitespace=true) | indent(6) }@`
 {%   endif %}
 {#   Configuration #}
 {%   if plugin_type != 'module' and plugin_type != 'role' and (value['ini'] or value['env'] or value['vars'] or value['cli']) %}
@@ -256,7 +256,7 @@
 {%   endif %}
 {#   Show default value, when multiple choice or no choices #}
 {%   if value['default'] is not none and value['default'] not in value['choices'] %}
-      <p class="ansible-option-line"><span class="ansible-option-default-bold">Default:</span> <span class="ansible-option-default">@{ value['default'] | tojson | escape | indent(6) }@</span></p>
+      <p class="ansible-option-line"><span class="ansible-option-default-bold">Default:</span> <span class="ansible-option-default">@{ value['default'] | antsibull_to_json | escape | indent(6) }@</span></p>
 {%   endif %}
 {#   Configuration #}
 {%   if plugin_type != 'module' and plugin_type != 'role' and (value['ini'] or value['env'] or value['vars'] or value['cli']) %}

--- a/src/antsibull_docs/data/docsite/macros/returnvalues.rst.j2
+++ b/src/antsibull_docs/data/docsite/macros/returnvalues.rst.j2
@@ -92,7 +92,7 @@
       .. rst-class:: ansible-option-line
       .. rst-class:: ansible-option-sample
 
-      :ansible-option-sample-bold:`Sample:` @{ value['sample'] | tojson | rst_escape | indent(6) }@
+      :ansible-option-sample-bold:`Sample:` @{ value['sample'] | antsibull_to_json | rst_escape | indent(6) }@
 {%   endif %}
 
 
@@ -167,7 +167,7 @@
       </ul>
 {%   endif %}
 {%   if value['sample'] is not none %}
-      <p class="ansible-option-line ansible-option-sample"><span class="ansible-option-sample-bold">Sample:</span> @{ value['sample'] | tojson | escape | indent(6) }@</p>
+      <p class="ansible-option-line ansible-option-sample"><span class="ansible-option-sample-bold">Sample:</span> @{ value['sample'] | antsibull_to_json | escape | indent(6) }@</p>
 {%   endif %}
     </div></td>
   </tr>

--- a/src/antsibull_docs/jinja2/environment.py
+++ b/src/antsibull_docs/jinja2/environment.py
@@ -11,7 +11,7 @@ from jinja2 import Environment, FileSystemLoader, PackageLoader
 
 from .filters import (
     do_max, documented_type, html_ify, rst_ify, rst_escape, rst_fmt, rst_xline, move_first,
-    massage_author_name, extract_options_from_list, remove_options_from_list,
+    massage_author_name, extract_options_from_list, remove_options_from_list, to_json,
 )
 from .tests import still_relevant, test_list
 
@@ -80,6 +80,7 @@ def doc_environment(template_location):
     env.filters['massage_author_name'] = massage_author_name
     env.filters['extract_options_from_list'] = extract_options_from_list
     env.filters['remove_options_from_list'] = remove_options_from_list
+    env.filters['antsibull_to_json'] = to_json
     env.tests['list'] = test_list
     env.tests['still_relevant'] = still_relevant
 

--- a/src/antsibull_docs/jinja2/filters.py
+++ b/src/antsibull_docs/jinja2/filters.py
@@ -6,6 +6,7 @@
 Jinja2 filters for use in Ansible documentation.
 """
 
+import json
 import re
 from html import escape as html_escape
 from urllib.parse import quote
@@ -218,3 +219,7 @@ def remove_options_from_list(options: t.Dict[str, t.Any],
     for option in options_to_remove:
         result.pop(option, None)
     return result
+
+
+def to_json(data: t.Any) -> str:
+    return json.dumps(data, sort_keys=True, separators=(', ', ': '))

--- a/tests/units/test_jinja2.py
+++ b/tests/units/test_jinja2.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from antsibull_docs.jinja2.filters import rst_ify, rst_escape, move_first, massage_author_name
+from antsibull_docs.jinja2.filters import rst_ify, rst_escape, move_first, massage_author_name, to_json
 
 
 RST_IFY_DATA = {
@@ -86,3 +86,16 @@ MASSAGE_AUTHOR_NAME = [
 @pytest.mark.parametrize('input, expected', MASSAGE_AUTHOR_NAME)
 def test_massage_author_name(input, expected):
     assert massage_author_name(input) == expected
+
+
+TO_JSON = [
+    ('', '""'),
+    ('<foo>', '"<foo>"'),
+    (True, 'true'),
+    ({'b': False, 'a': 1}, '{"a": 1, "b": false}'),
+]
+
+
+@pytest.mark.parametrize('input, expected', TO_JSON)
+def test_to_json(input, expected):
+    assert to_json(input) == expected


### PR DESCRIPTION
As reported by @LvffY on #ansible-docs, in default and return value examples (which are JSONified), `<` and `>` are escaped as `\u003c` resp. `\u003e`. This is something Jinja2 does to avoid folks to shoot themselves in the foot in HTML templates. Since we properly escape the `tojson` output, we don't need this extra safety. This PR removes that extra safety.