### PR TITLE
Consider plugins whose last component of FQCN starts with '_' as private

### DIFF
--- a/changelogs/fragments/56-private.yml
+++ b/changelogs/fragments/56-private.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "From now on plugins outside ``ansible.builtin`` whose last FQCN component starts with ``_`` are treated as private and marked as such in their documentation, and are no longer listed in plugin indexes (https://github.com/ansible-community/antsibull-docs/pull/56)."

--- a/src/antsibull_docs/data/docsite/plugin.rst.j2
+++ b/src/antsibull_docs/data/docsite/plugin.rst.j2
@@ -139,6 +139,15 @@ DEPRECATED
 :Alternative: @{ doc['deprecated']['alternative'] | rst_ify }@
 {% endif %}
 
+{% if is_private -%}
+PRIVATE
+-------
+The collection considers this {% if plugin_type == 'module' %}module{% else %}@{ plugin_type }@ plugin{% endif %} private.
+You can use it with the above FQCN, but be warned that @{ collection }@ might not consider
+this {% if plugin_type == 'module' %}module{% else %}@{ plugin_type }@ plugin{% endif %} as part of its public API and
+can make breaking changes even in bugfix releases.
+{% endif %}
+
 Synopsis
 --------
 

--- a/src/antsibull_docs/data/docsite/role.rst.j2
+++ b/src/antsibull_docs/data/docsite/role.rst.j2
@@ -112,6 +112,13 @@ DEPRECATED
 :Alternative: @{ ep_doc['deprecated']['alternative'] | rst_ify }@
 {%   endif %}
 
+{% if is_private -%}
+PRIVATE
+-------
+The collection considers this role private. You can use it with the above FQCN, but be warned that @{ collection }@ might
+not consider this role as part of its public API and can make breaking changes even in bugfix releases.
+{% endif %}
+
 Synopsis
 ^^^^^^^^
 

--- a/tests/functional/baseline-default/collections/ns2/col/_bar_lookup.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/_bar_lookup.rst
@@ -2,7 +2,7 @@
 .. Document meta
 
 :orphan:
-:github_url: https://github.com/ansible-community/antsibull-docs/edit/main/tests/functional/collections/ansible_collections/ns2/col/plugins/vars/foo.py?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr
+:github_url: https://github.com/ansible-community/antsibull-docs/edit/main/tests/functional/collections/ansible_collections/ns2/col/plugins/lookup/_bar.py?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr
 
 .. |antsibull-internal-nbsp| unicode:: 0xA0
     :trim:
@@ -27,7 +27,7 @@
 
 .. Anchors
 
-.. _ansible_collections.ns2.col.foo_vars:
+.. _ansible_collections.ns2.col._bar_lookup:
 
 .. Anchors: short name for ansible.builtin
 
@@ -37,25 +37,23 @@
 
 .. Title
 
-ns2.col.foo vars -- Load foo
-++++++++++++++++++++++++++++
+ns2.col._bar lookup -- Look up some bar
++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
 .. note::
-    This vars plugin is part of the `ns2.col collection <https://galaxy.ansible.com/ns2/col>`_ (version 2.1.0).
+    This lookup plugin is part of the `ns2.col collection <https://galaxy.ansible.com/ns2/col>`_ (version 2.1.0).
 
     To install it, use: :code:`ansible-galaxy collection install ns2.col`.
-    You need further requirements to be able to use this vars plugin,
-    see :ref:`Requirements <ansible_collections.ns2.col.foo_vars_requirements>` for details.
 
-    To use it in a playbook, specify: :code:`ns2.col.foo`.
+    To use it in a playbook, specify: :code:`ns2.col._bar`.
 
 .. version_added
 
 .. rst-class:: ansible-version-added
 
-New in ns2.col 0.9.0
+New in ns2.col 1.0.0
 
 .. contents::
    :local:
@@ -64,14 +62,19 @@ New in ns2.col 0.9.0
 .. Deprecated
 
 
+PRIVATE
+-------
+The collection considers this lookup plugin private.
+You can use it with the above FQCN, but be warned that ns2.col might not consider
+this lookup plugin as part of its public API and
+can make breaking changes even in bugfix releases.
 
 Synopsis
 --------
 
 .. Description
 
-- Load some foo.
-- This is so glorious.
+- This one is private.
 
 
 .. Aliases
@@ -79,24 +82,13 @@ Synopsis
 
 .. Requirements
 
-.. _ansible_collections.ns2.col.foo_vars_requirements:
-
-Requirements
-------------
-The below requirements are needed on the local controller node that executes this vars.
-
-- Enabled in Ansible's configuration.
 
 
 
+.. Terms
 
-
-
-.. Options
-
-Parameters
-----------
-
+Terms
+-----
 
 .. rst-class:: ansible-option-table
 
@@ -111,21 +103,21 @@ Parameters
   * - .. raw:: html
 
         <div class="ansible-option-cell">
-        <div class="ansibleOptionAnchor" id="parameter-_valid_extensions"></div>
+        <div class="ansibleOptionAnchor" id="parameter-_terms"></div>
 
