### PR TITLE
Semantic markup: make sure that FQCN/plugin type is passed on to rst_ify/html_ify outside of plugin pages

### DIFF
--- a/src/antsibull_docs/data/docsite/list_of_callback_plugins.rst.j2
+++ b/src/antsibull_docs/data/docsite/list_of_callback_plugins.rst.j2
@@ -18,7 +18,7 @@ See :ref:`list_of_callback_plugins` for the list of *all* callback plugins.
 @{ '-' * (collection_name | length) }@
 
 {%   for plugin_name, plugin_desc in plugins.items() | sort %}
-* :ref:`@{ collection_name }@.@{ plugin_name }@ <ansible_collections.@{ collection_name }@.@{ plugin_name }@_callback>` -- @{ plugin_desc | rst_ify }@
+* :ref:`@{ collection_name }@.@{ plugin_name }@ <ansible_collections.@{ collection_name }@.@{ plugin_name }@_callback>` -- @{ plugin_desc | rst_ify(plugin_fqcn=collection_name ~ '.' ~ plugin_name, plugin_type='callback') }@
 {%   endfor %}
 
 {% else %}

--- a/src/antsibull_docs/data/docsite/list_of_env_variables.rst.j2
+++ b/src/antsibull_docs/data/docsite/list_of_env_variables.rst.j2
@@ -19,7 +19,7 @@ Environment variables used by the ansible-core configuration are documented in :
 .. envvar:: @{ env_var.name }@
 
 {%   for paragraph in env_var.description or [] %}
-    @{ paragraph | replace('\n', '\n    ') | rst_ify | indent(4) }@
+    @{ paragraph | replace('\n', '\n    ') | rst_ify(plugin_fqcn='', plugin_type='') | indent(4) }@
 
 {%   endfor %}
     *Used by:*

--- a/src/antsibull_docs/data/docsite/list_of_plugins.rst.j2
+++ b/src/antsibull_docs/data/docsite/list_of_plugins.rst.j2
@@ -34,7 +34,7 @@ Index of all @{ plugin_type | capitalize }@ Plugins
 @{ '-' * (collection_name | length) }@
 
 {%   for plugin_name, plugin_desc in plugins.items() | sort %}
-* :ref:`@{ collection_name }@.@{ plugin_name }@ <ansible_collections.@{ collection_name }@.@{ plugin_name }@_@{ plugin_type }@>` -- @{ plugin_desc | rst_ify }@
+* :ref:`@{ collection_name }@.@{ plugin_name }@ <ansible_collections.@{ collection_name }@.@{ plugin_name }@_@{ plugin_type }@>` -- @{ plugin_desc | rst_ify(plugin_fqcn=collection_name ~ '.' ~ plugin_name, plugin_type=plugin_type) }@
 {%   endfor %}
 
 {% endfor %}

--- a/src/antsibull_docs/data/docsite/plugins_by_collection.rst.j2
+++ b/src/antsibull_docs/data/docsite/plugins_by_collection.rst.j2
@@ -10,7 +10,7 @@
 
 {% macro list_plugins(plugin_type) %}
 {%   for name, desc in plugin_maps[plugin_type].items() | sort %}
-* :ref:`@{ name }@ @{ plugin_type }@ <ansible_collections.@{ collection_name }@.@{ name }@_@{ plugin_type }@>` -- @{ desc | rst_ify | indent(width=2) }@
+* :ref:`@{ name }@ @{ plugin_type }@ <ansible_collections.@{ collection_name }@.@{ name }@_@{ plugin_type }@>` -- @{ desc | rst_ify(plugin_fqcn=collection_name ~ '.' ~ name, plugin_type=plugin_type) | indent(width=2) }@
 {%   endfor %}
 {%   if breadcrumbs %}
 

--- a/src/antsibull_docs/jinja2/filters.py
+++ b/src/antsibull_docs/jinja2/filters.py
@@ -19,9 +19,12 @@ mlog = log.fields(mod=__name__)
 _EMAIL_ADDRESS = re.compile(r"(?:<{mail}>|\({mail}\)|{mail})".format(mail=r"[\w.+-]+@[\w.-]+\.\w+"))
 
 
-def extract_plugin_data(context: Context) -> t.Tuple[t.Optional[str], t.Optional[str]]:
-    plugin_fqcn = context.get('plugin_name')
-    plugin_type = context.get('plugin_type')
+def extract_plugin_data(context: Context,
+                        plugin_fqcn: t.Optional[str] = None,
+                        plugin_type: t.Optional[str] = None
+                        ) -> t.Tuple[t.Optional[str], t.Optional[str]]:
+    plugin_fqcn = context.get('plugin_name') if plugin_fqcn is None else plugin_fqcn
+    plugin_type = context.get('plugin_type') if plugin_type is None else plugin_type
     if plugin_fqcn is None or plugin_type is None:
         return None, None
     # if plugin_type == 'role':

