### PR TITLE
Avoid Sphinx 5.2.0.post0 for docsite builds to work around a sphinx-rtd-theme bug

### DIFF
--- a/changelogs/fragments/40-sphinx-init-restriction.yml
+++ b/changelogs/fragments/40-sphinx-init-restriction.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - "The ``sphinx-init`` subcommand's ``requirement.txt`` file avoids Sphinx 5.2.0.post0, which triggers a bug in sphinx-rtd-theme
+     which happens to be the parent theme of the default theme sphinx_ansible_theme used by ``sphinx-init``
+     (https://github.com/ansible-community/antsibull-docs/issues/39, https://github.com/ansible-community/antsibull-docs/pull/40)."

--- a/src/antsibull_docs/data/sphinx_init/requirements_txt.j2
+++ b/src/antsibull_docs/data/sphinx_init/requirements_txt.j2
@@ -4,5 +4,5 @@
 
 antsibull-docs >= 1.0.0, < 2.0.0
 ansible-pygments
-sphinx
+sphinx != 5.2.0.post0  # The != 5.2.0.post0 restriction is thanks due to a bug in the sphinx-rtd-theme. Once this is fixed, this restriction can be removed.
 @{ sphinx_theme_package }@


### PR DESCRIPTION
This is mainly a workaround, see #39 for details.

The proper fix would be getting https://github.com/readthedocs/sphinx_rtd_theme/pull/1344 merged and into a new release ASAP.