-      .. _ansible_collections.ns2.col.foo_vars__parameter-_valid_extensions:
+      .. _ansible_collections.ns2.col._bar_lookup__parameter-_terms:
 
       .. rst-class:: ansible-option-title
 
-      **_valid_extensions**
+      **Terms**
 
       .. raw:: html
 
-        <a class="ansibleOptionLink" href="#parameter-_valid_extensions" title="Permalink to this option"></a>
+        <a class="ansibleOptionLink" href="#parameter-_terms" title="Permalink to this option"></a>
 
       .. rst-class:: ansible-option-type-line
 
-      :ansible-option-type:`list` / :ansible-option-elements:`elements=string`
+      :ansible-option-type:`list` / :ansible-option-elements:`elements=dictionary` / :ansible-option-required:`required`
 
 
 
@@ -138,31 +130,18 @@ Parameters
 
         <div class="ansible-option-cell">
 
-      All extensions to check.
-
-
-      .. rst-class:: ansible-option-line
-
-      :ansible-option-default-bold:`Default:` :ansible-option-default:`[".foo", ".foobar"]`
-
-      .. rst-class:: ansible-option-line
-
-      :ansible-option-configuration:`Configuration:`
-
-      - INI entry:
-
-        .. code-block::
-
-          [defaults]
-          foo_valid_extensions = .foo, .foobar
-
-
-      - Environment variable: :envvar:`ANSIBLE\_FOO\_FILENAME\_EXT`
+      Something
 
 
       .. raw:: html
 
         </div>
+
+
+
+
+
+.. Options
 
 
 .. Attributes
@@ -176,6 +155,17 @@ Parameters
 
 .. Examples
 
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Look up!
+      ansible.builtin.debug:
+        msg: "{{ lookup('ns2.col._bar', {}) }}"
+
+
 
 
 .. Facts
@@ -183,11 +173,69 @@ Parameters
 
 .. Return values
 
+Return Value
+------------
+
+.. rst-class:: ansible-option-table
+
+.. list-table::
+  :width: 100%
+  :widths: auto
+  :header-rows: 1
+
+  * - Key
+    - Description
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="return-_raw"></div>
+
+      .. _ansible_collections.ns2.col._bar_lookup__return-_raw:
+
+      .. rst-class:: ansible-option-title
+
+      **Return value**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#return-_raw" title="Permalink to this return value"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`list` / :ansible-option-elements:`elements=dictionary`
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      The resulting stuff.
+
+
+      .. rst-class:: ansible-option-line
+
+      :ansible-option-returned-bold:`Returned:` success
+
+
+      .. raw:: html
+
+        </div>
+
+
 
 ..  Status (Presently only deprecated)
 
 
 .. Authors
+
+Authors
+~~~~~~~
+
+- Felix Fontein (@felixfontein)
 
 
 .. hint::

--- a/tests/functional/baseline-default/collections/ns2/col/foo2_module.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo2_module.rst
@@ -59,6 +59,7 @@ ns2.col.foo2 module -- Another foo
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_become.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_become.rst
@@ -59,6 +59,7 @@ ns2.col.foo become -- Use foo
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_cache.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_cache.rst
@@ -62,6 +62,7 @@ New in ns2.col 1.9.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_callback.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_callback.rst
@@ -62,6 +62,7 @@ New in ns2.col 0.0.1
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_cliconf.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_cliconf.rst
@@ -59,6 +59,7 @@ ns2.col.foo cliconf -- Foo router CLI config
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_connection.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_connection.rst
@@ -62,6 +62,7 @@ New in ns2.col 1.2.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_filter.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_filter.rst
@@ -62,6 +62,7 @@ New in ns2.col 1.3.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_inventory.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_inventory.rst
@@ -62,6 +62,7 @@ New in ns2.col 0.5.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_lookup.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_lookup.rst
@@ -62,6 +62,7 @@ New in ns2.col 1.0.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_module.rst
@@ -64,6 +64,7 @@ New in ns2.col 2.0.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_shell.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_shell.rst
@@ -62,6 +62,7 @@ New in ns2.col 1.0.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_strategy.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_strategy.rst
@@ -62,6 +62,7 @@ New in ns2.col 1.1.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_test.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_test.rst
@@ -59,6 +59,7 @@ ns2.col.foo test -- Is something a foo
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_vars.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_vars.rst
@@ -64,6 +64,7 @@ New in ns2.col 0.9.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/_bar_lookup.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/_bar_lookup.rst
@@ -2,7 +2,7 @@
 .. Document meta
 
 :orphan:
-:github_url: https://github.com/ansible-community/antsibull-docs/edit/main/tests/functional/collections/ansible_collections/ns2/col/plugins/vars/foo.py?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr
+:github_url: https://github.com/ansible-community/antsibull-docs/edit/main/tests/functional/collections/ansible_collections/ns2/col/plugins/lookup/_bar.py?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr
 
 .. |antsibull-internal-nbsp| unicode:: 0xA0
     :trim:
@@ -27,7 +27,7 @@
 
 .. Anchors
 
-.. _ansible_collections.ns2.col.foo_vars:
+.. _ansible_collections.ns2.col._bar_lookup:
 
 .. Anchors: short name for ansible.builtin
 
