### PR TITLE
Fix rst/index.rst license header comment

### DIFF
--- a/changelogs/fragments/66-sphinx-init-index.rst.yml
+++ b/changelogs/fragments/66-sphinx-init-index.rst.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "The license header for the template for the ``rst/index.rst`` file created by ``antsibull-docs sphinx-init`` was commented incorrectly and thus showed up in the templated file (https://github.com/ansible-community/antsibull-docs/pull/66)."

--- a/src/antsibull_docs/data/sphinx_init/rst_index_rst.j2
+++ b/src/antsibull_docs/data/sphinx_init/rst_index_rst.j2
@@ -1,6 +1,8 @@
-# Copyright (c) Ansible Project
-# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
-# SPDX-License-Identifier: GPL-3.0-or-later
+{#
+  Copyright (c) Ansible Project
+  GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+  SPDX-License-Identifier: GPL-3.0-or-later
+#}
 
 .. _docsite_root_index:
 


### PR DESCRIPTION
You can see the output before this PR in https://ansible-collections.github.io/community.dns/branch/main/index.html.