### PR TITLE
sphinx-init: drop no longer neccessary restriction in requirements.txt

### DIFF
--- a/changelogs/fragments/68-sphinx-init-req.yml
+++ b/changelogs/fragments/68-sphinx-init-req.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Removed ``sphinx`` restriction in ``requirements.txt`` file created by ``antsibull-docs sphinx-init`` since the bug in ``sphinx-rtd-theme`` has been fixed (https://github.com/ansible-community/antsibull-docs/pull/68)."

--- a/src/antsibull_docs/data/sphinx_init/requirements_txt.j2
+++ b/src/antsibull_docs/data/sphinx_init/requirements_txt.j2
@@ -4,5 +4,5 @@
 
 antsibull-docs >= 1.0.0, < 2.0.0
 ansible-pygments
-sphinx != 5.2.0.post0  # The != 5.2.0.post0 restriction is thanks due to a bug in the sphinx-rtd-theme. Once this is fixed, this restriction can be removed.
+sphinx
 @{ sphinx_theme_package }@


### PR DESCRIPTION
The sphinx-rtd-theme bug has been resolved for some time now, and a newer Sphinx version has long been released which (temporarily) fixed the problem as well.

Basically undoes #40.