### PR TITLE
Always write environment variable index; add it to index.rst generated by sphinx-init

### DIFF
--- a/changelogs/fragments/80-sphinx-init-env-index.yml
+++ b/changelogs/fragments/80-sphinx-init-env-index.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "The default ``index.rst`` created by ``antsibull-docs sphinx-init`` includes the new environment variable index (https://github.com/ansible-community/antsibull-docs/pull/80)."

--- a/src/antsibull_docs/cli/doc_commands/stable.py
+++ b/src/antsibull_docs/cli/doc_commands/stable.py
@@ -456,12 +456,9 @@ def generate_docs_for_all_collections(venv: t.Union[VenvRunner, FakeVenvRunner],
                                   squash_hierarchy=squash_hierarchy))
     flog.debug('Finished writing extra docs')
 
-    if referenced_env_vars:
-        asyncio_run(output_environment_variables(dest_dir, referenced_env_vars,
-                                                 squash_hierarchy=squash_hierarchy))
-        flog.debug('Finished writing environment variables')
-    else:
-        flog.debug('Skipping environment variables (as there are none)')
+    asyncio_run(output_environment_variables(dest_dir, referenced_env_vars,
+                                             squash_hierarchy=squash_hierarchy))
+    flog.debug('Finished writing environment variables')
     return 0
 
 

--- a/src/antsibull_docs/data/docsite/list_of_env_variables.rst.j2
+++ b/src/antsibull_docs/data/docsite/list_of_env_variables.rst.j2
@@ -36,4 +36,6 @@ Environment variables used by the ansible-core configuation are documented in :r
 {%     endif -%}
 {%-  endfor %}
 
+{% else %}
+No environment variables have been defined.
 {% endfor %}

--- a/src/antsibull_docs/data/sphinx_init/rst_index_rst.j2
+++ b/src/antsibull_docs/data/sphinx_init/rst_index_rst.j2
@@ -31,3 +31,10 @@ This docsite contains documentation of some collections.
    :glob:
 
    collections/index_*
+
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Reference indexes:
+
+   collections/environment_variables


### PR DESCRIPTION
The updated index looks like this: https://ansible.fontein.de/ The new part is at the bottom.

This PR changes that the env var index is always written; in case it happens to be empty, `No environment variables have been defined.` will be shown.