### PR TITLE
Fix module/role level version_added rendering

### DIFF
--- a/changelogs/fragments/41-version_added.yml
+++ b/changelogs/fragments/41-version_added.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Avoid collection names with ``_`` in them appear wrongly escaped in the HTML output (https://github.com/ansible-community/antsibull-docs/pull/41)."

--- a/src/antsibull_docs/data/docsite/macros/version_added.rst.j2
+++ b/src/antsibull_docs/data/docsite/macros/version_added.rst.j2
@@ -18,24 +18,24 @@ ansible-core
 
 {% macro version_added_rst(version_added, version_added_collection=None, do_not_escape_first_word=False) -%}
 {%-   if version_added_collection == 'ansible.builtin' -%}
-@{ ansible_name(version_added) }@ @{ version_added | rst_escape }@
+@{      ansible_name(version_added) }@ @{ version_added | rst_escape }@
 {%-   elif version_added_collection and do_not_escape_first_word -%}
-@{ version_added_collection }@ @{ version_added | rst_escape }@
+@{      version_added_collection }@ @{ version_added | rst_escape }@
 {%-   elif version_added_collection -%}
-@{ version_added_collection | rst_escape }@ @{ version_added | rst_escape }@
+@{      version_added_collection | rst_escape }@ @{ version_added | rst_escape }@
 {%-   elif do_not_escape_first_word -%}
-@{ version_added }@
+@{      version_added }@
 {%-   else -%}
-@{ version_added | rst_escape }@
+@{      version_added | rst_escape }@
 {%-   endif -%}
 {%- endmacro %}
 
 {% macro version_added_html(version_added, version_added_collection=None) -%}
 {%-   if version_added_collection == 'ansible.builtin' -%}
-@{ ansible_name(version_added) }@ @{ version_added | escape }@
+@{      ansible_name(version_added) }@ @{ version_added | escape }@
 {%-   elif version_added_collection -%}
-@{ version_added_collection | escape }@ @{ version_added | escape }@
+@{      version_added_collection | escape }@ @{ version_added | escape }@
 {%-   else -%}
-@{ version_added | escape }@
+@{      version_added | escape }@
 {%-   endif -%}
 {%- endmacro %}

--- a/src/antsibull_docs/data/docsite/macros/version_added.rst.j2
+++ b/src/antsibull_docs/data/docsite/macros/version_added.rst.j2
@@ -16,11 +16,15 @@ ansible-core
 {%-  endif -%}
 {%- endmacro %}
 
-{% macro version_added_rst(version_added, version_added_collection=None) -%}
+{% macro version_added_rst(version_added, version_added_collection=None, do_not_escape_first_word=False) -%}
 {%-   if version_added_collection == 'ansible.builtin' -%}
 @{ ansible_name(version_added) }@ @{ version_added | rst_escape }@
+{%-   elif version_added_collection and do_not_escape_first_word -%}
+@{ version_added_collection }@ @{ version_added | rst_escape }@
 {%-   elif version_added_collection -%}
 @{ version_added_collection | rst_escape }@ @{ version_added | rst_escape }@
+{%-   elif do_not_escape_first_word -%}
+@{ version_added }@
 {%-   else -%}
 @{ version_added | rst_escape }@
 {%-   endif -%}

--- a/src/antsibull_docs/data/docsite/plugin.rst.j2
+++ b/src/antsibull_docs/data/docsite/plugin.rst.j2
@@ -112,7 +112,7 @@
 .. version_added
 
 {% if doc['version_added'] is still_relevant(collection=doc['version_added_collection'] or collection) -%}
-.. versionadded:: @{ version_added_rst(doc['version_added'], doc['version_added_collection'] or collection) }@
+.. versionadded:: @{ version_added_rst(doc['version_added'], doc['version_added_collection'] or collection, do_not_escape_first_word=true) }@
 {% endif %}
 
 .. contents::

--- a/src/antsibull_docs/data/docsite/role.rst.j2
+++ b/src/antsibull_docs/data/docsite/role.rst.j2
@@ -92,7 +92,7 @@
 .. version_added
 
 {%   if ep_doc['version_added'] is still_relevant(collection=collection) -%}
-.. versionadded:: @{ version_added_rst(ep_doc['version_added'], collection) }@
+.. versionadded:: @{ version_added_rst(ep_doc['version_added'], collection, do_not_escape_first_word=true) }@
 {%   endif %}
 
 .. Deprecated


### PR DESCRIPTION
There `_` is escaped and the escaping is visible in the rendered HTML, see for example https://docs.ansible.com/ansible/devel/collections/community/hashi_vault/vault_kv2_get_module.html, https://docs.ansible.com/ansible/devel/collections/community/sap_libs/sap_snote_module.html, and https://docs.ansible.com/ansible/devel/collections/cloudscale_ch/cloud/network_module.html.

Thanks to @briantist for noticing and reporting this on IRC.