### PR TITLE
Allow to specify toctree elements that are not strings

### DIFF
--- a/changelogs/fragments/45-extra-docs-toctree.yml
+++ b/changelogs/fragments/45-extra-docs-toctree.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Allow the ``toctree`` entries for in a collection's ``docs/docsite/extra-docs.yml`` to be a dictionary with ``ref`` and ``title`` keys instead of just a reference as a string (https://github.com/ansible-community/antsibull-docs/pull/45)."

--- a/src/antsibull_docs/data/docsite/plugins_by_collection.rst.j2
+++ b/src/antsibull_docs/data/docsite/plugins_by_collection.rst.j2
@@ -94,7 +94,11 @@ Communication
     :maxdepth: 1
 
 {%     for toctree_entry in section.toctree %}
-    @{toctree_entry}@
+{%       if toctree_entry.title %}
+    @{ toctree_entry.title | rst_escape }@ <@{ toctree_entry.ref }@>
+{%       else %}
+    @{ toctree_entry.ref }@
+{%       endif %}
 {%     endfor %}
 {%   endif %}
 


### PR DESCRIPTION
For example, this allows to have
```.yml
---
sections:
  - title: Changelog
    toctree:
      - title: Changelog
        ref: CHANGELOG
```
in docs/docsite/extra-docs.yml to get a toctree entry `Changelog <docsite/CHANGELOG>`.

Implements https://github.com/ansible-community/antsibull-docs/issues/31#issuecomment-1232882727

CC @briantist