@@ -37,25 +37,23 @@
 
 .. Title
 
-ns2.col.foo vars -- Load foo
-++++++++++++++++++++++++++++
+ns2.col._bar lookup -- Look up some bar
++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
 .. note::
-    This vars plugin is part of the `ns2.col collection <https://galaxy.ansible.com/ns2/col>`_ (version 2.1.0).
+    This lookup plugin is part of the `ns2.col collection <https://galaxy.ansible.com/ns2/col>`_ (version 2.1.0).
 
     To install it, use: :code:`ansible-galaxy collection install ns2.col`.
-    You need further requirements to be able to use this vars plugin,
-    see :ref:`Requirements <ansible_collections.ns2.col.foo_vars_requirements>` for details.
 
-    To use it in a playbook, specify: :code:`ns2.col.foo`.
+    To use it in a playbook, specify: :code:`ns2.col._bar`.
 
 .. version_added
 
 .. rst-class:: ansible-version-added
 
-New in ns2.col 0.9.0
+New in ns2.col 1.0.0
 
 .. contents::
    :local:
@@ -64,14 +62,19 @@ New in ns2.col 0.9.0
 .. Deprecated
 
 
+PRIVATE
+-------
+The collection considers this lookup plugin private.
+You can use it with the above FQCN, but be warned that ns2.col might not consider
+this lookup plugin as part of its public API and
+can make breaking changes even in bugfix releases.
 
 Synopsis
 --------
 
 .. Description
 
-- Load some foo.
-- This is so glorious.
+- This one is private.
 
 
 .. Aliases
@@ -79,24 +82,13 @@ Synopsis
 
 .. Requirements
 
-.. _ansible_collections.ns2.col.foo_vars_requirements:
-
-Requirements
-------------
-The below requirements are needed on the local controller node that executes this vars.
-
-- Enabled in Ansible's configuration.
 
 
 
+.. Terms
 
-
-
-.. Options
-
-Parameters
-----------
-
+Terms
+-----
 
 .. rst-class:: ansible-option-table
 
@@ -111,21 +103,21 @@ Parameters
   * - .. raw:: html
 
         <div class="ansible-option-cell">
-        <div class="ansibleOptionAnchor" id="parameter-_valid_extensions"></div>
+        <div class="ansibleOptionAnchor" id="parameter-_terms"></div>
 
-      .. _ansible_collections.ns2.col.foo_vars__parameter-_valid_extensions:
+      .. _ansible_collections.ns2.col._bar_lookup__parameter-_terms:
 
       .. rst-class:: ansible-option-title
 
-      **_valid_extensions**
+      **Terms**
 
       .. raw:: html
 
-        <a class="ansibleOptionLink" href="#parameter-_valid_extensions" title="Permalink to this option"></a>
+        <a class="ansibleOptionLink" href="#parameter-_terms" title="Permalink to this option"></a>
 
       .. rst-class:: ansible-option-type-line
 
-      :ansible-option-type:`list` / :ansible-option-elements:`elements=string`
+      :ansible-option-type:`list` / :ansible-option-elements:`elements=dictionary` / :ansible-option-required:`required`
 
 
 
@@ -138,31 +130,18 @@ Parameters
 
         <div class="ansible-option-cell">
 
-      All extensions to check.
-
-
-      .. rst-class:: ansible-option-line
-
-      :ansible-option-default-bold:`Default:` :ansible-option-default:`[".foo", ".foobar"]`
-
-      .. rst-class:: ansible-option-line
-
-      :ansible-option-configuration:`Configuration:`
-
-      - INI entry:
-
-        .. code-block::
-
-          [defaults]
-          foo_valid_extensions = .foo, .foobar
-
-
-      - Environment variable: :envvar:`ANSIBLE\_FOO\_FILENAME\_EXT`
+      Something
 
 
       .. raw:: html
 
         </div>
+
+
+
+
+
+.. Options
 
 
 .. Attributes
@@ -176,6 +155,17 @@ Parameters
 
 .. Examples
 
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Look up!
+      ansible.builtin.debug:
+        msg: "{{ lookup('ns2.col._bar', {}) }}"
+
+
 
 
 .. Facts
@@ -183,11 +173,69 @@ Parameters
 
 .. Return values
 
+Return Value
+------------
+
+.. rst-class:: ansible-option-table
+
+.. list-table::
+  :width: 100%
+  :widths: auto
+  :header-rows: 1
+
+  * - Key
+    - Description
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="return-_raw"></div>
+
+      .. _ansible_collections.ns2.col._bar_lookup__return-_raw:
+
+      .. rst-class:: ansible-option-title
+
+      **Return value**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#return-_raw" title="Permalink to this return value"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`list` / :ansible-option-elements:`elements=dictionary`
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      The resulting stuff.
+
+
+      .. rst-class:: ansible-option-line
+
+      :ansible-option-returned-bold:`Returned:` success
+
+
+      .. raw:: html
+
+        </div>
+
+
 
 ..  Status (Presently only deprecated)
 
 
 .. Authors