--- a/src/antsibull_docs/jinja2/htmlify.py
+++ b/src/antsibull_docs/jinja2/htmlify.py
@@ -299,7 +299,7 @@ _COMMAND_SET = CommandSet([
 
 @pass_context
 def html_ify(context: Context, text: str,
-             /,
+             *,
              plugin_fqcn: t.Optional[str] = None,
              plugin_type: t.Optional[str] = None) -> str:
     ''' convert symbols like I(this is in italics) to valid HTML '''

--- a/src/antsibull_docs/jinja2/htmlify.py
+++ b/src/antsibull_docs/jinja2/htmlify.py
@@ -42,7 +42,9 @@ class _Context:
     plugin_fqcn: t.Optional[str]
     plugin_type: t.Optional[str]
 
-    def __init__(self, j2_context: Context):
+    def __init__(self, j2_context: Context,
+                 plugin_fqcn: t.Optional[str] = None,
+                 plugin_type: t.Optional[str] = None):
         self.j2_context = j2_context
         self.counts = {
             'italic': 0,
@@ -59,7 +61,8 @@ class _Context:
             'return-value': 0,
             'ruler': 0,
         }
-        self.plugin_fqcn, self.plugin_type = extract_plugin_data(j2_context)
+        self.plugin_fqcn, self.plugin_type = extract_plugin_data(
+            j2_context, plugin_fqcn=plugin_fqcn, plugin_type=plugin_type)
 
 
 # In the following, we make heavy use of escaped whitespace ("\ ") being removed from the output.
@@ -295,12 +298,19 @@ _COMMAND_SET = CommandSet([
 
 
 @pass_context
-def html_ify(context: Context, text: str) -> str:
+def html_ify(context: Context, text: str,
+             /,
+             plugin_fqcn: t.Optional[str] = None,
+             plugin_type: t.Optional[str] = None) -> str:
     ''' convert symbols like I(this is in italics) to valid HTML '''
     flog = mlog.fields(func='html_ify')
     flog.fields(text=text).debug('Enter')
 
-    our_context = _Context(context)
+    our_context = _Context(
+        context,
+        plugin_fqcn=plugin_fqcn,
+        plugin_type=plugin_type,
+    )
 
     try:
         text = convert_text(text, _COMMAND_SET, html_escape, our_context)

--- a/src/antsibull_docs/jinja2/rstify.py
+++ b/src/antsibull_docs/jinja2/rstify.py
@@ -267,7 +267,7 @@ _COMMAND_SET = CommandSet([
 
 @pass_context
 def rst_ify(context: Context, text: str,
-            /,
+            *,
             plugin_fqcn: t.Optional[str] = None,
             plugin_type: t.Optional[str] = None) -> str:
     ''' convert symbols like I(this is in italics) to valid restructured text '''

--- a/src/antsibull_docs/jinja2/rstify.py
+++ b/src/antsibull_docs/jinja2/rstify.py
@@ -70,7 +70,9 @@ class _Context:
     plugin_fqcn: t.Optional[str]
     plugin_type: t.Optional[str]
 
-    def __init__(self, j2_context: Context):
+    def __init__(self, j2_context: Context,
+                 plugin_fqcn: t.Optional[str] = None,
+                 plugin_type: t.Optional[str] = None):
         self.j2_context = j2_context
         self.counts = {
             'italic': 0,
@@ -87,7 +89,8 @@ class _Context:
             'return-value': 0,
             'ruler': 0,
         }
-        self.plugin_fqcn, self.plugin_type = extract_plugin_data(j2_context)
+        self.plugin_fqcn, self.plugin_type = extract_plugin_data(
+            j2_context, plugin_fqcn=plugin_fqcn, plugin_type=plugin_type)
 
 
 # In the following, we make heavy use of escaped whitespace ("\ ") being removed from the output.
@@ -263,12 +266,19 @@ _COMMAND_SET = CommandSet([
 
 
 @pass_context
-def rst_ify(context: Context, text: str) -> str:
+def rst_ify(context: Context, text: str,
+            /,
+            plugin_fqcn: t.Optional[str] = None,
+            plugin_type: t.Optional[str] = None) -> str:
     ''' convert symbols like I(this is in italics) to valid restructured text '''
     flog = mlog.fields(func='rst_ify')
     flog.fields(text=text).debug('Enter')
 
-    our_context = _Context(context)
+    our_context = _Context(
+        context,
+        plugin_fqcn=plugin_fqcn,
+        plugin_type=plugin_type,
+    )
 
     try:
         text = convert_text(text, _COMMAND_SET, rst_escape, our_context)

--- a/tests/functional/baseline-default/collections/callback_index_stdout.rst
+++ b/tests/functional/baseline-default/collections/callback_index_stdout.rst
@@ -11,5 +11,5 @@ See :ref:`list_of_callback_plugins` for the list of *all* callback plugins.
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_callback>` -- Foo output
+* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_callback>` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
 

--- a/tests/functional/baseline-default/collections/index_become.rst
+++ b/tests/functional/baseline-default/collections/index_become.rst
@@ -9,5 +9,5 @@ Index of all Become Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_become>` -- Use foo
+* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_become>` -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
 

--- a/tests/functional/baseline-default/collections/index_cache.rst
+++ b/tests/functional/baseline-default/collections/index_cache.rst
@@ -9,5 +9,5 @@ Index of all Cache Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_cache>` -- Foo files
+* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_cache>` -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
 

--- a/tests/functional/baseline-default/collections/index_callback.rst
+++ b/tests/functional/baseline-default/collections/index_callback.rst
@@ -17,5 +17,5 @@ Index of all Callback Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_callback>` -- Foo output
+* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_callback>` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
 

--- a/tests/functional/baseline-default/collections/index_connection.rst
+++ b/tests/functional/baseline-default/collections/index_connection.rst
@@ -9,5 +9,5 @@ Index of all Connection Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_connection>` -- Foo connection
+* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_connection>` -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
 

--- a/tests/functional/baseline-default/collections/index_filter.rst
+++ b/tests/functional/baseline-default/collections/index_filter.rst
@@ -9,5 +9,5 @@ Index of all Filter Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_filter>` -- The foo filter
+* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_filter>` -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
 

--- a/tests/functional/baseline-default/collections/index_inventory.rst
+++ b/tests/functional/baseline-default/collections/index_inventory.rst
@@ -9,5 +9,5 @@ Index of all Inventory Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_inventory>` -- The foo inventory
+* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_inventory>` -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
 

--- a/tests/functional/baseline-default/collections/index_lookup.rst
+++ b/tests/functional/baseline-default/collections/index_lookup.rst
@@ -9,5 +9,5 @@ Index of all Lookup Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>` -- Look up some foo
+* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>` -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
 

--- a/tests/functional/baseline-default/collections/index_module.rst
+++ b/tests/functional/baseline-default/collections/index_module.rst
@@ -14,6 +14,6 @@ ns.col2
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_module>` -- Do some foo
+* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_module>` -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
 * :ref:`ns2.col.foo2 <ansible_collections.ns2.col.foo2_module>` -- Another foo
 

--- a/tests/functional/baseline-default/collections/index_shell.rst
+++ b/tests/functional/baseline-default/collections/index_shell.rst
@@ -9,5 +9,5 @@ Index of all Shell Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_shell>` -- Foo shell
+* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_shell>` -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
 

--- a/tests/functional/baseline-default/collections/index_test.rst
+++ b/tests/functional/baseline-default/collections/index_test.rst
@@ -9,5 +9,5 @@ Index of all Test Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_test>` -- Is something a foo
+* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_test>` -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
 

--- a/tests/functional/baseline-default/collections/index_vars.rst
+++ b/tests/functional/baseline-default/collections/index_vars.rst
@@ -9,5 +9,5 @@ Index of all Vars Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_vars>` -- Load foo
+* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_vars>` -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_become.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_become.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo become -- Use foo
-+++++++++++++++++++++++++++++
+ns2.col.foo become -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_cache.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_cache.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo cache -- Foo files
-++++++++++++++++++++++++++++++
+ns2.col.foo cache -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -142,6 +142,43 @@ Parameters
 
 
       - Environment variable: :envvar:`ANSIBLE\_CACHE\_PLUGIN\_CONNECTION`
+
+
+      .. raw:: html
+
+        </div>
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo_cache__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Nothing.
 
 
       .. raw:: html

--- a/tests/functional/baseline-default/collections/ns2/col/foo_callback.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_callback.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo callback -- Foo output
-++++++++++++++++++++++++++++++++++
+ns2.col.foo callback -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -87,6 +87,57 @@ Synopsis
 
 
 .. Options
+
+Parameters
+----------
+
+
+.. rst-class:: ansible-option-table
+
+.. list-table::
+  :width: 100%
+  :widths: auto
+  :header-rows: 1
+
+  * - Parameter
+    - Comments
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo_callback__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Nothing.
+
+
+      .. raw:: html
+
+        </div>
 
 
 .. Attributes

--- a/tests/functional/baseline-default/collections/ns2/col/foo_connection.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_connection.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo connection -- Foo connection
-++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo connection -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -95,6 +95,43 @@ Parameters
 
   * - Parameter
     - Comments
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo_connection__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`integer`
+
+
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Foo bar.
+
+
+      .. raw:: html
+
+        </div>
 
   * - .. raw:: html
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_filter.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_filter.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo filter -- The foo filter
-++++++++++++++++++++++++++++++++++++
+ns2.col.foo filter -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -152,6 +152,43 @@ This describes keyword parameters of the filter. These are the values ``key1=val
 
   * - Parameter
     - Comments
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo_filter__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Some bar.
+
+
+      .. raw:: html
+
+        </div>
 
   * - .. raw:: html
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_inventory.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_inventory.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo inventory -- The foo inventory
-++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo inventory -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -81,6 +81,57 @@ Synopsis
 
 
 .. Options
+
+Parameters
+----------
+
+
+.. rst-class:: ansible-option-table
+
+.. list-table::
+  :width: 100%
+  :widths: auto
+  :header-rows: 1
+
+  * - Parameter
+    - Comments
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo_inventory__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Foo bar.
+
+
+      .. raw:: html
+
+        </div>
 
 
 .. Attributes

--- a/tests/functional/baseline-default/collections/ns2/col/foo_lookup.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_lookup.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo lookup -- Look up some foo
-++++++++++++++++++++++++++++++++++++++
+ns2.col.foo lookup -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -136,6 +136,57 @@ Terms
 
 
 .. Options
+
+Parameters
+----------
+
+
+.. rst-class:: ansible-option-table
+
+.. list-table::
+  :width: 100%
+  :widths: auto
+  :header-rows: 1
+
+  * - Parameter
+    - Comments
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo_lookup__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Foo bar.
+
+
+      .. raw:: html
+
+        </div>
 
 
 .. Attributes

--- a/tests/functional/baseline-default/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_module.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo module -- Do some foo
-+++++++++++++++++++++++++++++++++
+ns2.col.foo module -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -463,7 +463,7 @@ See Also
    \ :ref:`ns2.col.foo3 <ansible_collections.ns2.col.foo3_module>`\ 
        The official documentation on the **ns2.col.foo3** module.
    \ :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>`\  lookup plugin
-       Look up some foo.
+       Look up some foo \ :ansopt:`ns2.col.foo#module:bar`\ .
 
 .. Examples
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_shell.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_shell.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo shell -- Foo shell
-++++++++++++++++++++++++++++++
+ns2.col.foo shell -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -95,6 +95,43 @@ Parameters
 
   * - Parameter
     - Comments
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo_shell__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Foo bar.
+
+
+      .. raw:: html
+
+        </div>
 
   * - .. raw:: html
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_test.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_test.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo test -- Is something a foo
-++++++++++++++++++++++++++++++++++++++
+ns2.col.foo test -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -134,6 +134,58 @@ This describes the input of the test, the value before ``is ns2.col.foo`` or ``i
 
 
 .. Options
+
+Keyword parameters
+------------------
+
+This describes keyword parameters of the test. These are the values ``key1=value1``, ``key2=value2`` and so on in the following examples: ``input is ns2.col.foo(key1=value1, key2=value2, ...)`` and ``input is not ns2.col.foo(key1=value1, key2=value2, ...)``.
+
+.. rst-class:: ansible-option-table
+
+.. list-table::
+  :width: 100%
+  :widths: auto
+  :header-rows: 1
+
+  * - Parameter
+    - Comments
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo_test__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Foo bar.
+
+
+      .. raw:: html
+
+        </div>
 
 
 .. Attributes

--- a/tests/functional/baseline-default/collections/ns2/col/foo_vars.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_vars.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo vars -- Load foo
-++++++++++++++++++++++++++++
+ns2.col.foo vars -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -157,6 +157,43 @@ Parameters
 
 
       - Environment variable: :envvar:`ANSIBLE\_FOO\_FILENAME\_EXT`
+
+
+      .. raw:: html
+
+        </div>
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo_vars__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Foo bar.
 
 
       .. raw:: html

--- a/tests/functional/baseline-default/collections/ns2/col/index.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/index.rst
@@ -74,7 +74,7 @@ These are the plugins in the ns2.col collection:
 Modules
 ~~~~~~~
 
-* :ref:`foo module <ansible_collections.ns2.col.foo_module>` -- Do some foo
+* :ref:`foo module <ansible_collections.ns2.col.foo_module>` -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
 * :ref:`foo2 module <ansible_collections.ns2.col.foo2_module>` -- Another foo
 
 .. toctree::
@@ -88,7 +88,7 @@ Modules
 Become Plugins
 ~~~~~~~~~~~~~~
 
-* :ref:`foo become <ansible_collections.ns2.col.foo_become>` -- Use foo
+* :ref:`foo become <ansible_collections.ns2.col.foo_become>` -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -100,7 +100,7 @@ Become Plugins
 Cache Plugins
 ~~~~~~~~~~~~~
 
-* :ref:`foo cache <ansible_collections.ns2.col.foo_cache>` -- Foo files
+* :ref:`foo cache <ansible_collections.ns2.col.foo_cache>` -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -112,7 +112,7 @@ Cache Plugins
 Callback Plugins
 ~~~~~~~~~~~~~~~~
 
-* :ref:`foo callback <ansible_collections.ns2.col.foo_callback>` -- Foo output
+* :ref:`foo callback <ansible_collections.ns2.col.foo_callback>` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -136,7 +136,7 @@ Cliconf Plugins
 Connection Plugins
 ~~~~~~~~~~~~~~~~~~
 
-* :ref:`foo connection <ansible_collections.ns2.col.foo_connection>` -- Foo connection
+* :ref:`foo connection <ansible_collections.ns2.col.foo_connection>` -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -148,7 +148,7 @@ Connection Plugins
 Filter Plugins
 ~~~~~~~~~~~~~~
 
-* :ref:`foo filter <ansible_collections.ns2.col.foo_filter>` -- The foo filter
+* :ref:`foo filter <ansible_collections.ns2.col.foo_filter>` -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -160,7 +160,7 @@ Filter Plugins
 Inventory Plugins
 ~~~~~~~~~~~~~~~~~
 
-* :ref:`foo inventory <ansible_collections.ns2.col.foo_inventory>` -- The foo inventory
+* :ref:`foo inventory <ansible_collections.ns2.col.foo_inventory>` -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -172,7 +172,7 @@ Inventory Plugins
 Lookup Plugins
 ~~~~~~~~~~~~~~
 
-* :ref:`foo lookup <ansible_collections.ns2.col.foo_lookup>` -- Look up some foo
+* :ref:`foo lookup <ansible_collections.ns2.col.foo_lookup>` -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -184,7 +184,7 @@ Lookup Plugins
 Shell Plugins
 ~~~~~~~~~~~~~
 
-* :ref:`foo shell <ansible_collections.ns2.col.foo_shell>` -- Foo shell
+* :ref:`foo shell <ansible_collections.ns2.col.foo_shell>` -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -208,7 +208,7 @@ Strategy Plugins
 Test Plugins
 ~~~~~~~~~~~~
 
-* :ref:`foo test <ansible_collections.ns2.col.foo_test>` -- Is something a foo
+* :ref:`foo test <ansible_collections.ns2.col.foo_test>` -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -220,7 +220,7 @@ Test Plugins
 Vars Plugins
 ~~~~~~~~~~~~
 
-* :ref:`foo vars <ansible_collections.ns2.col.foo_vars>` -- Load foo
+* :ref:`foo vars <ansible_collections.ns2.col.foo_vars>` -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
 
 .. toctree::
     :maxdepth: 1

--- a/tests/functional/baseline-no-breadcrumbs/collections/callback_index_stdout.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/callback_index_stdout.rst
@@ -11,5 +11,5 @@ See :ref:`list_of_callback_plugins` for the list of *all* callback plugins.
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_callback>` -- Foo output
+* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_callback>` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_become.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_become.rst
@@ -9,5 +9,5 @@ Index of all Become Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_become>` -- Use foo
+* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_become>` -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_cache.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_cache.rst
@@ -9,5 +9,5 @@ Index of all Cache Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_cache>` -- Foo files
+* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_cache>` -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_callback.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_callback.rst
@@ -17,5 +17,5 @@ Index of all Callback Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_callback>` -- Foo output
+* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_callback>` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_connection.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_connection.rst
@@ -9,5 +9,5 @@ Index of all Connection Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_connection>` -- Foo connection
+* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_connection>` -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_filter.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_filter.rst
@@ -9,5 +9,5 @@ Index of all Filter Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_filter>` -- The foo filter
+* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_filter>` -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_inventory.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_inventory.rst
@@ -9,5 +9,5 @@ Index of all Inventory Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_inventory>` -- The foo inventory
+* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_inventory>` -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_lookup.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_lookup.rst
@@ -9,5 +9,5 @@ Index of all Lookup Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>` -- Look up some foo
+* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>` -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_module.rst
@@ -14,6 +14,6 @@ ns.col2
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_module>` -- Do some foo
+* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_module>` -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
 * :ref:`ns2.col.foo2 <ansible_collections.ns2.col.foo2_module>` -- Another foo
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_shell.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_shell.rst
@@ -9,5 +9,5 @@ Index of all Shell Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_shell>` -- Foo shell
+* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_shell>` -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_test.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_test.rst
@@ -9,5 +9,5 @@ Index of all Test Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_test>` -- Is something a foo
+* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_test>` -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_vars.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_vars.rst
@@ -9,5 +9,5 @@ Index of all Vars Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_vars>` -- Load foo
+* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_vars>` -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_become.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_become.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo become -- Use foo
-+++++++++++++++++++++++++++++
+ns2.col.foo become -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_cache.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_cache.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo cache -- Foo files
-++++++++++++++++++++++++++++++
+ns2.col.foo cache -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -142,6 +142,43 @@ Parameters
 
 
       - Environment variable: :envvar:`ANSIBLE\_CACHE\_PLUGIN\_CONNECTION`
+
+
+      .. raw:: html
+
+        </div>
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo_cache__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Nothing.
 
 
       .. raw:: html

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_callback.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_callback.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo callback -- Foo output
-++++++++++++++++++++++++++++++++++
+ns2.col.foo callback -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -87,6 +87,57 @@ Synopsis
 
 
 .. Options
+
+Parameters
+----------
+
+
+.. rst-class:: ansible-option-table
+
+.. list-table::
+  :width: 100%
+  :widths: auto
+  :header-rows: 1
+
+  * - Parameter
+    - Comments
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo_callback__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Nothing.
+
+
+      .. raw:: html
+
+        </div>
 
 
 .. Attributes

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_connection.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_connection.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo connection -- Foo connection
-++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo connection -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -95,6 +95,43 @@ Parameters
 
   * - Parameter
     - Comments
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo_connection__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`integer`
+
+
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Foo bar.
+
+
+      .. raw:: html
+
+        </div>
 
   * - .. raw:: html
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_filter.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_filter.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo filter -- The foo filter
-++++++++++++++++++++++++++++++++++++
+ns2.col.foo filter -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -152,6 +152,43 @@ This describes keyword parameters of the filter. These are the values ``key1=val
 
   * - Parameter
     - Comments
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo_filter__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Some bar.
+
+
+      .. raw:: html
+
+        </div>
 
   * - .. raw:: html
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_inventory.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_inventory.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo inventory -- The foo inventory
-++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo inventory -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -81,6 +81,57 @@ Synopsis
 
 
 .. Options
+
+Parameters
+----------
+
+
+.. rst-class:: ansible-option-table
+
+.. list-table::
+  :width: 100%
+  :widths: auto
+  :header-rows: 1
+
+  * - Parameter
+    - Comments
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo_inventory__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Foo bar.
+
+
+      .. raw:: html
+
+        </div>
 
 
 .. Attributes

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_lookup.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_lookup.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo lookup -- Look up some foo
-++++++++++++++++++++++++++++++++++++++
+ns2.col.foo lookup -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -136,6 +136,57 @@ Terms
 
 
 .. Options
+
+Parameters
+----------
+
+
+.. rst-class:: ansible-option-table
+
+.. list-table::
+  :width: 100%
+  :widths: auto
+  :header-rows: 1
+
+  * - Parameter
+    - Comments
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo_lookup__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Foo bar.
+
+
+      .. raw:: html
+
+        </div>
 
 
 .. Attributes

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_module.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo module -- Do some foo
-+++++++++++++++++++++++++++++++++
+ns2.col.foo module -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -463,7 +463,7 @@ See Also
    \ :ref:`ns2.col.foo3 <ansible_collections.ns2.col.foo3_module>`\ 
        The official documentation on the **ns2.col.foo3** module.
    \ :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>`\  lookup plugin
-       Look up some foo.
+       Look up some foo \ :ansopt:`ns2.col.foo#module:bar`\ .
 
 .. Examples
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_shell.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_shell.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo shell -- Foo shell
-++++++++++++++++++++++++++++++
+ns2.col.foo shell -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -95,6 +95,43 @@ Parameters
 
   * - Parameter
     - Comments
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo_shell__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Foo bar.
+
+
+      .. raw:: html
+
+        </div>
 
   * - .. raw:: html
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_test.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_test.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo test -- Is something a foo
-++++++++++++++++++++++++++++++++++++++
+ns2.col.foo test -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -134,6 +134,58 @@ This describes the input of the test, the value before ``is ns2.col.foo`` or ``i
 
 
 .. Options
+
+Keyword parameters
+------------------
+
+This describes keyword parameters of the test. These are the values ``key1=value1``, ``key2=value2`` and so on in the following examples: ``input is ns2.col.foo(key1=value1, key2=value2, ...)`` and ``input is not ns2.col.foo(key1=value1, key2=value2, ...)``.
+
+.. rst-class:: ansible-option-table
+
+.. list-table::
+  :width: 100%
+  :widths: auto
+  :header-rows: 1
+
+  * - Parameter
+    - Comments
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo_test__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Foo bar.
+
+
+      .. raw:: html
+
+        </div>
 
 
 .. Attributes

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_vars.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_vars.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo vars -- Load foo
-++++++++++++++++++++++++++++
+ns2.col.foo vars -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -157,6 +157,43 @@ Parameters
 
 
       - Environment variable: :envvar:`ANSIBLE\_FOO\_FILENAME\_EXT`
+
+
+      .. raw:: html
+
+        </div>
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo_vars__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Foo bar.
 
 
       .. raw:: html

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/index.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/index.rst
@@ -75,26 +75,26 @@ These are the plugins in the ns2.col collection:
 Modules
 ~~~~~~~
 
-* :ref:`foo module <ansible_collections.ns2.col.foo_module>` -- Do some foo
+* :ref:`foo module <ansible_collections.ns2.col.foo_module>` -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
 * :ref:`foo2 module <ansible_collections.ns2.col.foo2_module>` -- Another foo
 
 
 Become Plugins
 ~~~~~~~~~~~~~~
 
-* :ref:`foo become <ansible_collections.ns2.col.foo_become>` -- Use foo
+* :ref:`foo become <ansible_collections.ns2.col.foo_become>` -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
 
 
 Cache Plugins
 ~~~~~~~~~~~~~
 
-* :ref:`foo cache <ansible_collections.ns2.col.foo_cache>` -- Foo files
+* :ref:`foo cache <ansible_collections.ns2.col.foo_cache>` -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
 
 
 Callback Plugins
 ~~~~~~~~~~~~~~~~
 
-* :ref:`foo callback <ansible_collections.ns2.col.foo_callback>` -- Foo output
+* :ref:`foo callback <ansible_collections.ns2.col.foo_callback>` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
 
 
 Cliconf Plugins
@@ -106,31 +106,31 @@ Cliconf Plugins
 Connection Plugins
 ~~~~~~~~~~~~~~~~~~
 
-* :ref:`foo connection <ansible_collections.ns2.col.foo_connection>` -- Foo connection
+* :ref:`foo connection <ansible_collections.ns2.col.foo_connection>` -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
 
 
 Filter Plugins
 ~~~~~~~~~~~~~~
 
-* :ref:`foo filter <ansible_collections.ns2.col.foo_filter>` -- The foo filter
+* :ref:`foo filter <ansible_collections.ns2.col.foo_filter>` -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
 
 
 Inventory Plugins
 ~~~~~~~~~~~~~~~~~
 
-* :ref:`foo inventory <ansible_collections.ns2.col.foo_inventory>` -- The foo inventory
+* :ref:`foo inventory <ansible_collections.ns2.col.foo_inventory>` -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
 
 
 Lookup Plugins
 ~~~~~~~~~~~~~~
 
-* :ref:`foo lookup <ansible_collections.ns2.col.foo_lookup>` -- Look up some foo
+* :ref:`foo lookup <ansible_collections.ns2.col.foo_lookup>` -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
 
 
 Shell Plugins
 ~~~~~~~~~~~~~
 
-* :ref:`foo shell <ansible_collections.ns2.col.foo_shell>` -- Foo shell
+* :ref:`foo shell <ansible_collections.ns2.col.foo_shell>` -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
 
 
 Strategy Plugins
@@ -142,13 +142,13 @@ Strategy Plugins
 Test Plugins
 ~~~~~~~~~~~~
 
-* :ref:`foo test <ansible_collections.ns2.col.foo_test>` -- Is something a foo
+* :ref:`foo test <ansible_collections.ns2.col.foo_test>` -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
 
 
 Vars Plugins
 ~~~~~~~~~~~~
 
-* :ref:`foo vars <ansible_collections.ns2.col.foo_vars>` -- Load foo
+* :ref:`foo vars <ansible_collections.ns2.col.foo_vars>` -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
 
 
 Role Index

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_become.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_become.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo become -- Use foo
-+++++++++++++++++++++++++++++
+ns2.col.foo become -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_cache.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_cache.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo cache -- Foo files
-++++++++++++++++++++++++++++++
+ns2.col.foo cache -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -142,6 +142,43 @@ Parameters
 
 
       - Environment variable: :envvar:`ANSIBLE\_CACHE\_PLUGIN\_CONNECTION`
+
+
+      .. raw:: html
+
+        </div>
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo_cache__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Nothing.
 
 
       .. raw:: html

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_callback.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_callback.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo callback -- Foo output
-++++++++++++++++++++++++++++++++++
+ns2.col.foo callback -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -87,6 +87,57 @@ Synopsis
 
 
 .. Options
+
+Parameters
+----------
+
+
+.. rst-class:: ansible-option-table
+
+.. list-table::
+  :width: 100%
+  :widths: auto
+  :header-rows: 1
+
+  * - Parameter
+    - Comments
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo_callback__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Nothing.
+
+
+      .. raw:: html
+
+        </div>
 
 
 .. Attributes

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_connection.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_connection.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo connection -- Foo connection
-++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo connection -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -95,6 +95,43 @@ Parameters
 
   * - Parameter
     - Comments
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo_connection__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`integer`
+
+
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Foo bar.
+
+
+      .. raw:: html
+
+        </div>
 
   * - .. raw:: html
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_filter.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_filter.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo filter -- The foo filter
-++++++++++++++++++++++++++++++++++++
+ns2.col.foo filter -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -152,6 +152,43 @@ This describes keyword parameters of the filter. These are the values ``key1=val
 
   * - Parameter
     - Comments
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo_filter__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Some bar.
+
+
+      .. raw:: html
+
+        </div>
 
   * - .. raw:: html
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_inventory.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_inventory.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo inventory -- The foo inventory
-++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo inventory -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -81,6 +81,57 @@ Synopsis
 
 
 .. Options
+
+Parameters
+----------
+
+
+.. rst-class:: ansible-option-table
+
+.. list-table::
+  :width: 100%
+  :widths: auto
+  :header-rows: 1
+
+  * - Parameter
+    - Comments
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo_inventory__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Foo bar.
+
+
+      .. raw:: html
+
+        </div>
 
 
 .. Attributes

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_lookup.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_lookup.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo lookup -- Look up some foo
-++++++++++++++++++++++++++++++++++++++
+ns2.col.foo lookup -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -136,6 +136,57 @@ Terms
 
 
 .. Options
+
+Parameters
+----------
+
+
+.. rst-class:: ansible-option-table
+
+.. list-table::
+  :width: 100%
+  :widths: auto
+  :header-rows: 1
+
+  * - Parameter
+    - Comments
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo_lookup__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Foo bar.
+
+
+      .. raw:: html
+
+        </div>
 
 
 .. Attributes

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_module.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo module -- Do some foo
-+++++++++++++++++++++++++++++++++
+ns2.col.foo module -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -463,7 +463,7 @@ See Also
    \ :ref:`ns2.col.foo3 <ansible_collections.ns2.col.foo3_module>`\ 
        The official documentation on the **ns2.col.foo3** module.
    \ :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>`\  lookup plugin
-       Look up some foo.
+       Look up some foo \ :ansopt:`ns2.col.foo#module:bar`\ .
 
 .. Examples
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_shell.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_shell.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo shell -- Foo shell
-++++++++++++++++++++++++++++++
+ns2.col.foo shell -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -95,6 +95,43 @@ Parameters
 
   * - Parameter
     - Comments
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo_shell__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Foo bar.
+
+
+      .. raw:: html
+
+        </div>
 
   * - .. raw:: html
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_test.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_test.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo test -- Is something a foo
-++++++++++++++++++++++++++++++++++++++
+ns2.col.foo test -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -134,6 +134,58 @@ This describes the input of the test, the value before ``is ns2.col.foo`` or ``i
 
 
 .. Options
+
+Keyword parameters
+------------------
+
+This describes keyword parameters of the test. These are the values ``key1=value1``, ``key2=value2`` and so on in the following examples: ``input is ns2.col.foo(key1=value1, key2=value2, ...)`` and ``input is not ns2.col.foo(key1=value1, key2=value2, ...)``.
+
+.. rst-class:: ansible-option-table
+
+.. list-table::
+  :width: 100%
+  :widths: auto
+  :header-rows: 1
+
+  * - Parameter
+    - Comments
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo_test__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Foo bar.
+
+
+      .. raw:: html
+
+        </div>
 
 
 .. Attributes

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_vars.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_vars.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo vars -- Load foo
-++++++++++++++++++++++++++++
+ns2.col.foo vars -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -157,6 +157,43 @@ Parameters
 
 
       - Environment variable: :envvar:`ANSIBLE\_FOO\_FILENAME\_EXT`
+
+
+      .. raw:: html
+
+        </div>
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo_vars__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Foo bar.
 
 
       .. raw:: html

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/index.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/index.rst
@@ -74,7 +74,7 @@ These are the plugins in the ns2.col collection:
 Modules
 ~~~~~~~
 
-* :ref:`foo module <ansible_collections.ns2.col.foo_module>` -- Do some foo
+* :ref:`foo module <ansible_collections.ns2.col.foo_module>` -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
 * :ref:`foo2 module <ansible_collections.ns2.col.foo2_module>` -- Another foo
 
 .. toctree::
@@ -88,7 +88,7 @@ Modules
 Become Plugins
 ~~~~~~~~~~~~~~
 
-* :ref:`foo become <ansible_collections.ns2.col.foo_become>` -- Use foo
+* :ref:`foo become <ansible_collections.ns2.col.foo_become>` -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -100,7 +100,7 @@ Become Plugins
 Cache Plugins
 ~~~~~~~~~~~~~
 
-* :ref:`foo cache <ansible_collections.ns2.col.foo_cache>` -- Foo files
+* :ref:`foo cache <ansible_collections.ns2.col.foo_cache>` -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -112,7 +112,7 @@ Cache Plugins
 Callback Plugins
 ~~~~~~~~~~~~~~~~
 
-* :ref:`foo callback <ansible_collections.ns2.col.foo_callback>` -- Foo output
+* :ref:`foo callback <ansible_collections.ns2.col.foo_callback>` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -136,7 +136,7 @@ Cliconf Plugins
 Connection Plugins
 ~~~~~~~~~~~~~~~~~~
 
-* :ref:`foo connection <ansible_collections.ns2.col.foo_connection>` -- Foo connection
+* :ref:`foo connection <ansible_collections.ns2.col.foo_connection>` -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -148,7 +148,7 @@ Connection Plugins
 Filter Plugins
 ~~~~~~~~~~~~~~
 
-* :ref:`foo filter <ansible_collections.ns2.col.foo_filter>` -- The foo filter
+* :ref:`foo filter <ansible_collections.ns2.col.foo_filter>` -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -160,7 +160,7 @@ Filter Plugins
 Inventory Plugins
 ~~~~~~~~~~~~~~~~~
 
-* :ref:`foo inventory <ansible_collections.ns2.col.foo_inventory>` -- The foo inventory
+* :ref:`foo inventory <ansible_collections.ns2.col.foo_inventory>` -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -172,7 +172,7 @@ Inventory Plugins
 Lookup Plugins
 ~~~~~~~~~~~~~~
 
-* :ref:`foo lookup <ansible_collections.ns2.col.foo_lookup>` -- Look up some foo
+* :ref:`foo lookup <ansible_collections.ns2.col.foo_lookup>` -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -184,7 +184,7 @@ Lookup Plugins
 Shell Plugins
 ~~~~~~~~~~~~~
 
-* :ref:`foo shell <ansible_collections.ns2.col.foo_shell>` -- Foo shell
+* :ref:`foo shell <ansible_collections.ns2.col.foo_shell>` -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -208,7 +208,7 @@ Strategy Plugins
 Test Plugins
 ~~~~~~~~~~~~
 
-* :ref:`foo test <ansible_collections.ns2.col.foo_test>` -- Is something a foo
+* :ref:`foo test <ansible_collections.ns2.col.foo_test>` -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -220,7 +220,7 @@ Test Plugins
 Vars Plugins
 ~~~~~~~~~~~~
 
-* :ref:`foo vars <ansible_collections.ns2.col.foo_vars>` -- Load foo
+* :ref:`foo vars <ansible_collections.ns2.col.foo_vars>` -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
 
 .. toctree::
     :maxdepth: 1

--- a/tests/functional/baseline-squash-hierarchy/foo_become.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_become.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo become -- Use foo
-+++++++++++++++++++++++++++++
+ns2.col.foo become -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-squash-hierarchy/foo_cache.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_cache.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo cache -- Foo files
-++++++++++++++++++++++++++++++
+ns2.col.foo cache -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -142,6 +142,43 @@ Parameters
 
 
       - Environment variable: :envvar:`ANSIBLE\_CACHE\_PLUGIN\_CONNECTION`
+
+
+      .. raw:: html
+
+        </div>
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo_cache__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Nothing.
 
 
       .. raw:: html

--- a/tests/functional/baseline-squash-hierarchy/foo_callback.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_callback.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo callback -- Foo output
-++++++++++++++++++++++++++++++++++
+ns2.col.foo callback -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -87,6 +87,57 @@ Synopsis
 
 
 .. Options
+
+Parameters
+----------
+
+
+.. rst-class:: ansible-option-table
+
+.. list-table::
+  :width: 100%
+  :widths: auto
+  :header-rows: 1
+
+  * - Parameter
+    - Comments
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo_callback__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Nothing.
+
+
+      .. raw:: html
+
+        </div>
 
 
 .. Attributes

--- a/tests/functional/baseline-squash-hierarchy/foo_connection.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_connection.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo connection -- Foo connection
-++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo connection -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -95,6 +95,43 @@ Parameters
 
   * - Parameter
     - Comments
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo_connection__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`integer`
+
+
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Foo bar.
+
+
+      .. raw:: html
+
+        </div>
 
   * - .. raw:: html
 

--- a/tests/functional/baseline-squash-hierarchy/foo_filter.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_filter.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo filter -- The foo filter
-++++++++++++++++++++++++++++++++++++
+ns2.col.foo filter -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -152,6 +152,43 @@ This describes keyword parameters of the filter. These are the values ``key1=val
 
   * - Parameter
     - Comments
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo_filter__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Some bar.
+
+
+      .. raw:: html
+
+        </div>
 
   * - .. raw:: html
 

--- a/tests/functional/baseline-squash-hierarchy/foo_inventory.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_inventory.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo inventory -- The foo inventory
-++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo inventory -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -81,6 +81,57 @@ Synopsis
 
 
 .. Options
+
+Parameters
+----------
+
+
+.. rst-class:: ansible-option-table
+
+.. list-table::
+  :width: 100%
+  :widths: auto
+  :header-rows: 1
+
+  * - Parameter
+    - Comments
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo_inventory__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Foo bar.
+
+
+      .. raw:: html
+
+        </div>
 
 
 .. Attributes

--- a/tests/functional/baseline-squash-hierarchy/foo_lookup.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_lookup.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo lookup -- Look up some foo
-++++++++++++++++++++++++++++++++++++++
+ns2.col.foo lookup -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -136,6 +136,57 @@ Terms
 
 
 .. Options
+
+Parameters
+----------
+
+
+.. rst-class:: ansible-option-table
+
+.. list-table::
+  :width: 100%
+  :widths: auto
+  :header-rows: 1
+
+  * - Parameter
+    - Comments
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo_lookup__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Foo bar.
+
+
+      .. raw:: html
+
+        </div>
 
 
 .. Attributes

--- a/tests/functional/baseline-squash-hierarchy/foo_module.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_module.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo module -- Do some foo
-+++++++++++++++++++++++++++++++++
+ns2.col.foo module -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -463,7 +463,7 @@ See Also
    \ :ref:`ns2.col.foo3 <ansible_collections.ns2.col.foo3_module>`\ 
        The official documentation on the **ns2.col.foo3** module.
    \ :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>`\  lookup plugin
-       Look up some foo.
+       Look up some foo \ :ansopt:`ns2.col.foo#module:bar`\ .
 
 .. Examples
 

--- a/tests/functional/baseline-squash-hierarchy/foo_shell.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_shell.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo shell -- Foo shell
-++++++++++++++++++++++++++++++
+ns2.col.foo shell -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -95,6 +95,43 @@ Parameters
 
   * - Parameter
     - Comments
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo_shell__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Foo bar.
+
+
+      .. raw:: html
+
+        </div>
 
   * - .. raw:: html
 

--- a/tests/functional/baseline-squash-hierarchy/foo_test.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_test.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo test -- Is something a foo
-++++++++++++++++++++++++++++++++++++++
+ns2.col.foo test -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -134,6 +134,58 @@ This describes the input of the test, the value before ``is ns2.col.foo`` or ``i
 
 
 .. Options
+
+Keyword parameters
+------------------
+
+This describes keyword parameters of the test. These are the values ``key1=value1``, ``key2=value2`` and so on in the following examples: ``input is ns2.col.foo(key1=value1, key2=value2, ...)`` and ``input is not ns2.col.foo(key1=value1, key2=value2, ...)``.
+
+.. rst-class:: ansible-option-table
+
+.. list-table::
+  :width: 100%
+  :widths: auto
+  :header-rows: 1
+
+  * - Parameter
+    - Comments
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo_test__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Foo bar.
+
+
+      .. raw:: html
+
+        </div>
 
 
 .. Attributes

--- a/tests/functional/baseline-squash-hierarchy/foo_vars.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_vars.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo vars -- Load foo
-++++++++++++++++++++++++++++
+ns2.col.foo vars -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -157,6 +157,43 @@ Parameters
 
 
       - Environment variable: :envvar:`ANSIBLE\_FOO\_FILENAME\_EXT`
+
+
+      .. raw:: html
+
+        </div>
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo_vars__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Foo bar.
 
 
       .. raw:: html

--- a/tests/functional/baseline-squash-hierarchy/index.rst
+++ b/tests/functional/baseline-squash-hierarchy/index.rst
@@ -74,7 +74,7 @@ These are the plugins in the ns2.col collection:
 Modules
 ~~~~~~~
 
-* :ref:`foo module <ansible_collections.ns2.col.foo_module>` -- Do some foo
+* :ref:`foo module <ansible_collections.ns2.col.foo_module>` -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
 * :ref:`foo2 module <ansible_collections.ns2.col.foo2_module>` -- Another foo
 
 .. toctree::
@@ -88,7 +88,7 @@ Modules
 Become Plugins
 ~~~~~~~~~~~~~~
 
-* :ref:`foo become <ansible_collections.ns2.col.foo_become>` -- Use foo
+* :ref:`foo become <ansible_collections.ns2.col.foo_become>` -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -100,7 +100,7 @@ Become Plugins
 Cache Plugins
 ~~~~~~~~~~~~~
 
-* :ref:`foo cache <ansible_collections.ns2.col.foo_cache>` -- Foo files
+* :ref:`foo cache <ansible_collections.ns2.col.foo_cache>` -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -112,7 +112,7 @@ Cache Plugins
 Callback Plugins
 ~~~~~~~~~~~~~~~~
 
-* :ref:`foo callback <ansible_collections.ns2.col.foo_callback>` -- Foo output
+* :ref:`foo callback <ansible_collections.ns2.col.foo_callback>` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -136,7 +136,7 @@ Cliconf Plugins
 Connection Plugins
 ~~~~~~~~~~~~~~~~~~
 
-* :ref:`foo connection <ansible_collections.ns2.col.foo_connection>` -- Foo connection
+* :ref:`foo connection <ansible_collections.ns2.col.foo_connection>` -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -148,7 +148,7 @@ Connection Plugins
 Filter Plugins
 ~~~~~~~~~~~~~~
 
-* :ref:`foo filter <ansible_collections.ns2.col.foo_filter>` -- The foo filter
+* :ref:`foo filter <ansible_collections.ns2.col.foo_filter>` -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -160,7 +160,7 @@ Filter Plugins
 Inventory Plugins
 ~~~~~~~~~~~~~~~~~
 
-* :ref:`foo inventory <ansible_collections.ns2.col.foo_inventory>` -- The foo inventory
+* :ref:`foo inventory <ansible_collections.ns2.col.foo_inventory>` -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -172,7 +172,7 @@ Inventory Plugins
 Lookup Plugins
 ~~~~~~~~~~~~~~
 
-* :ref:`foo lookup <ansible_collections.ns2.col.foo_lookup>` -- Look up some foo
+* :ref:`foo lookup <ansible_collections.ns2.col.foo_lookup>` -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -184,7 +184,7 @@ Lookup Plugins
 Shell Plugins
 ~~~~~~~~~~~~~
 
-* :ref:`foo shell <ansible_collections.ns2.col.foo_shell>` -- Foo shell
+* :ref:`foo shell <ansible_collections.ns2.col.foo_shell>` -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -208,7 +208,7 @@ Strategy Plugins
 Test Plugins
 ~~~~~~~~~~~~
 
-* :ref:`foo test <ansible_collections.ns2.col.foo_test>` -- Is something a foo
+* :ref:`foo test <ansible_collections.ns2.col.foo_test>` -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -220,7 +220,7 @@ Test Plugins
 Vars Plugins
 ~~~~~~~~~~~~
 
-* :ref:`foo vars <ansible_collections.ns2.col.foo_vars>` -- Load foo
+* :ref:`foo vars <ansible_collections.ns2.col.foo_vars>` -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
 
 .. toctree::
     :maxdepth: 1

--- a/tests/functional/baseline-use-html-blobs/collections/callback_index_stdout.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/callback_index_stdout.rst
@@ -11,5 +11,5 @@ See :ref:`list_of_callback_plugins` for the list of *all* callback plugins.
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_callback>` -- Foo output
+* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_callback>` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
 

--- a/tests/functional/baseline-use-html-blobs/collections/index_become.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_become.rst
@@ -9,5 +9,5 @@ Index of all Become Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_become>` -- Use foo
+* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_become>` -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
 

--- a/tests/functional/baseline-use-html-blobs/collections/index_cache.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_cache.rst
@@ -9,5 +9,5 @@ Index of all Cache Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_cache>` -- Foo files
+* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_cache>` -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
 

--- a/tests/functional/baseline-use-html-blobs/collections/index_callback.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_callback.rst
@@ -17,5 +17,5 @@ Index of all Callback Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_callback>` -- Foo output
+* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_callback>` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
 

--- a/tests/functional/baseline-use-html-blobs/collections/index_connection.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_connection.rst
@@ -9,5 +9,5 @@ Index of all Connection Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_connection>` -- Foo connection
+* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_connection>` -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
 

--- a/tests/functional/baseline-use-html-blobs/collections/index_filter.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_filter.rst
@@ -9,5 +9,5 @@ Index of all Filter Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_filter>` -- The foo filter
+* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_filter>` -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
 

--- a/tests/functional/baseline-use-html-blobs/collections/index_inventory.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_inventory.rst
@@ -9,5 +9,5 @@ Index of all Inventory Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_inventory>` -- The foo inventory
+* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_inventory>` -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
 

--- a/tests/functional/baseline-use-html-blobs/collections/index_lookup.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_lookup.rst
@@ -9,5 +9,5 @@ Index of all Lookup Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>` -- Look up some foo
+* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>` -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
 

--- a/tests/functional/baseline-use-html-blobs/collections/index_module.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_module.rst
@@ -9,6 +9,6 @@ Index of all Modules
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_module>` -- Do some foo
+* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_module>` -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
 * :ref:`ns2.col.foo2 <ansible_collections.ns2.col.foo2_module>` -- Another foo
 

--- a/tests/functional/baseline-use-html-blobs/collections/index_shell.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_shell.rst
@@ -9,5 +9,5 @@ Index of all Shell Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_shell>` -- Foo shell
+* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_shell>` -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
 

--- a/tests/functional/baseline-use-html-blobs/collections/index_test.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_test.rst
@@ -9,5 +9,5 @@ Index of all Test Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_test>` -- Is something a foo
+* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_test>` -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
 

--- a/tests/functional/baseline-use-html-blobs/collections/index_vars.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_vars.rst
@@ -9,5 +9,5 @@ Index of all Vars Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_vars>` -- Load foo
+* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_vars>` -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_become.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_become.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo become -- Use foo
-+++++++++++++++++++++++++++++
+ns2.col.foo become -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_cache.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_cache.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo cache -- Foo files
-++++++++++++++++++++++++++++++
+ns2.col.foo cache -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -122,6 +122,20 @@ Parameters
 
       </li>
       </ul>
+    </div></td>
+  </tr>
+  <tr class="row-odd">
+    <td><div class="ansible-option-cell">
+      <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+      <p class="ansible-option-title"><strong>bar</strong></p>
+      <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+      <p class="ansible-option-type-line">
+        <span class="ansible-option-type">string</span>
+      </p>
+
+    </div></td>
+    <td><div class="ansible-option-cell">
+      <p>Nothing.</p>
     </div></td>
   </tr>
   </tbody>

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_callback.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_callback.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo callback -- Foo output
-++++++++++++++++++++++++++++++++++
+ns2.col.foo callback -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -87,6 +87,38 @@ Synopsis
 
 
 .. Options
+
+Parameters
+----------
+
+
+.. raw:: html
+
+  <table class="colwidths-auto ansible-option-table docutils align-default" style="width: 100%">
+  <thead>
+  <tr class="row-odd">
+    <th class="head"><p>Parameter</p></th>
+    <th class="head"><p>Comments</p></th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr class="row-even">
+    <td><div class="ansible-option-cell">
+      <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+      <p class="ansible-option-title"><strong>bar</strong></p>
+      <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+      <p class="ansible-option-type-line">
+        <span class="ansible-option-type">string</span>
+      </p>
+
+    </div></td>
+    <td><div class="ansible-option-cell">
+      <p>Nothing.</p>
+    </div></td>
+  </tr>
+  </tbody>
+  </table>
+
 
 
 .. Attributes

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_connection.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_connection.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo connection -- Foo connection
-++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo connection -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -97,6 +97,20 @@ Parameters
   </thead>
   <tbody>
   <tr class="row-even">
+    <td><div class="ansible-option-cell">
+      <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+      <p class="ansible-option-title"><strong>bar</strong></p>
+      <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+      <p class="ansible-option-type-line">
+        <span class="ansible-option-type">integer</span>
+      </p>
+
+    </div></td>
+    <td><div class="ansible-option-cell">
+      <p>Foo bar.</p>
+    </div></td>
+  </tr>
+  <tr class="row-odd">
     <td><div class="ansible-option-cell">
       <div class="ansibleOptionAnchor" id="parameter-host"></div>
       <p class="ansible-option-title"><strong>host</strong></p>

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_filter.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_filter.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo filter -- The foo filter
-++++++++++++++++++++++++++++++++++++
+ns2.col.foo filter -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -136,6 +136,20 @@ This describes keyword parameters of the filter. These are the values ``key1=val
   </thead>
   <tbody>
   <tr class="row-even">
+    <td><div class="ansible-option-cell">
+      <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+      <p class="ansible-option-title"><strong>bar</strong></p>
+      <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+      <p class="ansible-option-type-line">
+        <span class="ansible-option-type">string</span>
+      </p>
+
+    </div></td>
+    <td><div class="ansible-option-cell">
+      <p>Some bar.</p>
+    </div></td>
+  </tr>
+  <tr class="row-odd">
     <td><div class="ansible-option-cell">
       <div class="ansibleOptionAnchor" id="parameter-foo"></div>
       <p class="ansible-option-title"><strong>foo</strong></p>

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_inventory.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_inventory.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo inventory -- The foo inventory
-++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo inventory -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -81,6 +81,38 @@ Synopsis
 
 
 .. Options
+
+Parameters
+----------
+
+
+.. raw:: html
+
+  <table class="colwidths-auto ansible-option-table docutils align-default" style="width: 100%">
+  <thead>
+  <tr class="row-odd">
+    <th class="head"><p>Parameter</p></th>
+    <th class="head"><p>Comments</p></th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr class="row-even">
+    <td><div class="ansible-option-cell">
+      <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+      <p class="ansible-option-title"><strong>bar</strong></p>
+      <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+      <p class="ansible-option-type-line">
+        <span class="ansible-option-type">string</span>
+      </p>
+
+    </div></td>
+    <td><div class="ansible-option-cell">
+      <p>Foo bar.</p>
+    </div></td>
+  </tr>
+  </tbody>
+  </table>
+
 
 
 .. Attributes

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_lookup.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_lookup.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo lookup -- Look up some foo
-++++++++++++++++++++++++++++++++++++++
+ns2.col.foo lookup -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -119,6 +119,38 @@ Terms
 
 
 .. Options
+
+Parameters
+----------
+
+
+.. raw:: html
+
+  <table class="colwidths-auto ansible-option-table docutils align-default" style="width: 100%">
+  <thead>
+  <tr class="row-odd">
+    <th class="head"><p>Parameter</p></th>
+    <th class="head"><p>Comments</p></th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr class="row-even">
+    <td><div class="ansible-option-cell">
+      <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+      <p class="ansible-option-title"><strong>bar</strong></p>
+      <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+      <p class="ansible-option-type-line">
+        <span class="ansible-option-type">string</span>
+      </p>
+
+    </div></td>
+    <td><div class="ansible-option-cell">
+      <p>Foo bar.</p>
+    </div></td>
+  </tr>
+  </tbody>
+  </table>
+
 
 
 .. Attributes

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_module.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo module -- Do some foo
-+++++++++++++++++++++++++++++++++
+ns2.col.foo module -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -376,7 +376,7 @@ See Also
    \ :ref:`ns2.col.foo3 <ansible_collections.ns2.col.foo3_module>`\ 
        The official documentation on the **ns2.col.foo3** module.
    \ :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>`\  lookup plugin
-       Look up some foo.
+       Look up some foo \ :ansopt:`ns2.col.foo#module:bar`\ .
 
 .. Examples
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_shell.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_shell.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo shell -- Foo shell
-++++++++++++++++++++++++++++++
+ns2.col.foo shell -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -97,6 +97,20 @@ Parameters
   </thead>
   <tbody>
   <tr class="row-even">
+    <td><div class="ansible-option-cell">
+      <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+      <p class="ansible-option-title"><strong>bar</strong></p>
+      <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+      <p class="ansible-option-type-line">
+        <span class="ansible-option-type">string</span>
+      </p>
+
+    </div></td>
+    <td><div class="ansible-option-cell">
+      <p>Foo bar.</p>
+    </div></td>
+  </tr>
+  <tr class="row-odd">
     <td><div class="ansible-option-cell">
       <div class="ansibleOptionAnchor" id="parameter-remote_tmp"></div>
       <p class="ansible-option-title"><strong>remote_tmp</strong></p>

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_test.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_test.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo test -- Is something a foo
-++++++++++++++++++++++++++++++++++++++
+ns2.col.foo test -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -116,6 +116,39 @@ This describes the input of the test, the value before ``is ns2.col.foo`` or ``i
 
 
 .. Options
+
+Keyword parameters
+------------------
+
+This describes keyword parameters of the test. These are the values ``key1=value1``, ``key2=value2`` and so on in the following examples: ``input is ns2.col.foo(key1=value1, key2=value2, ...)`` and ``input is not ns2.col.foo(key1=value1, key2=value2, ...)``.
+
+.. raw:: html
+
+  <table class="colwidths-auto ansible-option-table docutils align-default" style="width: 100%">
+  <thead>
+  <tr class="row-odd">
+    <th class="head"><p>Parameter</p></th>
+    <th class="head"><p>Comments</p></th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr class="row-even">
+    <td><div class="ansible-option-cell">
+      <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+      <p class="ansible-option-title"><strong>bar</strong></p>
+      <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+      <p class="ansible-option-type-line">
+        <span class="ansible-option-type">string</span>
+      </p>
+
+    </div></td>
+    <td><div class="ansible-option-cell">
+      <p>Foo bar.</p>
+    </div></td>
+  </tr>
+  </tbody>
+  </table>
+
 
 
 .. Attributes

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_vars.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_vars.rst
@@ -37,8 +37,8 @@
 
 .. Title
 
-ns2.col.foo vars -- Load foo
-++++++++++++++++++++++++++++
+ns2.col.foo vars -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -134,6 +134,20 @@ Parameters
 
       </li>
       </ul>
+    </div></td>
+  </tr>
+  <tr class="row-odd">
+    <td><div class="ansible-option-cell">
+      <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+      <p class="ansible-option-title"><strong>bar</strong></p>
+      <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+      <p class="ansible-option-type-line">
+        <span class="ansible-option-type">string</span>
+      </p>
+
+    </div></td>
+    <td><div class="ansible-option-cell">
+      <p>Foo bar.</p>
     </div></td>
   </tr>
   </tbody>

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/index.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/index.rst
@@ -74,7 +74,7 @@ These are the plugins in the ns2.col collection:
 Modules
 ~~~~~~~
 
-* :ref:`foo module <ansible_collections.ns2.col.foo_module>` -- Do some foo
+* :ref:`foo module <ansible_collections.ns2.col.foo_module>` -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
 * :ref:`foo2 module <ansible_collections.ns2.col.foo2_module>` -- Another foo
 
 .. toctree::
@@ -88,7 +88,7 @@ Modules
 Become Plugins
 ~~~~~~~~~~~~~~
 
-* :ref:`foo become <ansible_collections.ns2.col.foo_become>` -- Use foo
+* :ref:`foo become <ansible_collections.ns2.col.foo_become>` -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -100,7 +100,7 @@ Become Plugins
 Cache Plugins
 ~~~~~~~~~~~~~
 
-* :ref:`foo cache <ansible_collections.ns2.col.foo_cache>` -- Foo files
+* :ref:`foo cache <ansible_collections.ns2.col.foo_cache>` -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -112,7 +112,7 @@ Cache Plugins
 Callback Plugins
 ~~~~~~~~~~~~~~~~
 
-* :ref:`foo callback <ansible_collections.ns2.col.foo_callback>` -- Foo output
+* :ref:`foo callback <ansible_collections.ns2.col.foo_callback>` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -136,7 +136,7 @@ Cliconf Plugins
 Connection Plugins
 ~~~~~~~~~~~~~~~~~~
 
-* :ref:`foo connection <ansible_collections.ns2.col.foo_connection>` -- Foo connection
+* :ref:`foo connection <ansible_collections.ns2.col.foo_connection>` -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -148,7 +148,7 @@ Connection Plugins
 Filter Plugins
 ~~~~~~~~~~~~~~
 
-* :ref:`foo filter <ansible_collections.ns2.col.foo_filter>` -- The foo filter
+* :ref:`foo filter <ansible_collections.ns2.col.foo_filter>` -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -160,7 +160,7 @@ Filter Plugins
 Inventory Plugins
 ~~~~~~~~~~~~~~~~~
 
-* :ref:`foo inventory <ansible_collections.ns2.col.foo_inventory>` -- The foo inventory
+* :ref:`foo inventory <ansible_collections.ns2.col.foo_inventory>` -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -172,7 +172,7 @@ Inventory Plugins
 Lookup Plugins
 ~~~~~~~~~~~~~~
 
-* :ref:`foo lookup <ansible_collections.ns2.col.foo_lookup>` -- Look up some foo
+* :ref:`foo lookup <ansible_collections.ns2.col.foo_lookup>` -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -184,7 +184,7 @@ Lookup Plugins
 Shell Plugins
 ~~~~~~~~~~~~~
 
-* :ref:`foo shell <ansible_collections.ns2.col.foo_shell>` -- Foo shell
+* :ref:`foo shell <ansible_collections.ns2.col.foo_shell>` -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -208,7 +208,7 @@ Strategy Plugins
 Test Plugins
 ~~~~~~~~~~~~
 
-* :ref:`foo test <ansible_collections.ns2.col.foo_test>` -- Is something a foo
+* :ref:`foo test <ansible_collections.ns2.col.foo_test>` -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -220,7 +220,7 @@ Test Plugins
 Vars Plugins
 ~~~~~~~~~~~~
 
-* :ref:`foo vars <ansible_collections.ns2.col.foo_vars>` -- Load foo
+* :ref:`foo vars <ansible_collections.ns2.col.foo_vars>` -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
 
 .. toctree::
     :maxdepth: 1

--- a/tests/functional/collections/ansible_collections/ns2/col/plugins/become/foo.py
+++ b/tests/functional/collections/ansible_collections/ns2/col/plugins/become/foo.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 
 DOCUMENTATION = """
     name: foo
-    short_description: Use foo
+    short_description: Use foo O(bar)
     description:
         - This become plugin uses foo.
         - This is a second paragraph.

--- a/tests/functional/collections/ansible_collections/ns2/col/plugins/cache/foo.py
+++ b/tests/functional/collections/ansible_collections/ns2/col/plugins/cache/foo.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
     name: foo
-    short_description: Foo files
+    short_description: Foo files O(bar)
     description:
         - Cache foo files.
     version_added: "1.9.0"
@@ -24,6 +24,9 @@ DOCUMENTATION = '''
           - key: fact_caching_connection
             section: defaults
         type: path
+      bar:
+        description: Nothing.
+        type: str
 '''
 
 from ansible.plugins.cache import BaseFileCacheModule

--- a/tests/functional/collections/ansible_collections/ns2/col/plugins/callback/foo.py
+++ b/tests/functional/collections/ansible_collections/ns2/col/plugins/callback/foo.py
@@ -9,10 +9,14 @@ __metaclass__ = type
 DOCUMENTATION = '''
     name: foo
     type: stdout
-    short_description: Foo output
+    short_description: Foo output O(bar)
     version_added: 0.0.1
     description:
         - Absolut minimal foo output.
+    options:
+        bar:
+            description: Nothing.
+            type: string
 '''
 
 from ansible.plugins.callback import CallbackBase

--- a/tests/functional/collections/ansible_collections/ns2/col/plugins/connection/foo.py
+++ b/tests/functional/collections/ansible_collections/ns2/col/plugins/connection/foo.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
     name: foo
-    short_description: Foo connection
+    short_description: Foo connection O(bar)
     version_added: 1.2.0
     description:
         - This is for the C(foo) connection.
@@ -26,6 +26,9 @@ DOCUMENTATION = '''
                - name: ansible_ssh_host
                - name: delegated_vars['ansible_host']
                - name: delegated_vars['ansible_ssh_host']
+      bar:
+          description: Foo bar.
+          type: int
 '''
 
 from ansible.plugins.connection import ConnectionBase

--- a/tests/functional/collections/ansible_collections/ns2/col/plugins/filter/foo.py
+++ b/tests/functional/collections/ansible_collections/ns2/col/plugins/filter/foo.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 DOCUMENTATION = r'''
   name: foo
   version_added: 1.3.0
-  short_description: The foo filter
+  short_description: The foo filter O(bar)
   description:
     - Do some fooing.
   options:
@@ -23,6 +23,9 @@ DOCUMENTATION = r'''
       type: list
       elements: dictionary
       required: true
+    bar:
+      description: Some bar.
+      type: string
 '''
 
 EXAMPLES = r'''

--- a/tests/functional/collections/ansible_collections/ns2/col/plugins/inventory/foo.py
+++ b/tests/functional/collections/ansible_collections/ns2/col/plugins/inventory/foo.py
@@ -9,9 +9,13 @@ __metaclass__ = type
 DOCUMENTATION = '''
     name: foo
     version_added: 0.5.0
-    short_description: The foo inventory
+    short_description: The foo inventory O(bar)
     description:
         - Loads inventory from foo.
+    options:
+        bar:
+            description: Foo bar.
+            type: string
 '''
 
 EXAMPLES = '''

--- a/tests/functional/collections/ansible_collections/ns2/col/plugins/lookup/foo.py
+++ b/tests/functional/collections/ansible_collections/ns2/col/plugins/lookup/foo.py
@@ -10,7 +10,7 @@ DOCUMENTATION = """
     name: foo
     author: Felix Fontein (@felixfontein)
     version_added: "1.0.0"
-    short_description: Look up some foo
+    short_description: Look up some foo O(bar)
     description:
       - This looks up some foo.
       - Whatever that is.
@@ -20,6 +20,9 @@ DOCUMENTATION = """
         required: true
         type: list
         elements: str
+      bar:
+        description: Foo bar.
+        type: string
 """
 
 EXAMPLES = """

--- a/tests/functional/collections/ansible_collections/ns2/col/plugins/modules/foo.py
+++ b/tests/functional/collections/ansible_collections/ns2/col/plugins/modules/foo.py
@@ -15,7 +15,7 @@ author:
     - "Ansible Core Team"
     - "Someone else (@ansible)"
 version_added: "2.0.0"
-short_description: Do some foo
+short_description: Do some foo O(bar)
 description:
     - Does some foo on the remote host.
     - Whether foo is magic or not has not yet been determined.

--- a/tests/functional/collections/ansible_collections/ns2/col/plugins/shell/foo.py
+++ b/tests/functional/collections/ansible_collections/ns2/col/plugins/shell/foo.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
 name: foo
-short_description: Foo shell
+short_description: Foo shell O(bar)
 version_added: 1.0.0
 description:
   - This is for the foo shell.
@@ -27,6 +27,9 @@ options:
       - name: ansible_remote_tmp
     version_added: '2.10'
     version_added_collection: ansible.builtin
+  bar:
+    description: Foo bar.
+    type: string
 '''
 
 from ansible.plugins.shell import ShellBase

--- a/tests/functional/collections/ansible_collections/ns2/col/plugins/test/foo.py
+++ b/tests/functional/collections/ansible_collections/ns2/col/plugins/test/foo.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 DOCUMENTATION = r'''
   name: foo
   author: Nobody
-  short_description: Is something a foo
+  short_description: Is something a foo O(bar)
   description:
     - Check whether the input dictionary is a foo.
   options:
@@ -18,6 +18,9 @@ DOCUMENTATION = r'''
       description: Something to test.
       type: dictionary
       required: true
+    bar:
+      description: Foo bar.
+      type: string
 '''
 
 EXAMPLES = r'''

--- a/tests/functional/collections/ansible_collections/ns2/col/plugins/vars/foo.py
+++ b/tests/functional/collections/ansible_collections/ns2/col/plugins/vars/foo.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
     name: foo
     version_added: 0.9.0
-    short_description: Load foo
+    short_description: Load foo O(bar)
     requirements:
         - Enabled in Ansible's configuration.
     description:
@@ -29,6 +29,9 @@ DOCUMENTATION = '''
             section: defaults
         type: list
         elements: string
+      bar:
+        description: Foo bar.
+        type: string
 '''
 
 from ansible.plugins.vars import BaseVarsPlugin


### PR DESCRIPTION
Follow-up to #4, thus no changelog fragment.

This fixes the proble exposed by the rebase https://github.com/ansible-community/antsibull-docs/pull/75#issuecomment-1462637655.