### PR TITLE
Fix rstcheck-core support

### DIFF
--- a/.github/workflows/antsibull-docs.yml
+++ b/.github/workflows/antsibull-docs.yml
@@ -39,15 +39,16 @@ jobs:
           repository: ansible-community/antsibull-core
           path: antsibull-core
 
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: '3.10'
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install poetry
+          sed -i -e 's/^python = .*/python = "^3.10"/' pyproject.toml
           poetry install
           poetry update
         working-directory: antsibull-docs
@@ -125,15 +126,16 @@ jobs:
           repository: ansible-community/antsibull-core
           path: antsibull-core
 
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: '3.10'
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install poetry
+          sed -i -e 's/^python = .*/python = "^3.10"/' pyproject.toml
           poetry install
           poetry update
         working-directory: antsibull-docs
@@ -173,15 +175,16 @@ jobs:
           repository: ansible-community/antsibull-core
           path: antsibull-core
 
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: '3.10'
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install poetry
+          sed -i -e 's/^python = .*/python = "^3.10"/' pyproject.toml
           poetry install
           poetry update
         working-directory: antsibull-docs

--- a/.github/workflows/pythontests.yml
+++ b/.github/workflows/pythontests.yml
@@ -46,7 +46,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install poetry
-          sed -i -e 's/^python = .*/python = "^${{ matrix.python-version }}"/' pyproject.toml
+          if [ "${{ matrix.python-version }}" != "3.6" ]; then
+            # ^3.6 collides with 3.6.1 lower bound in antsibull-core
+            sed -i -e 's/^python = .*/python = "^${{ matrix.python-version }}"/' pyproject.toml
+          fi
           poetry install
           poetry update
         working-directory: antsibull-docs

--- a/.github/workflows/pythontests.yml
+++ b/.github/workflows/pythontests.yml
@@ -46,6 +46,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install poetry
+          sed -i -e 's/^python = .*/python = "^${{ matrix.python-version }}"/' pyproject.toml
           poetry install
           poetry update
         working-directory: antsibull-docs