+
+Authors
+~~~~~~~
+
+- Felix Fontein (@felixfontein)
 
 
 .. hint::

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo2_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo2_module.rst
@@ -59,6 +59,7 @@ ns2.col.foo2 module -- Another foo
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_become.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_become.rst
@@ -59,6 +59,7 @@ ns2.col.foo become -- Use foo
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_cache.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_cache.rst
@@ -62,6 +62,7 @@ New in ns2.col 1.9.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_callback.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_callback.rst
@@ -62,6 +62,7 @@ New in ns2.col 0.0.1
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_cliconf.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_cliconf.rst
@@ -59,6 +59,7 @@ ns2.col.foo cliconf -- Foo router CLI config
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_connection.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_connection.rst
@@ -62,6 +62,7 @@ New in ns2.col 1.2.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_filter.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_filter.rst
@@ -62,6 +62,7 @@ New in ns2.col 1.3.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_inventory.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_inventory.rst
@@ -62,6 +62,7 @@ New in ns2.col 0.5.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_lookup.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_lookup.rst
@@ -62,6 +62,7 @@ New in ns2.col 1.0.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_module.rst
@@ -64,6 +64,7 @@ New in ns2.col 2.0.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_shell.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_shell.rst
@@ -62,6 +62,7 @@ New in ns2.col 1.0.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_strategy.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_strategy.rst
@@ -62,6 +62,7 @@ New in ns2.col 1.1.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_test.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_test.rst
@@ -59,6 +59,7 @@ ns2.col.foo test -- Is something a foo
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_vars.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_vars.rst
@@ -64,6 +64,7 @@ New in ns2.col 0.9.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/_bar_lookup.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/_bar_lookup.rst
@@ -2,7 +2,7 @@
 .. Document meta
 
 :orphan:
-:github_url: https://github.com/ansible-community/antsibull-docs/edit/main/tests/functional/collections/ansible_collections/ns2/col/plugins/vars/foo.py?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr
+:github_url: https://github.com/ansible-community/antsibull-docs/edit/main/tests/functional/collections/ansible_collections/ns2/col/plugins/lookup/_bar.py?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr
 
 .. |antsibull-internal-nbsp| unicode:: 0xA0
     :trim:
@@ -27,7 +27,7 @@
 
 .. Anchors
 
-.. _ansible_collections.ns2.col.foo_vars:
+.. _ansible_collections.ns2.col._bar_lookup:
 
 .. Anchors: short name for ansible.builtin
 
@@ -37,25 +37,23 @@
 
 .. Title
 
-ns2.col.foo vars -- Load foo
-++++++++++++++++++++++++++++
+ns2.col._bar lookup -- Look up some bar
++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
 .. note::
-    This vars plugin is part of the `ns2.col collection <https://galaxy.ansible.com/ns2/col>`_ (version 2.1.0).
+    This lookup plugin is part of the `ns2.col collection <https://galaxy.ansible.com/ns2/col>`_ (version 2.1.0).
 
     To install it, use: :code:`ansible-galaxy collection install ns2.col`.
-    You need further requirements to be able to use this vars plugin,
-    see :ref:`Requirements <ansible_collections.ns2.col.foo_vars_requirements>` for details.
 
-    To use it in a playbook, specify: :code:`ns2.col.foo`.
+    To use it in a playbook, specify: :code:`ns2.col._bar`.
 
 .. version_added
 
 .. rst-class:: ansible-version-added
 
-New in ns2.col 0.9.0
+New in ns2.col 1.0.0
 
 .. contents::
    :local:
@@ -64,14 +62,19 @@ New in ns2.col 0.9.0
 .. Deprecated
 
 
+PRIVATE
+-------
+The collection considers this lookup plugin private.
+You can use it with the above FQCN, but be warned that ns2.col might not consider
+this lookup plugin as part of its public API and
+can make breaking changes even in bugfix releases.
 
 Synopsis
 --------
 
 .. Description
 
-- Load some foo.
-- This is so glorious.
+- This one is private.
 
 
 .. Aliases
@@ -79,24 +82,13 @@ Synopsis
 
 .. Requirements
 
-.. _ansible_collections.ns2.col.foo_vars_requirements:
-
-Requirements
-------------
-The below requirements are needed on the local controller node that executes this vars.
-
-- Enabled in Ansible's configuration.
 
 
 
+.. Terms
 
-
-
-.. Options
-
-Parameters
-----------
-
+Terms
+-----
 
 .. rst-class:: ansible-option-table
 
@@ -111,21 +103,21 @@ Parameters
   * - .. raw:: html
 
         <div class="ansible-option-cell">
-        <div class="ansibleOptionAnchor" id="parameter-_valid_extensions"></div>
+        <div class="ansibleOptionAnchor" id="parameter-_terms"></div>
 
-      .. _ansible_collections.ns2.col.foo_vars__parameter-_valid_extensions:
+      .. _ansible_collections.ns2.col._bar_lookup__parameter-_terms:
 
       .. rst-class:: ansible-option-title
 
-      **_valid_extensions**
+      **Terms**
 
       .. raw:: html
 
