### PR TITLE
Improve environment variable handling

### DIFF
--- a/changelogs/fragments/73-env-vars.yml
+++ b/changelogs/fragments/73-env-vars.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Use correct markup (``envvar`` role) for environment variables. Compile an index of all environment variables used by plugins (https://github.com/ansible-community/antsibull-docs/pull/73)."

--- a/src/antsibull_docs/data/collection-enum.py
+++ b/src/antsibull_docs/data/collection-enum.py
@@ -249,11 +249,10 @@ def main(args):
         collection_name = f'{meta["namespace"]}.{meta["name"]}'
         if match_filter(collection_name, coll_filter):
             result['collections'][collection_name] = meta
-    if match_filter('ansible.builtin', coll_filter):
-        result['collections']['ansible.builtin'] = {
-            'path': os.path.dirname(ansible_release.__file__),
-            'version': ansible_release.__version__,
-        }
+    result['collections']['ansible.builtin'] = {
+        'path': os.path.dirname(ansible_release.__file__),
+        'version': ansible_release.__version__,
+    }
 
     print(json.dumps(
         result, cls=AnsibleJSONEncoder, sort_keys=True, indent=4 if arguments.pretty else None))

--- a/src/antsibull_docs/data/docsite/list_of_env_variables.rst.j2
+++ b/src/antsibull_docs/data/docsite/list_of_env_variables.rst.j2
@@ -1,0 +1,39 @@
+{#
+  Copyright (c) Ansible Project
+  GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+  SPDX-License-Identifier: GPL-3.0-or-later
+#}
+
+:orphan:
+
+.. _list_of_collection_env_vars:
+
+Index of all Collection Environment Variables
+=============================================
+
+The following index documents all environment variables declared by plugins in collections.
+Environment variables used by the ansible-core configuation are documented in :ref:`ansible_configuration_settings`.
+{# TODO: use label `ansible_configuration_env_vars` once the ansible-core PR is merged #}
+
+{% for _, env_var in env_variables | dictsort %}
+.. envvar:: @{ env_var.name }@
+
+{%   for paragraph in env_var.description or [] %}
+    @{ paragraph | replace('\n', '\n    ') | rst_ify | indent(4) }@
+
+{%   endfor %}
+    *Used by:*
+{% set plugins_ = [] %}
+{%   for plugin_type, plugins in env_var.plugins.items() %}
+{%     for plugin_name in plugins %}
+{%       set _ = plugins_.append((plugin_name, plugin_type)) %}
+{%     endfor %}
+{%   endfor %}
+{%   for plugin_name, plugin_type in plugins_ | unique | sort %}
+    :ref:`@{ plugin_name | rst_escape }@ {% if plugin_type == 'module' %}module{% else %}@{ plugin_type }@ plugin{% endif %} <ansible_collections.@{ plugin_name }@_@{ plugin_type }@>`
+{%-    if not loop.last -%}
+,
+{%     endif -%}
+{%-  endfor %}
+
+{% endfor %}

--- a/src/antsibull_docs/data/docsite/macros/parameters.rst.j2
+++ b/src/antsibull_docs/data/docsite/macros/parameters.rst.j2
@@ -125,7 +125,7 @@
 {%       endfor %}
 {%     endif %}
 {%     for env in value['env'] %}
-      - Environment variable: @{ env['name'] | rst_escape }@
+      - Environment variable: :envvar:`@{ env['name'] | rst_escape(escape_ending_whitespace=true) }@`
 {%       if env['version_added'] is still_relevant(collection=env['version_added_collection'] or collection) %}
 
         :ansible-option-versionadded:`added in @{ version_added_rst(env['version_added'], env['version_added_collection'] or collection) }@`
@@ -250,7 +250,7 @@
 {%     endif %}
 {%     for env in value['env'] %}
       <li>
-        <p>Environment variable: @{ env['name'] | escape }@</p>
+        <p>Environment variable: <code class="xref std std-envvar literal notranslate">@{ env['name'] | escape }@</code></p>
 {%       if env['version_added'] is still_relevant(collection=env['version_added_collection'] or collection) %}
         <p><span class="ansible-option-versionadded">added in @{ version_added_html(env['version_added'], env['version_added_collection'] or collection) }@</span></p>
 {%       endif %}

--- a/src/antsibull_docs/docs_parsing/ansible_doc.py
+++ b/src/antsibull_docs/docs_parsing/ansible_doc.py
@@ -217,12 +217,11 @@ def get_collection_metadata(venv: t.Union['VenvRunner', 'FakeVenvRunner'],
                             ) -> t.Dict[str, AnsibleCollectionMetadata]:
     collection_metadata = {}
 
-    # Obtain ansible.builtin version
-    if collection_names is None or 'ansible.builtin' in collection_names:
-        venv_ansible = venv.get_command('ansible')
-        ansible_version_cmd = venv_ansible('--version', _env=env)
-        raw_result = ansible_version_cmd.stdout.decode('utf-8', errors='surrogateescape')
-        collection_metadata['ansible.builtin'] = _extract_ansible_builtin_metadata(raw_result)
+    # Obtain ansible.builtin version and path
+    venv_ansible = venv.get_command('ansible')
+    ansible_version_cmd = venv_ansible('--version', _env=env)
+    raw_result = ansible_version_cmd.stdout.decode('utf-8', errors='surrogateescape')
+    collection_metadata['ansible.builtin'] = _extract_ansible_builtin_metadata(raw_result)
 
     # Obtain collection versions
     venv_ansible_galaxy = venv.get_command('ansible-galaxy')

--- a/src/antsibull_docs/docs_parsing/parsing.py
+++ b/src/antsibull_docs/docs_parsing/parsing.py
@@ -53,8 +53,9 @@ async def get_ansible_plugin_info(venv: t.Union['VenvRunner', 'FakeVenvRunner'],
                     {information from ansible-doc --json.  See the ansible-doc documentation
                      for more info.}
 
-        The second component is a Mapping of collection names to metadata.
-
+        The second component is a Mapping of collection names to metadata. The second mapping
+        always includes the metadata for ansible.builtin, even if it was not explicitly
+        mentioned in ``collection_names``.
     """
     flog = mlog.fields(func='get_ansible_plugin_info')
 

--- a/src/antsibull_docs/env_variables.py
+++ b/src/antsibull_docs/env_variables.py
@@ -1,0 +1,124 @@
+# Author: Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2022, Ansible Project
+"""Environment variable handling."""
+
+import os
+import os.path
+import typing as t
+
+from antsibull_core import yaml
+
+from .docs_parsing import AnsibleCollectionMetadata
+
+
+class EnvironmentVariableInfo:
+    name: str
+    description: t.Optional[t.List[str]]
+    plugins: t.Dict[str, t.List[str]]  # maps plugin_type to lists of plugin FQCNs
+
+    def __init__(self,
+                 name: str,
+                 description: t.Optional[t.List[str]] = None,
+                 plugins: t.Optional[t.Dict[str, t.List[str]]] = None):
+        self.name = name
+        self.description = description
+        self.plugins = plugins or {}
+
+    def __repr__(self):
+        return f'E({self.name}, description={repr(self.description)}, plugins={self.plugins})'
+
+
+def load_ansible_config(ansible_builtin_metadata: AnsibleCollectionMetadata
+                        ) -> t.Mapping[str, t.Mapping[str, t.Any]]:
+    """
+    Load Ansible base configuration (``lib/ansible/config/base.yml``).
+
+    :arg ansible_builtin_metadata: Metadata for the ansible.builtin collection.
+    :returns: A Mapping of configuration options to information on these options.
+    """
+    return yaml.load_yaml_file(os.path.join(ansible_builtin_metadata.path, 'config', 'base.yml'))
+
+
+def _find_env_vars(options: t.Mapping[str, t.Mapping[str, t.Any]]
+                   ) -> t.Generator[t.Tuple[str, t.Optional[t.List[str]]], None, None]:
+    for _, option_data in options.items():
+        if isinstance(option_data.get('env'), list):
+            description = option_data.get('description')
+            if isinstance(description, str):
+                description = [description]
+            if isinstance(description, list):
+                description = [str(desc) for desc in description]
+            else:
+                description = None
+            for env_var in option_data['env']:
+                if isinstance(env_var.get('name'), str):
+                    yield (env_var['name'], description)
+        if isinstance(option_data.get('suboptions'), dict):
+            yield from _find_env_vars(option_data['suboptions'])
+
+
+def _collect_env_vars_and_descriptions(plugin_info: t.Mapping[str, t.Mapping[str, t.Any]],
+                                       core_envs: t.Set[str],
+                                       ) -> t.Tuple[t.Mapping[str, EnvironmentVariableInfo],
+                                                    t.Mapping[str, t.List[t.List[str]]]]:
+    other_variables: t.Dict[str, EnvironmentVariableInfo] = {}
+    other_variable_description: t.Dict[str, t.List[t.List[str]]] = {}
+    for plugin_type, plugins in plugin_info.items():
+        for plugin_name, plugin_data in plugins.items():
+            plugin_options: t.Mapping[str, t.Mapping[str, t.Any]] = (
+                (plugin_data.get('doc') or {}).get('options') or {}
+            )
+            for env_var, env_var_description in _find_env_vars(plugin_options):
+                if env_var in core_envs:
+                    continue
+                if env_var not in other_variables:
+                    other_variables[env_var] = EnvironmentVariableInfo(env_var)
+                    other_variable_description[env_var] = []
+                if plugin_type not in other_variables[env_var].plugins:
+                    other_variables[env_var].plugins[plugin_type] = []
+                other_variables[env_var].plugins[plugin_type].append(plugin_name)
+                if env_var_description is not None:
+                    other_variable_description[env_var].append(env_var_description)
+    return other_variables, other_variable_description
+
+
+def _augment_env_var_descriptions(other_variables: t.Mapping[str, EnvironmentVariableInfo],
+                                  other_variable_description: t.Mapping[str, t.List[t.List[str]]],
+                                  ) -> None:
+    for variable, variable_info in other_variables.items():
+        if other_variable_description[variable]:
+            value: t.Optional[t.List[str]] = other_variable_description[variable][0]
+            for other_value in other_variable_description[variable]:
+                if value != other_value:
+                    value = [
+                        'See the documentations for the options where this environment variable'
+                        ' is used.'
+                    ]
+                    break
+            variable_info.description = value
+
+
+def collect_referenced_environment_variables(plugin_info: t.Mapping[str, t.Mapping[str, t.Any]],
+                                             ansible_config: t.Mapping[str, t.Mapping[str, t.Any]],
+                                             ) -> t.Mapping[str, EnvironmentVariableInfo]:
+    """
+    Collect referenced environment variables that are not defined in the ansible-core
+    configuration.
+
+    :arg plugin_info: Mapping of plugin type to a mapping of plugin name to plugin record.
+    :arg ansible_config: The Ansible base configuration (``lib/ansible/config/base.yml``).
+    :returns: A Mapping of environment variable name to an environment variable infomation object.
+    """
+    core_envs = {'ANSIBLE_CONFIG'}
+    for config in ansible_config.values():
+        if config.get('env'):
+            for env in config['env']:
+                core_envs.add(env['name'])
+
+    other_variables, other_variable_description = _collect_env_vars_and_descriptions(
+        plugin_info, core_envs)
+    _augment_env_var_descriptions(other_variables, other_variable_description)
+    return other_variables

--- a/tests/functional/baseline-default/collections/environment_variables.rst
+++ b/tests/functional/baseline-default/collections/environment_variables.rst
@@ -1,0 +1,41 @@
+
+:orphan:
+
+.. _list_of_collection_env_vars:
+
+Index of all Collection Environment Variables
+=============================================
+
+The following index documents all environment variables declared by plugins in collections.
+Environment variables used by the ansible-core configuation are documented in :ref:`ansible_configuration_settings`.
+
+.. envvar:: ANSIBLE_FOO_EXE
+
+    Foo executable.
+
+    *Used by:*
+    :ref:`ns2.col.foo become plugin <ansible_collections.ns2.col.foo_become>`
+.. envvar:: ANSIBLE_FOO_FILENAME_EXT
+
+    All extensions to check.
+
+    *Used by:*
+    :ref:`ns2.col.foo vars plugin <ansible_collections.ns2.col.foo_vars>`
+.. envvar:: ANSIBLE_FOO_USER
+
+    User you 'become' to execute the task.
+
+    *Used by:*
+    :ref:`ns2.col.foo become plugin <ansible_collections.ns2.col.foo_become>`
+.. envvar:: ANSIBLE_REMOTE_TEMP
+
+    Temporary directory to use on targets when executing tasks.
+
+    *Used by:*
+    :ref:`ns2.col.foo shell plugin <ansible_collections.ns2.col.foo_shell>`
+.. envvar:: ANSIBLE_REMOTE_TMP
+
+    Temporary directory to use on targets when executing tasks.
+
+    *Used by:*
+    :ref:`ns2.col.foo shell plugin <ansible_collections.ns2.col.foo_shell>`

--- a/tests/functional/baseline-default/collections/ns2/col/foo_become.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_become.rst
@@ -211,9 +211,9 @@ Parameters
         Alternative: nothing
 
 
-      - Environment variable: ANSIBLE\_BECOME\_EXE
+      - Environment variable: :envvar:`ANSIBLE\_BECOME\_EXE`
 
-      - Environment variable: ANSIBLE\_FOO\_EXE
+      - Environment variable: :envvar:`ANSIBLE\_FOO\_EXE`
 
         Removed in: version 3.0.0
 
@@ -297,11 +297,11 @@ Parameters
           user = root
 
 
-      - Environment variable: ANSIBLE\_BECOME\_USER
+      - Environment variable: :envvar:`ANSIBLE\_BECOME\_USER`
 
         :ansible-option-versionadded:`added in ns2.col 0.1.0`
 
-      - Environment variable: ANSIBLE\_FOO\_USER
+      - Environment variable: :envvar:`ANSIBLE\_FOO\_USER`
 
       - Variable: ansible\_become\_user
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_cache.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_cache.rst
@@ -141,7 +141,7 @@ Parameters
           fact_caching_connection = VALUE
 
 
-      - Environment variable: ANSIBLE\_CACHE\_PLUGIN\_CONNECTION
+      - Environment variable: :envvar:`ANSIBLE\_CACHE\_PLUGIN\_CONNECTION`
 
 
       .. raw:: html

--- a/tests/functional/baseline-default/collections/ns2/col/foo_shell.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_shell.rst
@@ -148,9 +148,9 @@ Parameters
           remote_tmp = ~/.ansible/tmp
 
 
-      - Environment variable: ANSIBLE\_REMOTE\_TEMP
+      - Environment variable: :envvar:`ANSIBLE\_REMOTE\_TEMP`
 
-      - Environment variable: ANSIBLE\_REMOTE\_TMP
+      - Environment variable: :envvar:`ANSIBLE\_REMOTE\_TMP`
 
       - Variable: ansible\_remote\_tmp
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_vars.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_vars.rst
@@ -156,7 +156,7 @@ Parameters
           foo_valid_extensions = .foo, .foobar
 
 
-      - Environment variable: ANSIBLE\_FOO\_FILENAME\_EXT
+      - Environment variable: :envvar:`ANSIBLE\_FOO\_FILENAME\_EXT`
 
 
       .. raw:: html

--- a/tests/functional/baseline-no-breadcrumbs/collections/environment_variables.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/environment_variables.rst
@@ -1,0 +1,41 @@
+
+:orphan:
+
+.. _list_of_collection_env_vars:
+
+Index of all Collection Environment Variables
+=============================================
+
+The following index documents all environment variables declared by plugins in collections.
+Environment variables used by the ansible-core configuation are documented in :ref:`ansible_configuration_settings`.
+
+.. envvar:: ANSIBLE_FOO_EXE
+
+    Foo executable.
+
+    *Used by:*
+    :ref:`ns2.col.foo become plugin <ansible_collections.ns2.col.foo_become>`
+.. envvar:: ANSIBLE_FOO_FILENAME_EXT
+
+    All extensions to check.
+
+    *Used by:*
+    :ref:`ns2.col.foo vars plugin <ansible_collections.ns2.col.foo_vars>`
+.. envvar:: ANSIBLE_FOO_USER
+
+    User you 'become' to execute the task.
+
+    *Used by:*
+    :ref:`ns2.col.foo become plugin <ansible_collections.ns2.col.foo_become>`
+.. envvar:: ANSIBLE_REMOTE_TEMP
+
+    Temporary directory to use on targets when executing tasks.
+
+    *Used by:*
+    :ref:`ns2.col.foo shell plugin <ansible_collections.ns2.col.foo_shell>`
+.. envvar:: ANSIBLE_REMOTE_TMP
+
+    Temporary directory to use on targets when executing tasks.
+
+    *Used by:*
+    :ref:`ns2.col.foo shell plugin <ansible_collections.ns2.col.foo_shell>`

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_become.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_become.rst
@@ -211,9 +211,9 @@ Parameters
         Alternative: nothing
 
 
-      - Environment variable: ANSIBLE\_BECOME\_EXE
+      - Environment variable: :envvar:`ANSIBLE\_BECOME\_EXE`
 
-      - Environment variable: ANSIBLE\_FOO\_EXE
+      - Environment variable: :envvar:`ANSIBLE\_FOO\_EXE`
 
         Removed in: version 3.0.0
 
@@ -297,11 +297,11 @@ Parameters
           user = root
 
 
-      - Environment variable: ANSIBLE\_BECOME\_USER
+      - Environment variable: :envvar:`ANSIBLE\_BECOME\_USER`
 
         :ansible-option-versionadded:`added in ns2.col 0.1.0`
 
-      - Environment variable: ANSIBLE\_FOO\_USER
+      - Environment variable: :envvar:`ANSIBLE\_FOO\_USER`
 
       - Variable: ansible\_become\_user
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_cache.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_cache.rst
@@ -141,7 +141,7 @@ Parameters
           fact_caching_connection = VALUE
 
 
-      - Environment variable: ANSIBLE\_CACHE\_PLUGIN\_CONNECTION
+      - Environment variable: :envvar:`ANSIBLE\_CACHE\_PLUGIN\_CONNECTION`
 
 
       .. raw:: html

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_shell.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_shell.rst
@@ -148,9 +148,9 @@ Parameters
           remote_tmp = ~/.ansible/tmp
 
 
-      - Environment variable: ANSIBLE\_REMOTE\_TEMP
+      - Environment variable: :envvar:`ANSIBLE\_REMOTE\_TEMP`
 
-      - Environment variable: ANSIBLE\_REMOTE\_TMP
+      - Environment variable: :envvar:`ANSIBLE\_REMOTE\_TMP`
 
       - Variable: ansible\_remote\_tmp
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_vars.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_vars.rst
@@ -156,7 +156,7 @@ Parameters
           foo_valid_extensions = .foo, .foobar
 
 
-      - Environment variable: ANSIBLE\_FOO\_FILENAME\_EXT
+      - Environment variable: :envvar:`ANSIBLE\_FOO\_FILENAME\_EXT`
 
 
       .. raw:: html

--- a/tests/functional/baseline-no-indexes/collections/environment_variables.rst
+++ b/tests/functional/baseline-no-indexes/collections/environment_variables.rst
@@ -1,0 +1,41 @@
+
+:orphan:
+
+.. _list_of_collection_env_vars:
+
+Index of all Collection Environment Variables
+=============================================
+
+The following index documents all environment variables declared by plugins in collections.
+Environment variables used by the ansible-core configuation are documented in :ref:`ansible_configuration_settings`.
+
+.. envvar:: ANSIBLE_FOO_EXE
+
+    Foo executable.
+
+    *Used by:*
+    :ref:`ns2.col.foo become plugin <ansible_collections.ns2.col.foo_become>`
+.. envvar:: ANSIBLE_FOO_FILENAME_EXT
+
+    All extensions to check.
+
+    *Used by:*
+    :ref:`ns2.col.foo vars plugin <ansible_collections.ns2.col.foo_vars>`
+.. envvar:: ANSIBLE_FOO_USER
+
+    User you 'become' to execute the task.
+
+    *Used by:*
+    :ref:`ns2.col.foo become plugin <ansible_collections.ns2.col.foo_become>`
+.. envvar:: ANSIBLE_REMOTE_TEMP
+
+    Temporary directory to use on targets when executing tasks.
+
+    *Used by:*
+    :ref:`ns2.col.foo shell plugin <ansible_collections.ns2.col.foo_shell>`
+.. envvar:: ANSIBLE_REMOTE_TMP
+
+    Temporary directory to use on targets when executing tasks.
+
+    *Used by:*
+    :ref:`ns2.col.foo shell plugin <ansible_collections.ns2.col.foo_shell>`

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_become.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_become.rst
@@ -211,9 +211,9 @@ Parameters
         Alternative: nothing
 
 
-      - Environment variable: ANSIBLE\_BECOME\_EXE
+      - Environment variable: :envvar:`ANSIBLE\_BECOME\_EXE`
 
-      - Environment variable: ANSIBLE\_FOO\_EXE
+      - Environment variable: :envvar:`ANSIBLE\_FOO\_EXE`
 
         Removed in: version 3.0.0
 
@@ -297,11 +297,11 @@ Parameters
           user = root
 
 
-      - Environment variable: ANSIBLE\_BECOME\_USER
+      - Environment variable: :envvar:`ANSIBLE\_BECOME\_USER`
 
         :ansible-option-versionadded:`added in ns2.col 0.1.0`
 
-      - Environment variable: ANSIBLE\_FOO\_USER
+      - Environment variable: :envvar:`ANSIBLE\_FOO\_USER`
 
       - Variable: ansible\_become\_user
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_cache.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_cache.rst
@@ -141,7 +141,7 @@ Parameters
           fact_caching_connection = VALUE
 
 
-      - Environment variable: ANSIBLE\_CACHE\_PLUGIN\_CONNECTION
+      - Environment variable: :envvar:`ANSIBLE\_CACHE\_PLUGIN\_CONNECTION`
 
 
       .. raw:: html

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_shell.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_shell.rst
@@ -148,9 +148,9 @@ Parameters
           remote_tmp = ~/.ansible/tmp
 
 
-      - Environment variable: ANSIBLE\_REMOTE\_TEMP
+      - Environment variable: :envvar:`ANSIBLE\_REMOTE\_TEMP`
 
-      - Environment variable: ANSIBLE\_REMOTE\_TMP
+      - Environment variable: :envvar:`ANSIBLE\_REMOTE\_TMP`
 
       - Variable: ansible\_remote\_tmp
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_vars.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_vars.rst
@@ -156,7 +156,7 @@ Parameters
           foo_valid_extensions = .foo, .foobar
 
 
-      - Environment variable: ANSIBLE\_FOO\_FILENAME\_EXT
+      - Environment variable: :envvar:`ANSIBLE\_FOO\_FILENAME\_EXT`
 
 
       .. raw:: html

--- a/tests/functional/baseline-squash-hierarchy/environment_variables.rst
+++ b/tests/functional/baseline-squash-hierarchy/environment_variables.rst
@@ -1,0 +1,41 @@
+
+:orphan:
+
+.. _list_of_collection_env_vars:
+
+Index of all Collection Environment Variables
+=============================================
+
+The following index documents all environment variables declared by plugins in collections.
+Environment variables used by the ansible-core configuation are documented in :ref:`ansible_configuration_settings`.
+
+.. envvar:: ANSIBLE_FOO_EXE
+
+    Foo executable.
+
+    *Used by:*
+    :ref:`ns2.col.foo become plugin <ansible_collections.ns2.col.foo_become>`
+.. envvar:: ANSIBLE_FOO_FILENAME_EXT
+
+    All extensions to check.
+
+    *Used by:*
+    :ref:`ns2.col.foo vars plugin <ansible_collections.ns2.col.foo_vars>`
+.. envvar:: ANSIBLE_FOO_USER
+
+    User you 'become' to execute the task.
+
+    *Used by:*
+    :ref:`ns2.col.foo become plugin <ansible_collections.ns2.col.foo_become>`
+.. envvar:: ANSIBLE_REMOTE_TEMP
+
+    Temporary directory to use on targets when executing tasks.
+
+    *Used by:*
+    :ref:`ns2.col.foo shell plugin <ansible_collections.ns2.col.foo_shell>`
+.. envvar:: ANSIBLE_REMOTE_TMP
+
+    Temporary directory to use on targets when executing tasks.
+
+    *Used by:*
+    :ref:`ns2.col.foo shell plugin <ansible_collections.ns2.col.foo_shell>`

--- a/tests/functional/baseline-squash-hierarchy/foo_become.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_become.rst
@@ -211,9 +211,9 @@ Parameters
         Alternative: nothing
 
 
-      - Environment variable: ANSIBLE\_BECOME\_EXE
+      - Environment variable: :envvar:`ANSIBLE\_BECOME\_EXE`
 
-      - Environment variable: ANSIBLE\_FOO\_EXE
+      - Environment variable: :envvar:`ANSIBLE\_FOO\_EXE`
 
         Removed in: version 3.0.0
 
@@ -297,11 +297,11 @@ Parameters
           user = root
 
 
-      - Environment variable: ANSIBLE\_BECOME\_USER
+      - Environment variable: :envvar:`ANSIBLE\_BECOME\_USER`
 
         :ansible-option-versionadded:`added in ns2.col 0.1.0`
 
-      - Environment variable: ANSIBLE\_FOO\_USER
+      - Environment variable: :envvar:`ANSIBLE\_FOO\_USER`
 
       - Variable: ansible\_become\_user
 

--- a/tests/functional/baseline-squash-hierarchy/foo_cache.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_cache.rst
@@ -141,7 +141,7 @@ Parameters
           fact_caching_connection = VALUE
 
 
-      - Environment variable: ANSIBLE\_CACHE\_PLUGIN\_CONNECTION
+      - Environment variable: :envvar:`ANSIBLE\_CACHE\_PLUGIN\_CONNECTION`
 
 
       .. raw:: html

--- a/tests/functional/baseline-squash-hierarchy/foo_shell.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_shell.rst
@@ -148,9 +148,9 @@ Parameters
           remote_tmp = ~/.ansible/tmp
 
 
-      - Environment variable: ANSIBLE\_REMOTE\_TEMP
+      - Environment variable: :envvar:`ANSIBLE\_REMOTE\_TEMP`
 
-      - Environment variable: ANSIBLE\_REMOTE\_TMP
+      - Environment variable: :envvar:`ANSIBLE\_REMOTE\_TMP`
 
       - Variable: ansible\_remote\_tmp
 

--- a/tests/functional/baseline-squash-hierarchy/foo_vars.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_vars.rst
@@ -156,7 +156,7 @@ Parameters
           foo_valid_extensions = .foo, .foobar
 
 
-      - Environment variable: ANSIBLE\_FOO\_FILENAME\_EXT
+      - Environment variable: :envvar:`ANSIBLE\_FOO\_FILENAME\_EXT`
 
 
       .. raw:: html

--- a/tests/functional/baseline-use-html-blobs/collections/environment_variables.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/environment_variables.rst
@@ -1,0 +1,41 @@
+
+:orphan:
+
+.. _list_of_collection_env_vars:
+
+Index of all Collection Environment Variables
+=============================================
+
+The following index documents all environment variables declared by plugins in collections.
+Environment variables used by the ansible-core configuation are documented in :ref:`ansible_configuration_settings`.
+
+.. envvar:: ANSIBLE_FOO_EXE
+
+    Foo executable.
+
+    *Used by:*
+    :ref:`ns2.col.foo become plugin <ansible_collections.ns2.col.foo_become>`
+.. envvar:: ANSIBLE_FOO_FILENAME_EXT
+
+    All extensions to check.
+
+    *Used by:*
+    :ref:`ns2.col.foo vars plugin <ansible_collections.ns2.col.foo_vars>`
+.. envvar:: ANSIBLE_FOO_USER
+
+    User you 'become' to execute the task.
+
+    *Used by:*
+    :ref:`ns2.col.foo become plugin <ansible_collections.ns2.col.foo_become>`
+.. envvar:: ANSIBLE_REMOTE_TEMP
+
+    Temporary directory to use on targets when executing tasks.
+
+    *Used by:*
+    :ref:`ns2.col.foo shell plugin <ansible_collections.ns2.col.foo_shell>`
+.. envvar:: ANSIBLE_REMOTE_TMP
+
+    Temporary directory to use on targets when executing tasks.
+
+    *Used by:*
+    :ref:`ns2.col.foo shell plugin <ansible_collections.ns2.col.foo_shell>`

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_become.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_become.rst
@@ -143,11 +143,11 @@ Parameters
 
       </li>
       <li>
-        <p>Environment variable: ANSIBLE_BECOME_EXE</p>
+        <p>Environment variable: <code class="xref std std-envvar literal notranslate">ANSIBLE_BECOME_EXE</code></p>
 
       </li>
       <li>
-        <p>Environment variable: ANSIBLE_FOO_EXE</p>
+        <p>Environment variable: <code class="xref std std-envvar literal notranslate">ANSIBLE_FOO_EXE</code></p>
   <p>Removed in: version 3.0.0</p>
   <p>Why: Just some text.</p>
   <p>Alternative: nothing</p>
@@ -197,12 +197,12 @@ Parameters
 
       </li>
       <li>
-        <p>Environment variable: ANSIBLE_BECOME_USER</p>
+        <p>Environment variable: <code class="xref std std-envvar literal notranslate">ANSIBLE_BECOME_USER</code></p>
         <p><span class="ansible-option-versionadded">added in ns2.col 0.1.0</span></p>
 
       </li>
       <li>
-        <p>Environment variable: ANSIBLE_FOO_USER</p>
+        <p>Environment variable: <code class="xref std std-envvar literal notranslate">ANSIBLE_FOO_USER</code></p>
 
       </li>
       <li>

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_cache.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_cache.rst
@@ -118,7 +118,7 @@ Parameters
 
       </li>
       <li>
-        <p>Environment variable: ANSIBLE_CACHE_PLUGIN_CONNECTION</p>
+        <p>Environment variable: <code class="xref std std-envvar literal notranslate">ANSIBLE_CACHE_PLUGIN_CONNECTION</code></p>
 
       </li>
       </ul>

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_shell.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_shell.rst
@@ -119,11 +119,11 @@ Parameters
 
       </li>
       <li>
-        <p>Environment variable: ANSIBLE_REMOTE_TEMP</p>
+        <p>Environment variable: <code class="xref std std-envvar literal notranslate">ANSIBLE_REMOTE_TEMP</code></p>
 
       </li>
       <li>
-        <p>Environment variable: ANSIBLE_REMOTE_TMP</p>
+        <p>Environment variable: <code class="xref std std-envvar literal notranslate">ANSIBLE_REMOTE_TMP</code></p>
 
       </li>
       <li>

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_vars.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_vars.rst
@@ -130,7 +130,7 @@ Parameters
 
       </li>
       <li>
-        <p>Environment variable: ANSIBLE_FOO_FILENAME_EXT</p>
+        <p>Environment variable: <code class="xref std std-envvar literal notranslate">ANSIBLE_FOO_FILENAME_EXT</code></p>
 
       </li>
       </ul>


### PR DESCRIPTION
Improve environment variable handling:
- Use the correct Sphinx markup for environment variables (`envvar` role).
- Create an environment variable index.

Examples:
- Index: https://ansible.fontein.de/collections/environment_variables.html
- Enviornment variable in a plugin: https://ansible.fontein.de/collections/ansible/builtin/sh_shell.html#ansible-collections-ansible-builtin-sh-shell (click it!)