--- a/changelogs/fragments/20-rstcheck-core.yml
+++ b/changelogs/fragments/20-rstcheck-core.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Fix rstcheck-core support (https://github.com/ansible-community/antsibull-docs/pull/20)."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,10 @@ antsibull-core = ">= 1.0.0, < 2.0.0"
 asyncio-pool = "*"
 docutils = "*"
 jinja2 = "*"
-rstcheck = ">= 3.0.0, < 7.0.0"
+rstcheck = [
+    {version = ">= 3.0.0, < 4.0.0", python = "~3.6"},
+    {version = ">= 3.0.0, < 7.0.0", python = "^3.7"}
+]
 sphinx = "*"
 
 [tool.poetry.dev-dependencies]
@@ -54,6 +57,8 @@ pylint = "^2.12.0"
 pytest = "*"
 pytest-asyncio = ">= 0.12"
 pytest-cov = "*"
+# Needed for TypedDict in rstcheck-core stubs
+typing-extensions = {version = ">=3.7.4", python = "<3.8"}
 # For development, we install dependent projects under our control in dev mode:
 antsibull-core = { path = "../antsibull-core/", develop = true }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,10 +39,7 @@ antsibull-core = ">= 1.0.0, < 2.0.0"
 asyncio-pool = "*"
 docutils = "*"
 jinja2 = "*"
-rstcheck = [
-    {version = ">= 3.0.0, < 4.0.0", python = "~3.6"},
-    {version = ">= 3.0.0, < 7.0.0", python = "^3.7"}
-]
+rstcheck = ">= 3.0.0, < 4.0.0"
 sphinx = "*"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ antsibull-core = ">= 1.0.0, < 2.0.0"
 asyncio-pool = "*"
 docutils = "*"
 jinja2 = "*"
-rstcheck = ">= 3.0.0, < 4.0.0"
+rstcheck = ">= 3.0.0, < 7.0.0"
 sphinx = "*"
 
 [tool.poetry.dev-dependencies]

--- a/src/antsibull_docs/rstcheck.py
+++ b/src/antsibull_docs/rstcheck.py
@@ -46,8 +46,9 @@ def check_rst_content(content: str, filename: t.Optional[str] = None,
             return [(result['line_number'], 0, result['message']) for result in core_results]
     else:
         if ignore_directives or ignore_roles:
-            rstcheck.ignore_directives_and_roles(ignore_directives or [], ignore_roles or [])
-        results = rstcheck.check(
+            rstcheck.ignore_directives_and_roles(  # pylint: disable=no-member
+                ignore_directives or [], ignore_roles or [])
+        results = rstcheck.check(  # pylint: disable=no-member
             content,
             filename=filename,
             report_level=docutils.utils.Reporter.WARNING_LEVEL,

--- a/src/antsibull_docs/rstcheck.py
+++ b/src/antsibull_docs/rstcheck.py
@@ -43,7 +43,7 @@ def check_rst_content(content: str, filename: t.Optional[str] = None,
                 ignore_roles=ignore_roles,
             )
             core_results = rstcheck_core.checker.check_file(pathlib.Path(rst_path), config)
-            return [(result.line_number, 0, result.message) for result in core_results]
+            return [(result['line_number'], 0, result['message']) for result in core_results]
     else:
         if ignore_directives or ignore_roles:
             rstcheck.ignore_directives_and_roles(ignore_directives or [], ignore_roles or [])

--- a/stubs/rstcheck_core/types.pyi
+++ b/stubs/rstcheck_core/types.pyi
@@ -7,8 +7,13 @@ import pathlib
 
 from typing import Literal, Union
 
+try:
+    from typing import TypedDict
+except ImportError:
+    from typing_extensions import TypedDict
 
-class LintError:
+
+class LintError(TypedDict):
     source_origin: Union[pathlib.Path, Literal["<string>"], Literal["<stdin>"]]
     line_number: int
     message: str

--- a/tests/functional/test_docs_linting.py
+++ b/tests/functional/test_docs_linting.py
@@ -54,7 +54,7 @@ communication:
       url: https://groups.google.com/g/ansible-project
 ''')
     write_file(docsite_rst_dir / 'foo.rst', b'''
-_ansible_collections.foo.bar.docsite.bla:
+.. _ansible_collections.foo.bar.docsite.bla:
 
 Foo bar
 =======
@@ -116,13 +116,21 @@ communication:
     - topic: Ansible Project List
       url: https://groups.google.com/g/ansible-project
 ''')
-    write_file(docsite_rst_dir / 'foo.rst', b'''
-_ansible_collections.foo.bar.docsite.bla:
+    foo_rst = docsite_rst_dir / 'foo.rst'
+    write_file(foo_rst, b'''
+.. _ansible_collections.foo.bar.docsite.bla:
 
 Foo bar
 =======
 
 Baz bam :ref:`myself <ansible_collections.foo.bar.docsite.bla>`.
+
+.. _ansible_collections.foo.bar.bad_label:
+
+Bad section
+-----------
+
+Foo ``bar`.
 ''')
 
     stdout = io.StringIO()
@@ -137,4 +145,6 @@ Baz bam :ref:`myself <ansible_collections.foo.bar.docsite.bla>`.
         f'{links}:0:0: edit_on_github -> branch: field required (type=value_error.missing)',
         f'{links}:0:0: extra_links -> 1 -> description: field required (type=value_error.missing)',
         f'{links}:0:0: foo: extra fields not permitted (type=value_error.extra)',
+        f'{foo_rst}:14:0: (WARNING/2) Inline literal start-string without end-string.',
+        f'{foo_rst}:9:0: Label "ansible_collections.foo.bar.bad_label" does not start with expected prefix "ansible_collections.foo.bar.docsite."',
     ]


### PR DESCRIPTION
There's a bug that's unfortunately not caught in the tests since these run with an older rstcheck version. For some reason, poetry insists on installing rstcheck 3.5.0. This is because `poetry update` tries to install versions of the dependency that support **all** Python versions that antsibull-changelog also supports, i.e. 3.6+, and only rstcheck < 4.0.0 does that.