-        <a class="ansibleOptionLink" href="#parameter-_valid_extensions" title="Permalink to this option"></a>
+        <a class="ansibleOptionLink" href="#parameter-_terms" title="Permalink to this option"></a>
 
       .. rst-class:: ansible-option-type-line
 
-      :ansible-option-type:`list` / :ansible-option-elements:`elements=string`
+      :ansible-option-type:`list` / :ansible-option-elements:`elements=dictionary` / :ansible-option-required:`required`
 
 
 
@@ -138,31 +130,18 @@ Parameters
 
         <div class="ansible-option-cell">
 
-      All extensions to check.
-
-
-      .. rst-class:: ansible-option-line
-
-      :ansible-option-default-bold:`Default:` :ansible-option-default:`[".foo", ".foobar"]`
-
-      .. rst-class:: ansible-option-line
-
-      :ansible-option-configuration:`Configuration:`
-
-      - INI entry:
-
-        .. code-block::
-
-          [defaults]
-          foo_valid_extensions = .foo, .foobar
-
-
-      - Environment variable: :envvar:`ANSIBLE\_FOO\_FILENAME\_EXT`
+      Something
 
 
       .. raw:: html
 
         </div>
+
+
+
+
+
+.. Options
 
 
 .. Attributes
@@ -176,6 +155,17 @@ Parameters
 
 .. Examples
 
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Look up!
+      ansible.builtin.debug:
+        msg: "{{ lookup('ns2.col._bar', {}) }}"
+
+
 
 
 .. Facts
@@ -183,11 +173,69 @@ Parameters
 
 .. Return values
 
+Return Value
+------------
+
+.. rst-class:: ansible-option-table
+
+.. list-table::
+  :width: 100%
+  :widths: auto
+  :header-rows: 1
+
+  * - Key
+    - Description
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="return-_raw"></div>
+
+      .. _ansible_collections.ns2.col._bar_lookup__return-_raw:
+
+      .. rst-class:: ansible-option-title
+
+      **Return value**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#return-_raw" title="Permalink to this return value"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`list` / :ansible-option-elements:`elements=dictionary`
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      The resulting stuff.
+
+
+      .. rst-class:: ansible-option-line
+
+      :ansible-option-returned-bold:`Returned:` success
+
+
+      .. raw:: html
+
+        </div>
+
+
 
 ..  Status (Presently only deprecated)
 
 
 .. Authors
+
+Authors
+~~~~~~~
+
+- Felix Fontein (@felixfontein)
 
 
 .. hint::

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo2_module.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo2_module.rst
@@ -59,6 +59,7 @@ ns2.col.foo2 module -- Another foo
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_become.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_become.rst
@@ -59,6 +59,7 @@ ns2.col.foo become -- Use foo
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_cache.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_cache.rst
@@ -62,6 +62,7 @@ New in ns2.col 1.9.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_callback.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_callback.rst
@@ -62,6 +62,7 @@ New in ns2.col 0.0.1
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_cliconf.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_cliconf.rst
@@ -59,6 +59,7 @@ ns2.col.foo cliconf -- Foo router CLI config
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_connection.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_connection.rst
@@ -62,6 +62,7 @@ New in ns2.col 1.2.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_filter.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_filter.rst
@@ -62,6 +62,7 @@ New in ns2.col 1.3.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_inventory.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_inventory.rst
@@ -62,6 +62,7 @@ New in ns2.col 0.5.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_lookup.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_lookup.rst
@@ -62,6 +62,7 @@ New in ns2.col 1.0.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_module.rst
@@ -64,6 +64,7 @@ New in ns2.col 2.0.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_shell.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_shell.rst
@@ -62,6 +62,7 @@ New in ns2.col 1.0.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_strategy.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_strategy.rst
@@ -62,6 +62,7 @@ New in ns2.col 1.1.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_test.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_test.rst
@@ -59,6 +59,7 @@ ns2.col.foo test -- Is something a foo
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_vars.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_vars.rst
@@ -64,6 +64,7 @@ New in ns2.col 0.9.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-squash-hierarchy/_bar_lookup.rst
+++ b/tests/functional/baseline-squash-hierarchy/_bar_lookup.rst
@@ -2,7 +2,7 @@
 .. Document meta
 
 :orphan:
-:github_url: https://github.com/ansible-community/antsibull-docs/edit/main/tests/functional/collections/ansible_collections/ns2/col/plugins/vars/foo.py?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr
+:github_url: https://github.com/ansible-community/antsibull-docs/edit/main/tests/functional/collections/ansible_collections/ns2/col/plugins/lookup/_bar.py?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr
 
 .. |antsibull-internal-nbsp| unicode:: 0xA0
     :trim:
@@ -27,7 +27,7 @@
 
 .. Anchors
 
-.. _ansible_collections.ns2.col.foo_vars:
+.. _ansible_collections.ns2.col._bar_lookup:
 
 .. Anchors: short name for ansible.builtin
 
@@ -37,25 +37,23 @@
 
 .. Title
 
-ns2.col.foo vars -- Load foo
-++++++++++++++++++++++++++++
+ns2.col._bar lookup -- Look up some bar
++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
 .. note::
