### PR TITLE
Automatically use short_description for seealso's description for modules and plugins when none is provided

### DIFF
--- a/changelogs/fragments/74-short-description.yml
+++ b/changelogs/fragments/74-short-description.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Automatically use a module's or plugin's short description as the "See also" description if no description is provided (https://github.com/ansible-community/antsibull-docs/issues/64, https://github.com/ansible-community/antsibull-docs/pull/74)."

--- a/src/antsibull_docs/augment_docs.py
+++ b/src/antsibull_docs/augment_docs.py
@@ -73,12 +73,13 @@ def _add_seealso(seealso: t.List[t.MutableMapping[str, t.Any]],
         elif entry.get('plugin') and entry.get('plugin_type'):
             plugin = entry['plugin']
             plugin_type = entry['plugin_type']
-        if (
-            plugin and plugin_type in plugin_info and plugin in plugin_info[plugin_type]
-            and isinstance(plugin_info[plugin_type][plugin].get('doc'), dict)
-            and plugin_info[plugin_type][plugin]['doc'].get('short_description')
-        ):
+        else:
+            continue
+        try:
             desc = plugin_info[plugin_type][plugin]['doc']['short_description']
+        except (KeyError, TypeError):
+            desc = None
+        if desc:
             if not desc.endswith(('.', '!', '?')):
                 desc += '.'
             entry['description'] = desc

--- a/src/antsibull_docs/data/docsite/plugin.rst.j2
+++ b/src/antsibull_docs/data/docsite/plugin.rst.j2
@@ -301,13 +301,13 @@ See Also
        @{ item['description'] | rst_ify }@
 {%   elif item.module is defined %}
    @{ reference_plugin_rst(item['module'], 'module') }@
-      The official documentation on the **@{ item['module'] }@** module.
+       The official documentation on the **@{ item['module'] }@** module.
 {%   elif item.plugin is defined and item.plugin_type is defined and item.description %}
    @{ reference_plugin_rst(item['plugin'], item['plugin_type']) }@ @{ item['plugin_type'] }@ plugin
        @{ item['description'] | rst_ify }@
 {%   elif item.plugin is defined and item.plugin_type is defined %}
    @{ reference_plugin_rst(item['plugin'], item['plugin_type']) }@ @{ item['plugin_type'] }@ plugin
-      The official documentation on the **@{ item['plugin'] }@** @{ item['plugin_type'] }@ plugin.
+       The official documentation on the **@{ item['plugin'] }@** @{ item['plugin_type'] }@ plugin.
 {%   elif item.name is defined and item.link is defined and item.description %}
    `@{ item['name'] }@ <@{ item['link'] }@>`_
        @{ item['description'] | rst_ify }@

--- a/src/antsibull_docs/data/docsite/role.rst.j2
+++ b/src/antsibull_docs/data/docsite/role.rst.j2
@@ -174,13 +174,13 @@ See Also
        @{ item['description'] | rst_ify }@
 {%       elif item.module is defined %}
    @{ reference_plugin_rst(item['module'], 'module') }@
-      The official documentation on the **@{ item['module'] }@** module.
+       The official documentation on the **@{ item['module'] }@** module.
 {%       elif item.plugin is defined and item.plugin_type is defined and item.description %}
    @{ reference_plugin_rst(item['plugin'], item['plugin_type']) }@ @{ item['plugin_type'] }@ plugin
        @{ item['description'] | rst_ify }@
 {%       elif item.plugin is defined and item.plugin_type is defined %}
    @{ reference_plugin_rst(item['plugin'], item['plugin_type']) }@ @{ item['plugin_type'] }@ plugin
-      The official documentation on the **@{ item['plugin'] }@** @{ item['plugin_type'] }@ plugin.
+       The official documentation on the **@{ item['plugin'] }@** @{ item['plugin_type'] }@ plugin.
 {%       elif item.name is defined and item.link is defined and item.description %}
    `@{ item['name'] }@ <@{ item['link'] }@>`_
        @{ item['description'] | rst_ify }@

--- a/src/antsibull_docs/schemas/docs/base.py
+++ b/src/antsibull_docs/schemas/docs/base.py
@@ -588,6 +588,9 @@ class AttributeSchemaPlatform(AttributeSchemaBase):  # for 'platform'
         return list_from_scalars_comma_separated(obj)
 
 
+SeeAlsoSchemaT = t.Union[SeeAlsoLinkSchema, SeeAlsoModSchema, SeeAlsoPluginSchema, SeeAlsoRefSchema]
+
+
 class DocSchema(BaseModel):
     collection: str = REQUIRED_COLLECTION_NAME_OR_EMPTY_STR_F
     description: t.List[str]
@@ -600,10 +603,7 @@ class DocSchema(BaseModel):
     filename: str = ''
     notes: t.List[str] = []
     requirements: t.List[str] = []
-    seealso: t.List[t.Union[SeeAlsoLinkSchema,
-                            SeeAlsoModSchema,
-                            SeeAlsoPluginSchema,
-                            SeeAlsoRefSchema]] = []
+    seealso: t.List[SeeAlsoSchemaT] = []
     todo: t.List[str] = []
     version_added: str = 'historical'
     version_added_collection: str = COLLECTION_NAME_F

--- a/tests/functional/baseline-default/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_module.rst
@@ -459,7 +459,7 @@ See Also
    \ :ref:`ns2.col.foo2 <ansible_collections.ns2.col.foo2_module>`\ 
        Another foo.
    \ :ref:`ns2.col.foo3 <ansible_collections.ns2.col.foo3_module>`\ 
-      The official documentation on the **ns2.col.foo3** module.
+       The official documentation on the **ns2.col.foo3** module.
    \ :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>`\  lookup plugin
        Look up some foo.
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_module.rst
@@ -451,6 +451,17 @@ Attributes
 
 .. Seealso
 
+See Also
+--------
+
+.. seealso::
+
+   \ :ref:`ns2.col.foo2 <ansible_collections.ns2.col.foo2_module>`\ 
+       Another foo.
+   \ :ref:`ns2.col.foo3 <ansible_collections.ns2.col.foo3_module>`\ 
+      The official documentation on the **ns2.col.foo3** module.
+   \ :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>`\  lookup plugin
+       Look up some foo.
 
 .. Examples
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_module.rst
@@ -459,7 +459,7 @@ See Also
    \ :ref:`ns2.col.foo2 <ansible_collections.ns2.col.foo2_module>`\ 
        Another foo.
    \ :ref:`ns2.col.foo3 <ansible_collections.ns2.col.foo3_module>`\ 
-      The official documentation on the **ns2.col.foo3** module.
+       The official documentation on the **ns2.col.foo3** module.
    \ :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>`\  lookup plugin
        Look up some foo.
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_module.rst
@@ -451,6 +451,17 @@ Attributes
 
 .. Seealso
 
+See Also
+--------
+
+.. seealso::
+
+   \ :ref:`ns2.col.foo2 <ansible_collections.ns2.col.foo2_module>`\ 
+       Another foo.
+   \ :ref:`ns2.col.foo3 <ansible_collections.ns2.col.foo3_module>`\ 
+      The official documentation on the **ns2.col.foo3** module.
+   \ :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>`\  lookup plugin
+       Look up some foo.
 
 .. Examples
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_module.rst
@@ -459,7 +459,7 @@ See Also
    \ :ref:`ns2.col.foo2 <ansible_collections.ns2.col.foo2_module>`\ 
        Another foo.
    \ :ref:`ns2.col.foo3 <ansible_collections.ns2.col.foo3_module>`\ 
-      The official documentation on the **ns2.col.foo3** module.
+       The official documentation on the **ns2.col.foo3** module.
    \ :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>`\  lookup plugin
        Look up some foo.
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_module.rst
@@ -451,6 +451,17 @@ Attributes
 
 .. Seealso
 
+See Also
+--------
+
+.. seealso::
+
+   \ :ref:`ns2.col.foo2 <ansible_collections.ns2.col.foo2_module>`\ 
+       Another foo.
+   \ :ref:`ns2.col.foo3 <ansible_collections.ns2.col.foo3_module>`\ 
+      The official documentation on the **ns2.col.foo3** module.
+   \ :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>`\  lookup plugin
+       Look up some foo.
 
 .. Examples
 

--- a/tests/functional/baseline-squash-hierarchy/foo_module.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_module.rst
@@ -459,7 +459,7 @@ See Also
    \ :ref:`ns2.col.foo2 <ansible_collections.ns2.col.foo2_module>`\ 
        Another foo.
    \ :ref:`ns2.col.foo3 <ansible_collections.ns2.col.foo3_module>`\ 
-      The official documentation on the **ns2.col.foo3** module.
+       The official documentation on the **ns2.col.foo3** module.
    \ :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>`\  lookup plugin
        Look up some foo.
 

--- a/tests/functional/baseline-squash-hierarchy/foo_module.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_module.rst
@@ -451,6 +451,17 @@ Attributes
 
 .. Seealso
 
+See Also
+--------
+
+.. seealso::
+
+   \ :ref:`ns2.col.foo2 <ansible_collections.ns2.col.foo2_module>`\ 
+       Another foo.
+   \ :ref:`ns2.col.foo3 <ansible_collections.ns2.col.foo3_module>`\ 
+      The official documentation on the **ns2.col.foo3** module.
+   \ :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>`\  lookup plugin
+       Look up some foo.
 
 .. Examples
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_module.rst
@@ -373,7 +373,7 @@ See Also
    \ :ref:`ns2.col.foo2 <ansible_collections.ns2.col.foo2_module>`\ 
        Another foo.
    \ :ref:`ns2.col.foo3 <ansible_collections.ns2.col.foo3_module>`\ 
-      The official documentation on the **ns2.col.foo3** module.
+       The official documentation on the **ns2.col.foo3** module.
    \ :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>`\  lookup plugin
        Look up some foo.
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_module.rst
@@ -365,6 +365,17 @@ Attributes
 
 .. Seealso
 
+See Also
+--------
+
+.. seealso::
+
+   \ :ref:`ns2.col.foo2 <ansible_collections.ns2.col.foo2_module>`\ 
+       Another foo.
+   \ :ref:`ns2.col.foo3 <ansible_collections.ns2.col.foo3_module>`\ 
+      The official documentation on the **ns2.col.foo3** module.
+   \ :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>`\  lookup plugin
+       Look up some foo.
 
 .. Examples
 

--- a/tests/functional/collections/ansible_collections/ns2/col/plugins/modules/foo.py
+++ b/tests/functional/collections/ansible_collections/ns2/col/plugins/modules/foo.py
@@ -63,6 +63,12 @@ attributes:
         support: full
         membership:
           - ns2.col.foo_group
+
+seealso:
+    - module: ns2.col.foo2
+    - module: ns2.col.foo3  # does not exist
+    - plugin: ns2.col.foo
+      plugin_type: lookup
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
Fixes #64.

As an example, compare https://ansible.fontein.de/collections/ansible/builtin/add_host_module.html#see-also to https://docs.ansible.com/ansible/devel/collections/ansible/builtin/add_host_module.html#see-also.
