### PR TITLE
spinx-init: allow to copy index.rst from source file

### DIFF
--- a/changelogs/fragments/67-sphinx-init-index.rst.yml
+++ b/changelogs/fragments/67-sphinx-init-index.rst.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "It is now possible to provide a path to an existing file to be used as ``rst/index.rst`` for ``antsibull-docs sphinx-init`` (https://github.com/ansible-community/antsibull-docs/pull/67)."

--- a/changelogs/fragments/67-sphinx-init-index.rst.yml
+++ b/changelogs/fragments/67-sphinx-init-index.rst.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - "It is now possible to provide a path to an existing file to be used as ``rst/index.rst`` for ``antsibull-docs sphinx-init`` (https://github.com/ansible-community/antsibull-docs/pull/67)."

--- a/changelogs/fragments/68-sphinx-init-index.rst.yml
+++ b/changelogs/fragments/68-sphinx-init-index.rst.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "It is now possible to provide a path to an existing file to be used as ``rst/index.rst`` for ``antsibull-docs sphinx-init`` (https://github.com/ansible-community/antsibull-docs/pull/68)."

--- a/src/antsibull_docs/cli/antsibull_docs.py
+++ b/src/antsibull_docs/cli/antsibull_docs.py
@@ -160,6 +160,10 @@ def _normalize_sphinx_init_options(args: argparse.Namespace) -> None:
             raise InvalidArgumentError(
                 'Every `--intersphinx` value must have at least one colon (:).')
 
+    if args.index_rst_source is not None and not os.path.isfile(args.index_rst_source):
+        raise InvalidArgumentError('The rst/index.rst replacement file,'
+                                   f' {args.index_rst_source}, is not a file')
+
 
 def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
     """
@@ -360,6 +364,9 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
                                     ' conf.py. Use the syntax `identifier:https://server/path` to'
                                     ' add the identifier `identifier` with URL'
                                     ' `https://server/path`. The inventory is always `None`.')
+    sphinx_init_parser.add_argument('--index-rst-source',
+                                    help='Copy the provided file to rst/index.rst intead of'
+                                    ' templating a default one.')
 
     #
     # Lint collection docs

--- a/src/antsibull_docs/cli/doc_commands/sphinx_init.py
+++ b/src/antsibull_docs/cli/doc_commands/sphinx_init.py
@@ -18,29 +18,31 @@ from ...jinja2.environment import doc_environment
 mlog = log.fields(mod=__name__)
 
 
+RST_INDEX_RST = 'rst/index.rst'
+
 TEMPLATES = [
     '.gitignore',
     'antsibull-docs.cfg',
     'build.sh',
     'conf.py',
     'requirements.txt',
-    'rst/index.rst',
+    RST_INDEX_RST,
 ]
 
 
-def write_file(filename: str, content: str) -> None:
+def write_file(filename: str, content: str, encoding: t.Optional[str] = 'utf-8') -> None:
     """
     Write content into a file.
     """
     if os.path.exists(filename):
-        with open(filename, 'r', encoding='utf-8') as f:
+        with open(filename, 'rb' if encoding is None else 'r', encoding=encoding) as f:
             existing_content = f.read()
         if existing_content == content:
             print(f'Skipping {filename}')
             return
 
     print(f'Writing {filename}...')
-    with open(filename, 'w', encoding='utf-8') as f:
+    with open(filename, 'wb' if encoding is None else 'w', encoding=encoding) as f:
         f.write(content)
 
 
@@ -91,6 +93,7 @@ def site_init() -> int:
     for intersphinx in app_ctx.extra['intersphinx'] or []:
         inventory, url = intersphinx.split(':', 1)
         intersphinx_parts.append((inventory.rstrip(' '), url.lstrip(' ')))
+    index_rst_source = app_ctx.extra['index_rst_source']
 
     sphinx_theme = 'sphinx_ansible_theme'
     sphinx_theme_package = 'sphinx-ansible-theme >= 0.9.0'
@@ -107,6 +110,9 @@ def site_init() -> int:
     )
 
     for filename in TEMPLATES:
+        if filename == RST_INDEX_RST and index_rst_source is not None:
+            continue
+
         source = filename.replace('.', '_').replace('/', '_') + '.j2'
         template = env.get_template(source)
 
@@ -135,6 +141,14 @@ def site_init() -> int:
         # Make scripts executable
         if filename.endswith('.sh'):
             os.chmod(destination, 0o755)
+
+    if index_rst_source is not None:
+        with open(index_rst_source, 'rb') as f:
+            content = f.read()
+
+        destination = os.path.join(dest_dir, RST_INDEX_RST)
+        os.makedirs(os.path.dirname(destination), exist_ok=True)
+        write_file(destination, content, encoding=None)
 
     print(f'To build the docsite, go into {dest_dir} and run:')
     print('    pip install -r requirements.txt  # possibly use a venv')

--- a/src/antsibull_docs/cli/doc_commands/sphinx_init.py
+++ b/src/antsibull_docs/cli/doc_commands/sphinx_init.py
@@ -30,19 +30,35 @@ TEMPLATES = [
 ]
 
 
-def write_file(filename: str, content: str, encoding: t.Optional[str] = 'utf-8') -> None:
+def write_file(filename: str, content: str) -> None:
     """
     Write content into a file.
     """
     if os.path.exists(filename):
-        with open(filename, 'rb' if encoding is None else 'r', encoding=encoding) as f:
+        with open(filename, 'r', encoding='utf-8') as f:
             existing_content = f.read()
         if existing_content == content:
             print(f'Skipping {filename}')
             return
 
     print(f'Writing {filename}...')
-    with open(filename, 'wb' if encoding is None else 'w', encoding=encoding) as f:
+    with open(filename, 'w', encoding='utf-8') as f:
+        f.write(content)
+
+
+def write_binary_file(filename: str, content: bytes) -> None:
+    """
+    Write binary content into a file.
+    """
+    if os.path.exists(filename):
+        with open(filename, 'rb') as f:
+            existing_content = f.read()
+        if existing_content == content:
+            print(f'Skipping {filename}')
+            return
+
+    print(f'Writing {filename}...')
+    with open(filename, 'wb') as f:
         f.write(content)
 
 
@@ -144,11 +160,11 @@ def site_init() -> int:
 
     if index_rst_source is not None:
         with open(index_rst_source, 'rb') as f:
-            content = f.read()
+            binary_content = f.read()
 
         destination = os.path.join(dest_dir, RST_INDEX_RST)
         os.makedirs(os.path.dirname(destination), exist_ok=True)
-        write_file(destination, content, encoding=None)
+        write_binary_file(destination, binary_content)
 
     print(f'To build the docsite, go into {dest_dir} and run:')
     print('    pip install -r requirements.txt  # possibly use a venv')


### PR DESCRIPTION
This makes (most?) of https://github.com/ansible-collections/community.hashi_vault/tree/main/docs/preview unnecessary. Only the `rst/index.rst` file needs to be stored somewhere (and of course the GH shared workflows adjusted).

CC @briantist