-    This vars plugin is part of the `ns2.col collection <https://galaxy.ansible.com/ns2/col>`_ (version 2.1.0).
+    This lookup plugin is part of the `ns2.col collection <https://galaxy.ansible.com/ns2/col>`_ (version 2.1.0).
 
     To install it, use: :code:`ansible-galaxy collection install ns2.col`.
-    You need further requirements to be able to use this vars plugin,
-    see :ref:`Requirements <ansible_collections.ns2.col.foo_vars_requirements>` for details.
 
-    To use it in a playbook, specify: :code:`ns2.col.foo`.
+    To use it in a playbook, specify: :code:`ns2.col._bar`.
 
 .. version_added
 
 .. rst-class:: ansible-version-added
 
-New in ns2.col 0.9.0
+New in ns2.col 1.0.0
 
 .. contents::
    :local:
@@ -64,14 +62,19 @@ New in ns2.col 0.9.0
 .. Deprecated
 
 
+PRIVATE
+-------
+The collection considers this lookup plugin private.
+You can use it with the above FQCN, but be warned that ns2.col might not consider
+this lookup plugin as part of its public API and
+can make breaking changes even in bugfix releases.
 
 Synopsis
 --------
 
 .. Description
 
-- Load some foo.
-- This is so glorious.
+- This one is private.
 
 
 .. Aliases
@@ -79,24 +82,13 @@ Synopsis
 
 .. Requirements
 
-.. _ansible_collections.ns2.col.foo_vars_requirements:
-
-Requirements
-------------
-The below requirements are needed on the local controller node that executes this vars.
-
-- Enabled in Ansible's configuration.
 
 
 
+.. Terms
 
-
-
-.. Options
-
-Parameters
-----------
-
+Terms
+-----
 
 .. rst-class:: ansible-option-table
 
@@ -111,21 +103,21 @@ Parameters
   * - .. raw:: html
 
         <div class="ansible-option-cell">
-        <div class="ansibleOptionAnchor" id="parameter-_valid_extensions"></div>
+        <div class="ansibleOptionAnchor" id="parameter-_terms"></div>
 
-      .. _ansible_collections.ns2.col.foo_vars__parameter-_valid_extensions:
+      .. _ansible_collections.ns2.col._bar_lookup__parameter-_terms:
 
       .. rst-class:: ansible-option-title
 
-      **_valid_extensions**
+      **Terms**
 
       .. raw:: html
 
-        <a class="ansibleOptionLink" href="#parameter-_valid_extensions" title="Permalink to this option"></a>
+        <a class="ansibleOptionLink" href="#parameter-_terms" title="Permalink to this option"></a>
 
       .. rst-class:: ansible-option-type-line
 
-      :ansible-option-type:`list` / :ansible-option-elements:`elements=string`
+      :ansible-option-type:`list` / :ansible-option-elements:`elements=dictionary` / :ansible-option-required:`required`
 
 
 
@@ -138,31 +130,18 @@ Parameters
 
         <div class="ansible-option-cell">
 
-      All extensions to check.
-
-
-      .. rst-class:: ansible-option-line
-
-      :ansible-option-default-bold:`Default:` :ansible-option-default:`[".foo", ".foobar"]`
-
-      .. rst-class:: ansible-option-line
-
-      :ansible-option-configuration:`Configuration:`
-
-      - INI entry:
-
-        .. code-block::
-
-          [defaults]
-          foo_valid_extensions = .foo, .foobar
-
-
-      - Environment variable: :envvar:`ANSIBLE\_FOO\_FILENAME\_EXT`
+      Something
 
 
       .. raw:: html
 
         </div>
+
+
+
+
+
+.. Options
 
 
 .. Attributes
@@ -176,6 +155,17 @@ Parameters
 
 .. Examples
 
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Look up!
+      ansible.builtin.debug:
+        msg: "{{ lookup('ns2.col._bar', {}) }}"
+
+
 
 
 .. Facts
@@ -183,11 +173,69 @@ Parameters
 
 .. Return values
 
+Return Value
+------------
+
+.. rst-class:: ansible-option-table
+
+.. list-table::
+  :width: 100%
+  :widths: auto
+  :header-rows: 1
+
+  * - Key
+    - Description
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="return-_raw"></div>
+
+      .. _ansible_collections.ns2.col._bar_lookup__return-_raw:
+
+      .. rst-class:: ansible-option-title
+
+      **Return value**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#return-_raw" title="Permalink to this return value"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`list` / :ansible-option-elements:`elements=dictionary`
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      The resulting stuff.
+
+
+      .. rst-class:: ansible-option-line
+
+      :ansible-option-returned-bold:`Returned:` success
+
+
+      .. raw:: html
+
+        </div>
+
+
 
 ..  Status (Presently only deprecated)
 
 
 .. Authors
+
+Authors
+~~~~~~~
+
+- Felix Fontein (@felixfontein)
 
 
 .. hint::

--- a/tests/functional/baseline-squash-hierarchy/foo2_module.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo2_module.rst
@@ -59,6 +59,7 @@ ns2.col.foo2 module -- Another foo
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-squash-hierarchy/foo_become.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_become.rst
@@ -59,6 +59,7 @@ ns2.col.foo become -- Use foo
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-squash-hierarchy/foo_cache.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_cache.rst
@@ -62,6 +62,7 @@ New in ns2.col 1.9.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-squash-hierarchy/foo_callback.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_callback.rst
@@ -62,6 +62,7 @@ New in ns2.col 0.0.1
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-squash-hierarchy/foo_cliconf.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_cliconf.rst
@@ -59,6 +59,7 @@ ns2.col.foo cliconf -- Foo router CLI config
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-squash-hierarchy/foo_connection.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_connection.rst
@@ -62,6 +62,7 @@ New in ns2.col 1.2.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-squash-hierarchy/foo_filter.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_filter.rst
@@ -62,6 +62,7 @@ New in ns2.col 1.3.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-squash-hierarchy/foo_inventory.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_inventory.rst
@@ -62,6 +62,7 @@ New in ns2.col 0.5.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-squash-hierarchy/foo_lookup.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_lookup.rst
@@ -62,6 +62,7 @@ New in ns2.col 1.0.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-squash-hierarchy/foo_module.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_module.rst
@@ -64,6 +64,7 @@ New in ns2.col 2.0.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-squash-hierarchy/foo_shell.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_shell.rst
@@ -62,6 +62,7 @@ New in ns2.col 1.0.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-squash-hierarchy/foo_strategy.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_strategy.rst
@@ -62,6 +62,7 @@ New in ns2.col 1.1.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-squash-hierarchy/foo_test.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_test.rst
@@ -59,6 +59,7 @@ ns2.col.foo test -- Is something a foo
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/_bar_lookup.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/_bar_lookup.rst
@@ -2,7 +2,7 @@
 .. Document meta
 
 :orphan:
-:github_url: https://github.com/ansible-community/antsibull-docs/edit/main/tests/functional/collections/ansible_collections/ns2/col/plugins/test/foo.py?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr
+:github_url: https://github.com/ansible-community/antsibull-docs/edit/main/tests/functional/collections/ansible_collections/ns2/col/plugins/lookup/_bar.py?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr
 
 .. |antsibull-internal-nbsp| unicode:: 0xA0
     :trim:
@@ -27,7 +27,7 @@
 
 .. Anchors
 
-.. _ansible_collections.ns2.col.foo_test:
+.. _ansible_collections.ns2.col._bar_lookup:
 
 .. Anchors: short name for ansible.builtin
 
@@ -37,20 +37,23 @@
 
 .. Title
 
-ns2.col.foo test -- Is something a foo
-++++++++++++++++++++++++++++++++++++++
+ns2.col._bar lookup -- Look up some bar
++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
 .. note::
-    This test plugin is part of the `ns2.col collection <https://galaxy.ansible.com/ns2/col>`_ (version 2.1.0).
+    This lookup plugin is part of the `ns2.col collection <https://galaxy.ansible.com/ns2/col>`_ (version 2.1.0).
 
     To install it, use: :code:`ansible-galaxy collection install ns2.col`.
 
-    To use it in a playbook, specify: :code:`ns2.col.foo`.
+    To use it in a playbook, specify: :code:`ns2.col._bar`.
 
 .. version_added
 
+.. rst-class:: ansible-version-added
+
+New in ns2.col 1.0.0
 
 .. contents::
    :local:
@@ -59,13 +62,19 @@ ns2.col.foo test -- Is something a foo
 .. Deprecated
 
 
+PRIVATE
+-------
+The collection considers this lookup plugin private.
+You can use it with the above FQCN, but be warned that ns2.col might not consider
+this lookup plugin as part of its public API and
+can make breaking changes even in bugfix releases.
 
 Synopsis
 --------
 
 .. Description
 
-- Check whether the input dictionary is a foo.
+- This one is private.
 
 
 .. Aliases
@@ -76,13 +85,10 @@ Synopsis
 
 
 
+.. Terms
 
-.. Input
-
-Input
+Terms
 -----
-
-This describes the input of the test, the value before ``is ns2.col.foo`` or ``is not ns2.col.foo``.
 
 .. raw:: html
 
@@ -96,21 +102,23 @@ This describes the input of the test, the value before ``is ns2.col.foo`` or ``i
   <tbody>
   <tr class="row-even">
     <td><div class="ansible-option-cell">
-      <div class="ansibleOptionAnchor" id="parameter-_input"></div>
-      <p class="ansible-option-title"><strong>Input</strong></p>
-      <a class="ansibleOptionLink" href="#parameter-_input" title="Permalink to this option"></a>
+      <div class="ansibleOptionAnchor" id="parameter-_terms"></div>
+      <p class="ansible-option-title"><strong>Terms</strong></p>
+      <a class="ansibleOptionLink" href="#parameter-_terms" title="Permalink to this option"></a>
       <p class="ansible-option-type-line">
-        <span class="ansible-option-type">dictionary</span>
+        <span class="ansible-option-type">list</span>
+        / <span class="ansible-option-elements">elements=dictionary</span>
         / <span class="ansible-option-required">required</span>
       </p>
 
     </div></td>
     <td><div class="ansible-option-cell">
-      <p>Something to test.</p>
+      <p>Something</p>
     </div></td>
   </tr>
   </tbody>
   </table>
+
 
 
 
@@ -136,7 +144,9 @@ Examples
 .. code-block:: yaml+jinja
 
     
-    some_var: "{{ {'a': 1} is ns2.col.foo }}"
+    - name: Look up!
+      ansible.builtin.debug:
+        msg: "{{ lookup('ns2.col._bar', {}) }}"
 
 
 
@@ -161,15 +171,16 @@ Return Value
   <tbody>
   <tr class="row-even">
     <td><div class="ansible-option-cell">
-      <div class="ansibleOptionAnchor" id="return-_value"></div>
+      <div class="ansibleOptionAnchor" id="return-_raw"></div>
       <p class="ansible-option-title"><strong>Return value</strong></p>
-      <a class="ansibleOptionLink" href="#return-_value" title="Permalink to this return value"></a>
+      <a class="ansibleOptionLink" href="#return-_raw" title="Permalink to this return value"></a>
       <p class="ansible-option-type-line">
-        <span class="ansible-option-type">boolean</span>
+        <span class="ansible-option-type">list</span>
+        / <span class="ansible-option-elements">elements=dictionary</span>
       </p>
     </div></td>
     <td><div class="ansible-option-cell">
-      <p>Whether the input is a foo.</p>
+      <p>The resulting stuff.</p>
       <p class="ansible-option-line"><span class="ansible-option-returned-bold">Returned:</span> success</p>
     </div></td>
   </tr>
@@ -186,7 +197,7 @@ Return Value
 Authors
 ~~~~~~~
 
-- Nobody
+- Felix Fontein (@felixfontein)
 
 
 .. hint::

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo2_module.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo2_module.rst
@@ -59,6 +59,7 @@ ns2.col.foo2 module -- Another foo
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_become.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_become.rst
@@ -59,6 +59,7 @@ ns2.col.foo become -- Use foo
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_cache.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_cache.rst
@@ -62,6 +62,7 @@ New in ns2.col 1.9.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_callback.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_callback.rst
@@ -62,6 +62,7 @@ New in ns2.col 0.0.1
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_cliconf.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_cliconf.rst
@@ -59,6 +59,7 @@ ns2.col.foo cliconf -- Foo router CLI config
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_connection.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_connection.rst
@@ -62,6 +62,7 @@ New in ns2.col 1.2.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_filter.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_filter.rst
@@ -62,6 +62,7 @@ New in ns2.col 1.3.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_inventory.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_inventory.rst
@@ -62,6 +62,7 @@ New in ns2.col 0.5.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_lookup.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_lookup.rst
@@ -62,6 +62,7 @@ New in ns2.col 1.0.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_module.rst
@@ -64,6 +64,7 @@ New in ns2.col 2.0.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_shell.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_shell.rst
@@ -62,6 +62,7 @@ New in ns2.col 1.0.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_strategy.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_strategy.rst
@@ -62,6 +62,7 @@ New in ns2.col 1.1.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_vars.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_vars.rst
@@ -64,6 +64,7 @@ New in ns2.col 0.9.0
 .. Deprecated
 
 
+
 Synopsis
 --------
 

--- a/tests/functional/collections/ansible_collections/ns2/col/plugins/lookup/_bar.py
+++ b/tests/functional/collections/ansible_collections/ns2/col/plugins/lookup/_bar.py
@@ -1,0 +1,43 @@
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: Ansible Project
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = """
+    name: _bar
+    author: Felix Fontein (@felixfontein)
+    version_added: "1.0.0"
+    short_description: Look up some bar
+    description:
+      - This one is private.
+    options:
+      _terms:
+        description: Something
+        required: true
+        type: list
+        elements: dict
+"""
+
+EXAMPLES = """
+- name: Look up!
+  ansible.builtin.debug:
+    msg: "{{ lookup('ns2.col._bar', {}) }}"
+"""
+
+RETURN = """
+_raw:
+    description:
+      - The resulting stuff.
+    type: list
+    elements: dict
+"""
+
+from ansible.plugins.lookup import LookupBase
+
+
+class LookupModule(LookupBase):
+    def run(self, terms, variables=None, **kwargs):
+        self.set_options(var_options=variables, direct=kwargs)
+        return terms


### PR DESCRIPTION
Implementation for https://github.com/ansible-community/community-topics/issues/154

Once this is merged plugins outside `ansible.builtin` whose last FQCN component starts with `_` are treated as private and marked as such in their documentation, and are no longer listed in plugin indexes.

As an example see the following links, which refer to the hidden filter plugin `community.sops._latest_version` from https://github.com/ansible-collections/community.sops/pull/98:
- https://ansible.fontein.de/collections/community/sops/#filter-plugins does not show the filter
- https://ansible.fontein.de/collections/community/sops/_latest_version_filter.html shows the filter's documentation, with a `PRIVATE` notice (https://ansible.fontein.de/collections/community/sops/_latest_version_filter.html#private).
