### PR TITLE
Allow to validate Ansible markup

### DIFF
--- a/changelogs/fragments/112-validate-markup.yml
+++ b/changelogs/fragments/112-validate-markup.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - "The ``lint-collection-docs`` subcommand can be told not to run rstcheck when ``--plugin-docs`` is used by passing ``--skip-rstcheck``. This speeds up testing for large collections (https://github.com/ansible-community/antsibull-docs/pull/112)."
+  - "The ``lint-collection-docs`` subcommand will now also validate Ansible markup when ``--plugin-docs`` is passed. It can also ensure that no semantic markup is used with the new ``--disallow-semantic-markup`` option. This can for example be used by collections to avoid semantic markup being backported to older stable branches (https://github.com/ansible-community/antsibull-docs/pull/112)."

--- a/src/antsibull_docs/cli/antsibull_docs.py
+++ b/src/antsibull_docs/cli/antsibull_docs.py
@@ -427,8 +427,8 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
                                              dest='plugin_docs', action=BooleanOptionalAction,
                                              default=False,
                                              help='Determine whether to also check RST file'
-                                             ' generation and validation for plugins and roles'
-                                             ' in this collection.')
+                                             ' generation and schema and markup validation for'
+                                             ' plugins and roles in this collection.')
     lint_collection_docs_parser.add_argument('--skip-rstcheck',
                                              dest='skip_rstcheck', action=BooleanOptionalAction,
                                              default=False,

--- a/src/antsibull_docs/cli/antsibull_docs.py
+++ b/src/antsibull_docs/cli/antsibull_docs.py
@@ -435,6 +435,14 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
                                              help='When --plugin-docs is specified, do not run'
                                              ' rstcheck on the generated RST files. This speeds'
                                              ' up testing for large collections.')
+    lint_collection_docs_parser.add_argument('--disallow-semantic-markup',
+                                             dest='disallow_semantic_markup',
+                                             action=BooleanOptionalAction,
+                                             default=False,
+                                             help='When --plugin-docs is specified, check that'
+                                             ' there is no semantic markup used. This can be used'
+                                             ' by collections to ensure that semantic markup is'
+                                             ' not yet used.')
 
     flog.debug('Argument parser setup')
 

--- a/src/antsibull_docs/cli/antsibull_docs.py
+++ b/src/antsibull_docs/cli/antsibull_docs.py
@@ -429,6 +429,12 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
                                              help='Determine whether to also check RST file'
                                              ' generation and validation for plugins and roles'
                                              ' in this collection.')
+    lint_collection_docs_parser.add_argument('--skip-rstcheck',
+                                             dest='skip_rstcheck', action=BooleanOptionalAction,
+                                             default=False,
+                                             help='When --plugin-docs is specified, do not run'
+                                             ' rstcheck on the generated RST files. This speeds'
+                                             ' up testing for large collections.')
 
     flog.debug('Argument parser setup')
 

--- a/src/antsibull_docs/cli/doc_commands/lint_collection_docs.py
+++ b/src/antsibull_docs/cli/doc_commands/lint_collection_docs.py
@@ -33,6 +33,7 @@ def lint_collection_docs() -> int:
 
     collection_root = app_ctx.extra['collection_root_path']
     plugin_docs = app_ctx.extra['plugin_docs']
+    skip_rstcheck = app_ctx.extra['skip_rstcheck']
 
     flog.notice('Linting extra docs files')
     errors = lint_collection_extra_docs_files(collection_root)
@@ -47,7 +48,10 @@ def lint_collection_docs() -> int:
         collection_install = CollectionNameTransformer(
             app_ctx.collection_install, 'ansible-galaxy collection install {namespace}.{name}')
         errors.extend(lint_collection_plugin_docs(
-            collection_root, collection_url=collection_url, collection_install=collection_install))
+            collection_root,
+            collection_url=collection_url,
+            collection_install=collection_install,
+            skip_rstcheck=skip_rstcheck))
 
     messages = sorted(
         (os.path.normpath(error[0]), error[1], error[2], error[3].lstrip()) for error in errors

--- a/src/antsibull_docs/cli/doc_commands/lint_collection_docs.py
+++ b/src/antsibull_docs/cli/doc_commands/lint_collection_docs.py
@@ -34,6 +34,7 @@ def lint_collection_docs() -> int:
     collection_root = app_ctx.extra['collection_root_path']
     plugin_docs = app_ctx.extra['plugin_docs']
     skip_rstcheck = app_ctx.extra['skip_rstcheck']
+    disallow_semantic_markup = app_ctx.extra['disallow_semantic_markup']
 
     flog.notice('Linting extra docs files')
     errors = lint_collection_extra_docs_files(collection_root)
@@ -51,7 +52,8 @@ def lint_collection_docs() -> int:
             collection_root,
             collection_url=collection_url,
             collection_install=collection_install,
-            skip_rstcheck=skip_rstcheck))
+            skip_rstcheck=skip_rstcheck,
+            disallow_semantic_markup=disallow_semantic_markup))
 
     messages = sorted(
         (os.path.normpath(error[0]), error[1], error[2], error[3].lstrip()) for error in errors

--- a/src/antsibull_docs/lint_plugin_docs.py
+++ b/src/antsibull_docs/lint_plugin_docs.py
@@ -80,6 +80,7 @@ def _lint_collection_plugin_docs(collections_dir: str, collection_name: str,
                                  original_path_to_collection: str,
                                  collection_url: CollectionNameTransformer,
                                  collection_install: CollectionNameTransformer,
+                                 skip_rstcheck: bool,
                                  ) -> t.List[t.Tuple[str, int, int, str]]:
     # Load collection docs
     venv = FakeVenvRunner()
@@ -143,21 +144,25 @@ def _lint_collection_plugin_docs(collections_dir: str, collection_name: str,
                     use_html_blobs=False,
                     log_errors=False,
                 )
-                path = os.path.join(
-                    original_path_to_collection, 'plugins', plugin_type,
-                    f'{plugin_short_name}.rst')
-                rst_results = check_rst_content(
-                    rst_content, filename=path,
-                    ignore_directives=['rst-class'],
-                    ignore_roles=list(antsibull_roles.ROLES),
-                )
-                result.extend([(path, result[0], result[1], result[2]) for result in rst_results])
+                if not skip_rstcheck:
+                    path = os.path.join(
+                        original_path_to_collection, 'plugins', plugin_type,
+                        f'{plugin_short_name}.rst')
+                    rst_results = check_rst_content(
+                        rst_content, filename=path,
+                        ignore_directives=['rst-class'],
+                        ignore_roles=list(antsibull_roles.ROLES),
+                    )
+                    result.extend([
+                        (path, result[0], result[1], result[2]) for result in rst_results
+                    ])
     return result
 
 
 def lint_collection_plugin_docs(path_to_collection: str,
                                 collection_url: CollectionNameTransformer,
                                 collection_install: CollectionNameTransformer,
+                                skip_rstcheck: bool = False,
                                 ) -> t.List[t.Tuple[str, int, int, str]]:
     try:
         info = load_collection_info(path_to_collection)
@@ -198,5 +203,6 @@ def lint_collection_plugin_docs(path_to_collection: str,
         result.extend(_lint_collection_plugin_docs(
             copier.dir, collection_name, path_to_collection,
             collection_url=collection_url,
-            collection_install=collection_install))
+            collection_install=collection_install,
+            skip_rstcheck=skip_rstcheck))
     return result

--- a/src/antsibull_docs/lint_plugin_docs.py
+++ b/src/antsibull_docs/lint_plugin_docs.py
@@ -137,7 +137,7 @@ class _MarkupValidator:
         if plugin is None:
             return
         if plugin == self._context.current_plugin:
-            if _NAME_SEPARATOR.join(rv.link) not in self._option_names:
+            if _NAME_SEPARATOR.join(rv.link) not in self._return_value_names:
                 prefix = '' if plugin.type in ('role', 'module') else ' plugin'
                 self.errors.append(
                     f'{key}: return value name reference "{rv.name}" does not reference to an'
@@ -345,14 +345,16 @@ def _lint_collection_plugin_docs(collections_dir: str, collection_name: str,
                         plugin_type,
                         collection_name_,
                         collection_metadata[collection_name_]))
-                path = os.path.join(
-                    original_path_to_collection, 'plugins', plugin_type,
-                    f'{plugin_short_name}.rst')
                 if has_broken_docs(plugin_record, plugin_type):
                     result.append((filename, 0, 0, 'Did not return correct DOCUMENTATION'))
                 else:
                     result.extend(_validate_markup(
-                        plugin_record, plugin_name, plugin_type, path, disallow_semantic_markup))
+                        plugin_record,
+                        plugin_name,
+                        plugin_type,
+                        filename,
+                        disallow_semantic_markup,
+                    ))
                 for error in nonfatal_errors[plugin_type][plugin_name]:
                     result.append((filename, 0, 0, error))
                 rst_content = create_plugin_rst(
@@ -368,6 +370,9 @@ def _lint_collection_plugin_docs(collections_dir: str, collection_name: str,
                     log_errors=False,
                 )
                 if not skip_rstcheck:
+                    path = os.path.join(
+                        original_path_to_collection, 'plugins', plugin_type,
+                        f'{plugin_short_name}.rst')
                     rst_results = check_rst_content(
                         rst_content, filename=path,
                         ignore_directives=['rst-class'],

--- a/tests/functional/baseline-default/collections/index_module.rst
+++ b/tests/functional/baseline-default/collections/index_module.rst
@@ -10,6 +10,8 @@ ns.col2
 -------
 
 * :ref:`ns.col2.foo <ansible_collections.ns.col2.foo_module>` -- 
+* :ref:`ns.col2.foo2 <ansible_collections.ns.col2.foo2_module>` -- Foo two
+* :ref:`ns.col2.foo3 <ansible_collections.ns.col2.foo3_module>` -- Foo III
 
 ns2.col
 -------

--- a/tests/functional/baseline-default/collections/ns/col2/foo2_module.rst
+++ b/tests/functional/baseline-default/collections/ns/col2/foo2_module.rst
@@ -2,7 +2,6 @@
 .. Document meta
 
 :orphan:
-:github_url: https://github.com/ansible-community/antsibull-docs/edit/main/tests/functional/collections/ansible_collections/ns2/col/plugins/modules/foo2.py?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr
 
 .. |antsibull-internal-nbsp| unicode:: 0xA0
     :trim:
@@ -27,7 +26,7 @@
 
 .. Anchors
 
-.. _ansible_collections.ns2.col.foo2_module:
+.. _ansible_collections.ns.col2.foo2_module:
 
 .. Anchors: short name for ansible.builtin
 
@@ -37,17 +36,19 @@
 
 .. Title
 
-ns2.col.foo2 module -- Another foo
-++++++++++++++++++++++++++++++++++
+ns.col2.foo2 module -- Foo two
+++++++++++++++++++++++++++++++
 
 .. Collection note
 
 .. note::
-    This module is part of the `ns2.col collection <https://galaxy.ansible.com/ns2/col>`_ (version 2.1.0).
+    This module is part of the `ns.col2 collection <https://galaxy.ansible.com/ns/col2>`_ (version 0.0.1).
 
-    To install it, use: :code:`ansible-galaxy collection install ns2.col`.
+    To install it, use: :code:`ansible-galaxy collection install ns.col2`.
+    You need further requirements to be able to use this module,
+    see :ref:`Requirements <ansible_collections.ns.col2.foo2_module_requirements>` for details.
 
-    To use it in a playbook, specify: :code:`ns2.col.foo2`.
+    To use it in a playbook, specify: :code:`ns.col2.foo2`.
 
 .. version_added
 
@@ -64,13 +65,26 @@ Synopsis
 
 .. Description
 
-- Foo bar.
+- Does some foo on the remote host.
+- A broken reference \ :ref:`asdfasdfoobarTHISDOESNOTEXIST <asdfasdfoobarTHISDOESNOTEXIST>`\ .
+- The option \ :ansopt:`ns.col2.foo2#module:foo`\  exists, but \ :ansopt:`ns.col2.foo2#module:foobar`\  does not.
+- The return value \ :ansretval:`ns.col2.foo2#module:bar`\  exists, but \ :ansretval:`ns.col2.foo2#module:barbaz`\  does not.
+- Again existing: \ :ansopt:`ns.col2.foo#module:foo=1`\ , \ :ansretval:`ns.col2.foo#module:bar=2`\ 
+- Again not existing: \ :ansopt:`ns.col2.foo#module:foobar=1`\ , \ :ansretval:`ns.col2.foo#module:barbaz=2`\ 
 
 
 .. Aliases
 
 
 .. Requirements
+
+.. _ansible_collections.ns.col2.foo2_module_requirements:
+
+Requirements
+------------
+The below requirements are needed on the host that executes this module.
+
+- Foo.
 
 
 
@@ -97,7 +111,7 @@ Parameters
         <div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="parameter-bar"></div>
 
-      .. _ansible_collections.ns2.col.foo2_module__parameter-bar:
+      .. _ansible_collections.ns.col2.foo2_module__parameter-bar:
 
       .. rst-class:: ansible-option-title
 
@@ -106,6 +120,40 @@ Parameters
       .. raw:: html
 
         <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`list` / :ansible-option-elements:`elements=integer`
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Bar.
+
+
+      .. raw:: html
+
+        </div>
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-foo"></div>
+
+      .. _ansible_collections.ns.col2.foo2_module__parameter-foo:
+
+      .. rst-class:: ansible-option-title
+
+      **foo**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-foo" title="Permalink to this option"></a>
 
       .. rst-class:: ansible-option-type-line
 
@@ -119,12 +167,85 @@ Parameters
 
         <div class="ansible-option-cell">
 
-      Some bar.
+      The foo source.
 
 
       .. raw:: html
 
         </div>
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-subfoo"></div>
+
+      .. _ansible_collections.ns.col2.foo2_module__parameter-subfoo:
+
+      .. rst-class:: ansible-option-title
+
+      **subfoo**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-subfoo" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`dictionary`
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Some recursive foo.
+
+
+      .. raw:: html
+
+        </div>
+    
+  * - .. raw:: html
+
+        <div class="ansible-option-indent"></div><div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-subfoo/foo"></div>
+
+      .. _ansible_collections.ns.col2.foo2_module__parameter-subfoo/foo:
+
+      .. rst-class:: ansible-option-title
+
+      **foo**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-subfoo/foo" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string` / :ansible-option-required:`required`
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-indent-desc"></div><div class="ansible-option-cell">
+
+      A sub foo.
+
+      Whatever.
+
+      Also required when \ :emphasis:`subfoo`\  is specified when \ :emphasis:`foo=bar`\  or \ :literal:`baz`\ .
+
+
+      .. raw:: html
+
+        </div>
+
 
 
 .. Attributes
@@ -147,51 +268,9 @@ Attributes
   * - .. raw:: html
 
         <div class="ansible-option-cell">
-        <div class="ansibleOptionAnchor" id="attribute-action_group"></div>
-
-      .. _ansible_collections.ns2.col.foo2_module__attribute-action_group:
-
-      .. rst-class:: ansible-option-title
-
-      **action_group**
-
-      .. raw:: html
-
-        <a class="ansibleOptionLink" href="#attribute-action_group" title="Permalink to this attribute"></a>
-
-      .. raw:: html
-
-        </div>
-
-    - .. raw:: html
-
-        <div class="ansible-option-cell">
-
-      :ansible-attribute-support-property:`Action groups:` |antsibull-internal-nbsp|:ansible-attribute-support-full:`ns2.col.bar\_group`, :ansible-attribute-support-full:`ns2.col.foo\_group`
-
-
-      .. raw:: html
-
-        </div>
-
-    - .. raw:: html
-
-        <div class="ansible-option-cell">
-
-      Use \ :literal:`group/ns2.col.foo\_group`\  or \ :literal:`group/ns2.col.bar\_group`\  in \ :literal:`module\_defaults`\  to set defaults for this module.
-
-
-      .. raw:: html
-
-        </div>
-
-
-  * - .. raw:: html
-
-        <div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="attribute-check_mode"></div>
 
-      .. _ansible_collections.ns2.col.foo2_module__attribute-check_mode:
+      .. _ansible_collections.ns.col2.foo2_module__attribute-check_mode:
 
       .. rst-class:: ansible-option-title
 
@@ -233,7 +312,7 @@ Attributes
         <div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="attribute-diff_mode"></div>
 
-      .. _ansible_collections.ns2.col.foo2_module__attribute-diff_mode:
+      .. _ansible_collections.ns.col2.foo2_module__attribute-diff_mode:
 
       .. rst-class:: ansible-option-title
 
@@ -251,7 +330,7 @@ Attributes
 
         <div class="ansible-option-cell">
 
-      :ansible-attribute-support-label:`Support: \ `      \ :ansible-attribute-support-na:`N/A`
+      :ansible-attribute-support-label:`Support: \ `\ :ansible-attribute-support-full:`full`
 
 
       .. raw:: html
@@ -275,7 +354,7 @@ Attributes
         <div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="attribute-platform"></div>
 
-      .. _ansible_collections.ns2.col.foo2_module__attribute-platform:
+      .. _ansible_collections.ns.col2.foo2_module__attribute-platform:
 
       .. rst-class:: ansible-option-title
 
@@ -294,6 +373,10 @@ Attributes
         <div class="ansible-option-cell">
 
       :ansible-attribute-support-property:`Platform:` |antsibull-internal-nbsp|:ansible-attribute-support-full:`posix`
+
+      The module \ :strong:`ERROR while parsing`\ : While parsing M() at index 12: Module name "boo" is not a FQCN\  is not using an FQCN.
+
+      Sometimes our markup is \ :strong:`ERROR while parsing`\ : While parsing B() at index 25: Cannot find closing ")" after last parameter\ 
 
 
       .. raw:: html
@@ -327,15 +410,7 @@ Examples
 .. code-block:: yaml+jinja
 
     
-    - name: Do some foo
-      ns2.col.foo:
-        foo: '{{ foo }}'
-        bar:
-          - 1
-          - 2
-          - 3
-        subfoo:
-          foo: hoo!
+    name: This is YAML.
 
 
 
@@ -364,7 +439,7 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
         <div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="return-bar"></div>
 
-      .. _ansible_collections.ns2.col.foo2_module__return-bar:
+      .. _ansible_collections.ns.col2.foo2_module__return-bar:
 
       .. rst-class:: ansible-option-title
 
@@ -387,10 +462,6 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
         <div class="ansible-option-cell">
 
       Some bar.
-
-      Referencing myself as \ :ansretval:`ns2.col.foo2#module:bar`\ .
-
-      Do not confuse with \ :ansopt:`ns2.col.foo2#module:bar`\ .
 
 
       .. rst-class:: ansible-option-line
@@ -417,24 +488,12 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
 Authors
 ~~~~~~~
 
-- Another one (@ansible-community)
+- Someone else (@ansible)
 
 
 
 .. Extra links
 
-Collection links
-~~~~~~~~~~~~~~~~
-
-.. raw:: html
-
-  <p class="ansible-links">
-    <a href="https://github.com/ansible-collections/community.general/issues" aria-role="button" target="_blank" rel="noopener external">Issue Tracker</a>
-    <a href="https://github.com/ansible-collections/community.crypto" aria-role="button" target="_blank" rel="noopener external">Homepage</a>
-    <a href="https://github.com/ansible-collections/community.internal_test_tools" aria-role="button" target="_blank" rel="noopener external">Repository (Sources)</a>
-    <a href="https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&amp;labels=&amp;template=bug_report.md" aria-role="button" target="_blank" rel="noopener external">Submit a bug report</a>
-    <a href="./#communication-for-ns2-col" aria-role="button" target="_blank">Communication</a>
-  </p>
 
 .. Parsing errors
 

--- a/tests/functional/baseline-default/collections/ns/col2/foo3_module.rst
+++ b/tests/functional/baseline-default/collections/ns/col2/foo3_module.rst
@@ -2,7 +2,6 @@
 .. Document meta
 
 :orphan:
-:github_url: https://github.com/ansible-community/antsibull-docs/edit/main/tests/functional/collections/ansible_collections/ns2/col/plugins/modules/foo2.py?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr
 
 .. |antsibull-internal-nbsp| unicode:: 0xA0
     :trim:
@@ -27,7 +26,7 @@
 
 .. Anchors
 
-.. _ansible_collections.ns2.col.foo2_module:
+.. _ansible_collections.ns.col2.foo3_module:
 
 .. Anchors: short name for ansible.builtin
 
@@ -37,17 +36,19 @@
 
 .. Title
 
-ns2.col.foo2 module -- Another foo
-++++++++++++++++++++++++++++++++++
+ns.col2.foo3 module -- Foo III
+++++++++++++++++++++++++++++++
 
 .. Collection note
 
 .. note::
-    This module is part of the `ns2.col collection <https://galaxy.ansible.com/ns2/col>`_ (version 2.1.0).
+    This module is part of the `ns.col2 collection <https://galaxy.ansible.com/ns/col2>`_ (version 0.0.1).
 
-    To install it, use: :code:`ansible-galaxy collection install ns2.col`.
+    To install it, use: :code:`ansible-galaxy collection install ns.col2`.
+    You need further requirements to be able to use this module,
+    see :ref:`Requirements <ansible_collections.ns.col2.foo3_module_requirements>` for details.
 
-    To use it in a playbook, specify: :code:`ns2.col.foo2`.
+    To use it in a playbook, specify: :code:`ns.col2.foo3`.
 
 .. version_added
 
@@ -64,13 +65,21 @@ Synopsis
 
 .. Description
 
-- Foo bar.
+- Does some foo on the remote host.
 
 
 .. Aliases
 
 
 .. Requirements
+
+.. _ansible_collections.ns.col2.foo3_module_requirements:
+
+Requirements
+------------
+The below requirements are needed on the host that executes this module.
+
+- Foo.
 
 
 
@@ -97,7 +106,7 @@ Parameters
         <div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="parameter-bar"></div>
 
-      .. _ansible_collections.ns2.col.foo2_module__parameter-bar:
+      .. _ansible_collections.ns.col2.foo3_module__parameter-bar:
 
       .. rst-class:: ansible-option-title
 
@@ -106,6 +115,40 @@ Parameters
       .. raw:: html
 
         <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`list` / :ansible-option-elements:`elements=integer`
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Bar.
+
+
+      .. raw:: html
+
+        </div>
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-foo"></div>
+
+      .. _ansible_collections.ns.col2.foo3_module__parameter-foo:
+
+      .. rst-class:: ansible-option-title
+
+      **foo**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-foo" title="Permalink to this option"></a>
 
       .. rst-class:: ansible-option-type-line
 
@@ -119,12 +162,85 @@ Parameters
 
         <div class="ansible-option-cell">
 
-      Some bar.
+      The foo source.
 
 
       .. raw:: html
 
         </div>
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-subfoo"></div>
+
+      .. _ansible_collections.ns.col2.foo3_module__parameter-subfoo:
+
+      .. rst-class:: ansible-option-title
+
+      **subfoo**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-subfoo" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`dictionary`
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Some recursive foo.
+
+
+      .. raw:: html
+
+        </div>
+    
+  * - .. raw:: html
+
+        <div class="ansible-option-indent"></div><div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-subfoo/foo"></div>
+
+      .. _ansible_collections.ns.col2.foo3_module__parameter-subfoo/foo:
+
+      .. rst-class:: ansible-option-title
+
+      **foo**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-subfoo/foo" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string` / :ansible-option-required:`required`
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-indent-desc"></div><div class="ansible-option-cell">
+
+      A sub foo.
+
+      Whatever.
+
+      Also required when \ :emphasis:`subfoo`\  is specified when \ :emphasis:`foo=bar`\  or \ :literal:`baz`\ .
+
+
+      .. raw:: html
+
+        </div>
+
 
 
 .. Attributes
@@ -147,51 +263,9 @@ Attributes
   * - .. raw:: html
 
         <div class="ansible-option-cell">
-        <div class="ansibleOptionAnchor" id="attribute-action_group"></div>
-
-      .. _ansible_collections.ns2.col.foo2_module__attribute-action_group:
-
-      .. rst-class:: ansible-option-title
-
-      **action_group**
-
-      .. raw:: html
-
-        <a class="ansibleOptionLink" href="#attribute-action_group" title="Permalink to this attribute"></a>
-
-      .. raw:: html
-
-        </div>
-
-    - .. raw:: html
-
-        <div class="ansible-option-cell">
-
-      :ansible-attribute-support-property:`Action groups:` |antsibull-internal-nbsp|:ansible-attribute-support-full:`ns2.col.bar\_group`, :ansible-attribute-support-full:`ns2.col.foo\_group`
-
-
-      .. raw:: html
-
-        </div>
-
-    - .. raw:: html
-
-        <div class="ansible-option-cell">
-
-      Use \ :literal:`group/ns2.col.foo\_group`\  or \ :literal:`group/ns2.col.bar\_group`\  in \ :literal:`module\_defaults`\  to set defaults for this module.
-
-
-      .. raw:: html
-
-        </div>
-
-
-  * - .. raw:: html
-
-        <div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="attribute-check_mode"></div>
 
-      .. _ansible_collections.ns2.col.foo2_module__attribute-check_mode:
+      .. _ansible_collections.ns.col2.foo3_module__attribute-check_mode:
 
       .. rst-class:: ansible-option-title
 
@@ -233,7 +307,7 @@ Attributes
         <div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="attribute-diff_mode"></div>
 
-      .. _ansible_collections.ns2.col.foo2_module__attribute-diff_mode:
+      .. _ansible_collections.ns.col2.foo3_module__attribute-diff_mode:
 
       .. rst-class:: ansible-option-title
 
@@ -251,7 +325,7 @@ Attributes
 
         <div class="ansible-option-cell">
 
-      :ansible-attribute-support-label:`Support: \ `      \ :ansible-attribute-support-na:`N/A`
+      :ansible-attribute-support-label:`Support: \ `\ :ansible-attribute-support-full:`full`
 
 
       .. raw:: html
@@ -275,7 +349,7 @@ Attributes
         <div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="attribute-platform"></div>
 
-      .. _ansible_collections.ns2.col.foo2_module__attribute-platform:
+      .. _ansible_collections.ns.col2.foo3_module__attribute-platform:
 
       .. rst-class:: ansible-option-title
 
@@ -327,15 +401,7 @@ Examples
 .. code-block:: yaml+jinja
 
     
-    - name: Do some foo
-      ns2.col.foo:
-        foo: '{{ foo }}'
-        bar:
-          - 1
-          - 2
-          - 3
-        subfoo:
-          foo: hoo!
+    This is not YAML.
 
 
 
@@ -344,69 +410,6 @@ Examples
 
 
 .. Return values
-
-Return Values
--------------
-Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
-
-.. rst-class:: ansible-option-table
-
-.. list-table::
-  :width: 100%
-  :widths: auto
-  :header-rows: 1
-
-  * - Key
-    - Description
-
-  * - .. raw:: html
-
-        <div class="ansible-option-cell">
-        <div class="ansibleOptionAnchor" id="return-bar"></div>
-
-      .. _ansible_collections.ns2.col.foo2_module__return-bar:
-
-      .. rst-class:: ansible-option-title
-
-      **bar**
-
-      .. raw:: html
-
-        <a class="ansibleOptionLink" href="#return-bar" title="Permalink to this return value"></a>
-
-      .. rst-class:: ansible-option-type-line
-
-      :ansible-option-type:`string`
-
-      .. raw:: html
-
-        </div>
-
-    - .. raw:: html
-
-        <div class="ansible-option-cell">
-
-      Some bar.
-
-      Referencing myself as \ :ansretval:`ns2.col.foo2#module:bar`\ .
-
-      Do not confuse with \ :ansopt:`ns2.col.foo2#module:bar`\ .
-
-
-      .. rst-class:: ansible-option-line
-
-      :ansible-option-returned-bold:`Returned:` success
-
-      .. rst-class:: ansible-option-line
-      .. rst-class:: ansible-option-sample
-
-      :ansible-option-sample-bold:`Sample:` :ansible-rv-sample-value:`"baz"`
-
-
-      .. raw:: html
-
-        </div>
-
 
 
 ..  Status (Presently only deprecated)
@@ -417,24 +420,24 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
 Authors
 ~~~~~~~
 
-- Another one (@ansible-community)
+- Someone else (@ansible)
 
 
 
 .. Extra links
 
-Collection links
-~~~~~~~~~~~~~~~~
-
-.. raw:: html
-
-  <p class="ansible-links">
-    <a href="https://github.com/ansible-collections/community.general/issues" aria-role="button" target="_blank" rel="noopener external">Issue Tracker</a>
-    <a href="https://github.com/ansible-collections/community.crypto" aria-role="button" target="_blank" rel="noopener external">Homepage</a>
-    <a href="https://github.com/ansible-collections/community.internal_test_tools" aria-role="button" target="_blank" rel="noopener external">Repository (Sources)</a>
-    <a href="https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&amp;labels=&amp;template=bug_report.md" aria-role="button" target="_blank" rel="noopener external">Submit a bug report</a>
-    <a href="./#communication-for-ns2-col" aria-role="button" target="_blank">Communication</a>
-  </p>
 
 .. Parsing errors
+
+There were some errors parsing the documentation for this plugin.  Please file a bug with the `ns.col2 collection <https://galaxy.ansible.com/ns/col2>`_.
+
+The errors were:
+
+* ::
+
+        Unable to normalize foo3: return due to: 2 validation errors for PluginReturnSchema
+        return -> bar -> type
+          string does not match regex "^(any|bits|bool|bytes|complex|dict|float|int|json|jsonarg|list|path|sid|str|pathspec|pathlist)$" (type=value_error.str.regex; pattern=^(any|bits|bool|bytes|complex|dict|float|int|json|jsonarg|list|path|sid|str|pathspec|pathlist)$)
+        return -> baz
+          value is not a valid dict (type=type_error.dict)
 

--- a/tests/functional/baseline-default/collections/ns/col2/index.rst
+++ b/tests/functional/baseline-default/collections/ns/col2/index.rst
@@ -41,12 +41,16 @@ Modules
 ~~~~~~~
 
 * :ref:`foo module <ansible_collections.ns.col2.foo_module>` -- 
+* :ref:`foo2 module <ansible_collections.ns.col2.foo2_module>` -- Foo two
+* :ref:`foo3 module <ansible_collections.ns.col2.foo3_module>` -- Foo III
 
 .. toctree::
     :maxdepth: 1
     :hidden:
 
     foo_module
+    foo2_module
+    foo3_module
 
 
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo2_module.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo2_module.rst
@@ -79,6 +79,53 @@ Synopsis
 
 .. Options
 
+Parameters
+----------
+
+.. rst-class:: ansible-option-table
+
+.. list-table::
+  :width: 100%
+  :widths: auto
+  :header-rows: 1
+
+  * - Parameter
+    - Comments
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo2_module__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Some bar.
+
+
+      .. raw:: html
+
+        </div>
+
 
 .. Attributes
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_module.rst
@@ -10,6 +10,8 @@ ns.col2
 -------
 
 * :ref:`ns.col2.foo <ansible_collections.ns.col2.foo_module>` -- 
+* :ref:`ns.col2.foo2 <ansible_collections.ns.col2.foo2_module>` -- Foo two
+* :ref:`ns.col2.foo3 <ansible_collections.ns.col2.foo3_module>` -- Foo III
 
 ns2.col
 -------

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/foo2_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/foo2_module.rst
@@ -2,7 +2,6 @@
 .. Document meta
 
 :orphan:
-:github_url: https://github.com/ansible-community/antsibull-docs/edit/main/tests/functional/collections/ansible_collections/ns2/col/plugins/modules/foo2.py?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr
 
 .. |antsibull-internal-nbsp| unicode:: 0xA0
     :trim:
@@ -27,7 +26,7 @@
 
 .. Anchors
 
-.. _ansible_collections.ns2.col.foo2_module:
+.. _ansible_collections.ns.col2.foo2_module:
 
 .. Anchors: short name for ansible.builtin
 
@@ -37,17 +36,19 @@
 
 .. Title
 
-ns2.col.foo2 module -- Another foo
-++++++++++++++++++++++++++++++++++
+ns.col2.foo2 module -- Foo two
+++++++++++++++++++++++++++++++
 
 .. Collection note
 
 .. note::
-    This module is part of the `ns2.col collection <https://galaxy.ansible.com/ns2/col>`_ (version 2.1.0).
+    This module is part of the `ns.col2 collection <https://galaxy.ansible.com/ns/col2>`_ (version 0.0.1).
 
-    To install it, use: :code:`ansible-galaxy collection install ns2.col`.
+    To install it, use: :code:`ansible-galaxy collection install ns.col2`.
+    You need further requirements to be able to use this module,
+    see :ref:`Requirements <ansible_collections.ns.col2.foo2_module_requirements>` for details.
 
-    To use it in a playbook, specify: :code:`ns2.col.foo2`.
+    To use it in a playbook, specify: :code:`ns.col2.foo2`.
 
 .. version_added
 
@@ -64,13 +65,26 @@ Synopsis
 
 .. Description
 
-- Foo bar.
+- Does some foo on the remote host.
+- A broken reference \ :ref:`asdfasdfoobarTHISDOESNOTEXIST <asdfasdfoobarTHISDOESNOTEXIST>`\ .
+- The option \ :ansopt:`ns.col2.foo2#module:foo`\  exists, but \ :ansopt:`ns.col2.foo2#module:foobar`\  does not.
+- The return value \ :ansretval:`ns.col2.foo2#module:bar`\  exists, but \ :ansretval:`ns.col2.foo2#module:barbaz`\  does not.
+- Again existing: \ :ansopt:`ns.col2.foo#module:foo=1`\ , \ :ansretval:`ns.col2.foo#module:bar=2`\ 
+- Again not existing: \ :ansopt:`ns.col2.foo#module:foobar=1`\ , \ :ansretval:`ns.col2.foo#module:barbaz=2`\ 
 
 
 .. Aliases
 
 
 .. Requirements
+
+.. _ansible_collections.ns.col2.foo2_module_requirements:
+
+Requirements
+------------
+The below requirements are needed on the host that executes this module.
+
+- Foo.
 
 
 
@@ -97,7 +111,7 @@ Parameters
         <div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="parameter-bar"></div>
 
-      .. _ansible_collections.ns2.col.foo2_module__parameter-bar:
+      .. _ansible_collections.ns.col2.foo2_module__parameter-bar:
 
       .. rst-class:: ansible-option-title
 
@@ -106,6 +120,40 @@ Parameters
       .. raw:: html
 
         <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`list` / :ansible-option-elements:`elements=integer`
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Bar.
+
+
+      .. raw:: html
+
+        </div>
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-foo"></div>
+
+      .. _ansible_collections.ns.col2.foo2_module__parameter-foo:
+
+      .. rst-class:: ansible-option-title
+
+      **foo**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-foo" title="Permalink to this option"></a>
 
       .. rst-class:: ansible-option-type-line
 
@@ -119,12 +167,85 @@ Parameters
 
         <div class="ansible-option-cell">
 
-      Some bar.
+      The foo source.
 
 
       .. raw:: html
 
         </div>
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-subfoo"></div>
+
+      .. _ansible_collections.ns.col2.foo2_module__parameter-subfoo:
+
+      .. rst-class:: ansible-option-title
+
+      **subfoo**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-subfoo" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`dictionary`
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Some recursive foo.
+
+
+      .. raw:: html
+
+        </div>
+    
+  * - .. raw:: html
+
+        <div class="ansible-option-indent"></div><div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-subfoo/foo"></div>
+
+      .. _ansible_collections.ns.col2.foo2_module__parameter-subfoo/foo:
+
+      .. rst-class:: ansible-option-title
+
+      **foo**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-subfoo/foo" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string` / :ansible-option-required:`required`
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-indent-desc"></div><div class="ansible-option-cell">
+
+      A sub foo.
+
+      Whatever.
+
+      Also required when \ :emphasis:`subfoo`\  is specified when \ :emphasis:`foo=bar`\  or \ :literal:`baz`\ .
+
+
+      .. raw:: html
+
+        </div>
+
 
 
 .. Attributes
@@ -147,51 +268,9 @@ Attributes
   * - .. raw:: html
 
         <div class="ansible-option-cell">
-        <div class="ansibleOptionAnchor" id="attribute-action_group"></div>
-
-      .. _ansible_collections.ns2.col.foo2_module__attribute-action_group:
-
-      .. rst-class:: ansible-option-title
-
-      **action_group**
-
-      .. raw:: html
-
-        <a class="ansibleOptionLink" href="#attribute-action_group" title="Permalink to this attribute"></a>
-
-      .. raw:: html
-
-        </div>
-
-    - .. raw:: html
-
-        <div class="ansible-option-cell">
-
-      :ansible-attribute-support-property:`Action groups:` |antsibull-internal-nbsp|:ansible-attribute-support-full:`ns2.col.bar\_group`, :ansible-attribute-support-full:`ns2.col.foo\_group`
-
-
-      .. raw:: html
-
-        </div>
-
-    - .. raw:: html
-
-        <div class="ansible-option-cell">
-
-      Use \ :literal:`group/ns2.col.foo\_group`\  or \ :literal:`group/ns2.col.bar\_group`\  in \ :literal:`module\_defaults`\  to set defaults for this module.
-
-
-      .. raw:: html
-
-        </div>
-
-
-  * - .. raw:: html
-
-        <div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="attribute-check_mode"></div>
 
-      .. _ansible_collections.ns2.col.foo2_module__attribute-check_mode:
+      .. _ansible_collections.ns.col2.foo2_module__attribute-check_mode:
 
       .. rst-class:: ansible-option-title
 
@@ -233,7 +312,7 @@ Attributes
         <div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="attribute-diff_mode"></div>
 
-      .. _ansible_collections.ns2.col.foo2_module__attribute-diff_mode:
+      .. _ansible_collections.ns.col2.foo2_module__attribute-diff_mode:
 
       .. rst-class:: ansible-option-title
 
@@ -251,7 +330,7 @@ Attributes
 
         <div class="ansible-option-cell">
 
-      :ansible-attribute-support-label:`Support: \ `      \ :ansible-attribute-support-na:`N/A`
+      :ansible-attribute-support-label:`Support: \ `\ :ansible-attribute-support-full:`full`
 
 
       .. raw:: html
@@ -275,7 +354,7 @@ Attributes
         <div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="attribute-platform"></div>
 
-      .. _ansible_collections.ns2.col.foo2_module__attribute-platform:
+      .. _ansible_collections.ns.col2.foo2_module__attribute-platform:
 
       .. rst-class:: ansible-option-title
 
@@ -294,6 +373,10 @@ Attributes
         <div class="ansible-option-cell">
 
       :ansible-attribute-support-property:`Platform:` |antsibull-internal-nbsp|:ansible-attribute-support-full:`posix`
+
+      The module \ :strong:`ERROR while parsing`\ : While parsing M() at index 12: Module name "boo" is not a FQCN\  is not using an FQCN.
+
+      Sometimes our markup is \ :strong:`ERROR while parsing`\ : While parsing B() at index 25: Cannot find closing ")" after last parameter\ 
 
 
       .. raw:: html
@@ -327,15 +410,7 @@ Examples
 .. code-block:: yaml+jinja
 
     
-    - name: Do some foo
-      ns2.col.foo:
-        foo: '{{ foo }}'
-        bar:
-          - 1
-          - 2
-          - 3
-        subfoo:
-          foo: hoo!
+    name: This is YAML.
 
 
 
@@ -364,7 +439,7 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
         <div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="return-bar"></div>
 
-      .. _ansible_collections.ns2.col.foo2_module__return-bar:
+      .. _ansible_collections.ns.col2.foo2_module__return-bar:
 
       .. rst-class:: ansible-option-title
 
@@ -387,10 +462,6 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
         <div class="ansible-option-cell">
 
       Some bar.
-
-      Referencing myself as \ :ansretval:`ns2.col.foo2#module:bar`\ .
-
-      Do not confuse with \ :ansopt:`ns2.col.foo2#module:bar`\ .
 
 
       .. rst-class:: ansible-option-line
@@ -417,24 +488,12 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
 Authors
 ~~~~~~~
 
-- Another one (@ansible-community)
+- Someone else (@ansible)
 
 
 
 .. Extra links
 
-Collection links
-~~~~~~~~~~~~~~~~
-
-.. raw:: html
-
-  <p class="ansible-links">
-    <a href="https://github.com/ansible-collections/community.general/issues" aria-role="button" target="_blank" rel="noopener external">Issue Tracker</a>
-    <a href="https://github.com/ansible-collections/community.crypto" aria-role="button" target="_blank" rel="noopener external">Homepage</a>
-    <a href="https://github.com/ansible-collections/community.internal_test_tools" aria-role="button" target="_blank" rel="noopener external">Repository (Sources)</a>
-    <a href="https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&amp;labels=&amp;template=bug_report.md" aria-role="button" target="_blank" rel="noopener external">Submit a bug report</a>
-    <a href="./#communication-for-ns2-col" aria-role="button" target="_blank">Communication</a>
-  </p>
 
 .. Parsing errors
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/foo3_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/foo3_module.rst
@@ -2,7 +2,6 @@
 .. Document meta
 
 :orphan:
-:github_url: https://github.com/ansible-community/antsibull-docs/edit/main/tests/functional/collections/ansible_collections/ns2/col/plugins/modules/foo2.py?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr
 
 .. |antsibull-internal-nbsp| unicode:: 0xA0
     :trim:
@@ -27,7 +26,7 @@
 
 .. Anchors
 
-.. _ansible_collections.ns2.col.foo2_module:
+.. _ansible_collections.ns.col2.foo3_module:
 
 .. Anchors: short name for ansible.builtin
 
@@ -37,17 +36,19 @@
 
 .. Title
 
-ns2.col.foo2 module -- Another foo
-++++++++++++++++++++++++++++++++++
+ns.col2.foo3 module -- Foo III
+++++++++++++++++++++++++++++++
 
 .. Collection note
 
 .. note::
-    This module is part of the `ns2.col collection <https://galaxy.ansible.com/ns2/col>`_ (version 2.1.0).
+    This module is part of the `ns.col2 collection <https://galaxy.ansible.com/ns/col2>`_ (version 0.0.1).
 
-    To install it, use: :code:`ansible-galaxy collection install ns2.col`.
+    To install it, use: :code:`ansible-galaxy collection install ns.col2`.
+    You need further requirements to be able to use this module,
+    see :ref:`Requirements <ansible_collections.ns.col2.foo3_module_requirements>` for details.
 
-    To use it in a playbook, specify: :code:`ns2.col.foo2`.
+    To use it in a playbook, specify: :code:`ns.col2.foo3`.
 
 .. version_added
 
@@ -64,13 +65,21 @@ Synopsis
 
 .. Description
 
-- Foo bar.
+- Does some foo on the remote host.
 
 
 .. Aliases
 
 
 .. Requirements
+
+.. _ansible_collections.ns.col2.foo3_module_requirements:
+
+Requirements
+------------
+The below requirements are needed on the host that executes this module.
+
+- Foo.
 
 
 
@@ -97,7 +106,7 @@ Parameters
         <div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="parameter-bar"></div>
 
-      .. _ansible_collections.ns2.col.foo2_module__parameter-bar:
+      .. _ansible_collections.ns.col2.foo3_module__parameter-bar:
 
       .. rst-class:: ansible-option-title
 
@@ -106,6 +115,40 @@ Parameters
       .. raw:: html
 
         <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`list` / :ansible-option-elements:`elements=integer`
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Bar.
+
+
+      .. raw:: html
+
+        </div>
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-foo"></div>
+
+      .. _ansible_collections.ns.col2.foo3_module__parameter-foo:
+
+      .. rst-class:: ansible-option-title
+
+      **foo**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-foo" title="Permalink to this option"></a>
 
       .. rst-class:: ansible-option-type-line
 
@@ -119,12 +162,85 @@ Parameters
 
         <div class="ansible-option-cell">
 
-      Some bar.
+      The foo source.
 
 
       .. raw:: html
 
         </div>
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-subfoo"></div>
+
+      .. _ansible_collections.ns.col2.foo3_module__parameter-subfoo:
+
+      .. rst-class:: ansible-option-title
+
+      **subfoo**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-subfoo" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`dictionary`
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Some recursive foo.
+
+
+      .. raw:: html
+
+        </div>
+    
+  * - .. raw:: html
+
+        <div class="ansible-option-indent"></div><div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-subfoo/foo"></div>
+
+      .. _ansible_collections.ns.col2.foo3_module__parameter-subfoo/foo:
+
+      .. rst-class:: ansible-option-title
+
+      **foo**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-subfoo/foo" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string` / :ansible-option-required:`required`
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-indent-desc"></div><div class="ansible-option-cell">
+
+      A sub foo.
+
+      Whatever.
+
+      Also required when \ :emphasis:`subfoo`\  is specified when \ :emphasis:`foo=bar`\  or \ :literal:`baz`\ .
+
+
+      .. raw:: html
+
+        </div>
+
 
 
 .. Attributes
@@ -147,51 +263,9 @@ Attributes
   * - .. raw:: html
 
         <div class="ansible-option-cell">
-        <div class="ansibleOptionAnchor" id="attribute-action_group"></div>
-
-      .. _ansible_collections.ns2.col.foo2_module__attribute-action_group:
-
-      .. rst-class:: ansible-option-title
-
-      **action_group**
-
-      .. raw:: html
-
-        <a class="ansibleOptionLink" href="#attribute-action_group" title="Permalink to this attribute"></a>
-
-      .. raw:: html
-
-        </div>
-
-    - .. raw:: html
-
-        <div class="ansible-option-cell">
-
-      :ansible-attribute-support-property:`Action groups:` |antsibull-internal-nbsp|:ansible-attribute-support-full:`ns2.col.bar\_group`, :ansible-attribute-support-full:`ns2.col.foo\_group`
-
-
-      .. raw:: html
-
-        </div>
-
-    - .. raw:: html
-
-        <div class="ansible-option-cell">
-
-      Use \ :literal:`group/ns2.col.foo\_group`\  or \ :literal:`group/ns2.col.bar\_group`\  in \ :literal:`module\_defaults`\  to set defaults for this module.
-
-
-      .. raw:: html
-
-        </div>
-
-
-  * - .. raw:: html
-
-        <div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="attribute-check_mode"></div>
 
-      .. _ansible_collections.ns2.col.foo2_module__attribute-check_mode:
+      .. _ansible_collections.ns.col2.foo3_module__attribute-check_mode:
 
       .. rst-class:: ansible-option-title
 
@@ -233,7 +307,7 @@ Attributes
         <div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="attribute-diff_mode"></div>
 
-      .. _ansible_collections.ns2.col.foo2_module__attribute-diff_mode:
+      .. _ansible_collections.ns.col2.foo3_module__attribute-diff_mode:
 
       .. rst-class:: ansible-option-title
 
@@ -251,7 +325,7 @@ Attributes
 
         <div class="ansible-option-cell">
 
-      :ansible-attribute-support-label:`Support: \ `      \ :ansible-attribute-support-na:`N/A`
+      :ansible-attribute-support-label:`Support: \ `\ :ansible-attribute-support-full:`full`
 
 
       .. raw:: html
@@ -275,7 +349,7 @@ Attributes
         <div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="attribute-platform"></div>
 
-      .. _ansible_collections.ns2.col.foo2_module__attribute-platform:
+      .. _ansible_collections.ns.col2.foo3_module__attribute-platform:
 
       .. rst-class:: ansible-option-title
 
@@ -327,15 +401,7 @@ Examples
 .. code-block:: yaml+jinja
 
     
-    - name: Do some foo
-      ns2.col.foo:
-        foo: '{{ foo }}'
-        bar:
-          - 1
-          - 2
-          - 3
-        subfoo:
-          foo: hoo!
+    This is not YAML.
 
 
 
@@ -344,69 +410,6 @@ Examples
 
 
 .. Return values
-
-Return Values
--------------
-Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
-
-.. rst-class:: ansible-option-table
-
-.. list-table::
-  :width: 100%
-  :widths: auto
-  :header-rows: 1
-
-  * - Key
-    - Description
-
-  * - .. raw:: html
-
-        <div class="ansible-option-cell">
-        <div class="ansibleOptionAnchor" id="return-bar"></div>
-
-      .. _ansible_collections.ns2.col.foo2_module__return-bar:
-
-      .. rst-class:: ansible-option-title
-
-      **bar**
-
-      .. raw:: html
-
-        <a class="ansibleOptionLink" href="#return-bar" title="Permalink to this return value"></a>
-
-      .. rst-class:: ansible-option-type-line
-
-      :ansible-option-type:`string`
-
-      .. raw:: html
-
-        </div>
-
-    - .. raw:: html
-
-        <div class="ansible-option-cell">
-
-      Some bar.
-
-      Referencing myself as \ :ansretval:`ns2.col.foo2#module:bar`\ .
-
-      Do not confuse with \ :ansopt:`ns2.col.foo2#module:bar`\ .
-
-
-      .. rst-class:: ansible-option-line
-
-      :ansible-option-returned-bold:`Returned:` success
-
-      .. rst-class:: ansible-option-line
-      .. rst-class:: ansible-option-sample
-
-      :ansible-option-sample-bold:`Sample:` :ansible-rv-sample-value:`"baz"`
-
-
-      .. raw:: html
-
-        </div>
-
 
 
 ..  Status (Presently only deprecated)
@@ -417,24 +420,24 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
 Authors
 ~~~~~~~
 
-- Another one (@ansible-community)
+- Someone else (@ansible)
 
 
 
 .. Extra links
 
-Collection links
-~~~~~~~~~~~~~~~~
-
-.. raw:: html
-
-  <p class="ansible-links">
-    <a href="https://github.com/ansible-collections/community.general/issues" aria-role="button" target="_blank" rel="noopener external">Issue Tracker</a>
-    <a href="https://github.com/ansible-collections/community.crypto" aria-role="button" target="_blank" rel="noopener external">Homepage</a>
-    <a href="https://github.com/ansible-collections/community.internal_test_tools" aria-role="button" target="_blank" rel="noopener external">Repository (Sources)</a>
-    <a href="https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&amp;labels=&amp;template=bug_report.md" aria-role="button" target="_blank" rel="noopener external">Submit a bug report</a>
-    <a href="./#communication-for-ns2-col" aria-role="button" target="_blank">Communication</a>
-  </p>
 
 .. Parsing errors
+
+There were some errors parsing the documentation for this plugin.  Please file a bug with the `ns.col2 collection <https://galaxy.ansible.com/ns/col2>`_.
+
+The errors were:
+
+* ::
+
+        Unable to normalize foo3: return due to: 2 validation errors for PluginReturnSchema
+        return -> bar -> type
+          string does not match regex "^(any|bits|bool|bytes|complex|dict|float|int|json|jsonarg|list|path|sid|str|pathspec|pathlist)$" (type=value_error.str.regex; pattern=^(any|bits|bool|bytes|complex|dict|float|int|json|jsonarg|list|path|sid|str|pathspec|pathlist)$)
+        return -> baz
+          value is not a valid dict (type=type_error.dict)
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/index.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/index.rst
@@ -42,6 +42,8 @@ Modules
 ~~~~~~~
 
 * :ref:`foo module <ansible_collections.ns.col2.foo_module>` -- 
+* :ref:`foo2 module <ansible_collections.ns.col2.foo2_module>` -- Foo two
+* :ref:`foo3 module <ansible_collections.ns.col2.foo3_module>` -- Foo III
 
 
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo2_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo2_module.rst
@@ -79,6 +79,53 @@ Synopsis
 
 .. Options
 
+Parameters
+----------
+
+.. rst-class:: ansible-option-table
+
+.. list-table::
+  :width: 100%
+  :widths: auto
+  :header-rows: 1
+
+  * - Parameter
+    - Comments
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo2_module__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Some bar.
+
+
+      .. raw:: html
+
+        </div>
+
 
 .. Attributes
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo2_module.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo2_module.rst
@@ -79,6 +79,53 @@ Synopsis
 
 .. Options
 
+Parameters
+----------
+
+.. rst-class:: ansible-option-table
+
+.. list-table::
+  :width: 100%
+  :widths: auto
+  :header-rows: 1
+
+  * - Parameter
+    - Comments
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+
+      .. _ansible_collections.ns2.col.foo2_module__parameter-bar:
+
+      .. rst-class:: ansible-option-title
+
+      **bar**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Some bar.
+
+
+      .. raw:: html
+
+        </div>
+
 
 .. Attributes
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo2_module.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo2_module.rst
@@ -79,6 +79,36 @@ Synopsis
 
 .. Options
 
+Parameters
+----------
+
+.. raw:: html
+
+  <table class="colwidths-auto ansible-option-table docutils align-default" style="width: 100%">
+  <thead>
+  <tr class="row-odd">
+    <th class="head"><p>Parameter</p></th>
+    <th class="head"><p>Comments</p></th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr class="row-even">
+    <td><div class="ansible-option-cell">
+      <div class="ansibleOptionAnchor" id="parameter-bar"></div>
+      <p class="ansible-option-title"><strong>bar</strong></p>
+      <a class="ansibleOptionLink" href="#parameter-bar" title="Permalink to this option"></a>
+      <p class="ansible-option-type-line">
+        <span class="ansible-option-type">string</span>
+      </p>
+    </div></td>
+    <td><div class="ansible-option-cell">
+      <p>Some bar.</p>
+    </div></td>
+  </tr>
+  </tbody>
+  </table>
+
+
 
 .. Attributes
 

--- a/tests/functional/build-docs-baseline.sh
+++ b/tests/functional/build-docs-baseline.sh
@@ -15,7 +15,7 @@ make_baseline() {
     mkdir -p "${DEST}"
     ANSIBLE_COLLECTIONS_PATHS= ANSIBLE_COLLECTIONS_PATH=collections/ antsibull-docs collection --dest-dir "${DEST}" --use-current "$@" 2>&1 | (
         set +e
-        grep -v "An error page will be generated."
+        grep -v "ERROR:antsibull:func=create_plugin_rst:mod=antsibull_docs.write_docs.plugins:nonfatal_errors="
         set -e
     )
 

--- a/tests/functional/collections/ansible_collections/ns/col2/plugins/modules/foo2.py
+++ b/tests/functional/collections/ansible_collections/ns/col2/plugins/modules/foo2.py
@@ -10,10 +10,10 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
 ---
-module: foo
+module: foo2
 author:
     - "Someone else (@ansible)"
-version_added: foo
+short_description: Foo two
 description:
     - Does some foo on the remote host.
     - A broken reference R(asdfasdfoobarTHISDOESNOTEXIST,asdfasdfoobarTHISDOESNOTEXIST).
@@ -23,19 +23,15 @@ description:
     - "Again not existing: O(ns.col2.foo#module:foobar=1), RV(ns.col2.foo#module:barbaz=2)"
 options:
     foo:
-        The foo source.
+        description: The foo source.
+        type: str
     bar:
         description:
-          - A bar:
-            - foo
-            - bar
-            - baz
-          - true
-          - 42
-        type: list of ints
+          - Bar.
+        type: list
+        elements: int
     subfoo:
         description: Some recursive foo.
-        bam: baz
         type: dict
         suboptions:
             foo:
@@ -65,17 +61,15 @@ attributes:
 '''
 
 EXAMPLES = '''
-This is not YAML.
+name: This is YAML.
 '''
 
 RETURN = '''
 bar:
     description: Some bar.
     returned: success
-    type: string or so
+    type: string
     sample: baz
-baz:
-    baz!
 '''
 
 from ansible.module_utils.basic import AnsibleModule

--- a/tests/functional/collections/ansible_collections/ns/col2/plugins/modules/foo3.py
+++ b/tests/functional/collections/ansible_collections/ns/col2/plugins/modules/foo3.py
@@ -10,32 +10,23 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
 ---
-module: foo
+module: foo3
 author:
     - "Someone else (@ansible)"
-version_added: foo
+short_description: Foo III
 description:
     - Does some foo on the remote host.
-    - A broken reference R(asdfasdfoobarTHISDOESNOTEXIST,asdfasdfoobarTHISDOESNOTEXIST).
-    - The option O(foo) exists, but O(foobar) does not.
-    - The return value RV(bar) exists, but RV(barbaz) does not.
-    - "Again existing: O(ns.col2.foo#module:foo=1), RV(ns.col2.foo#module:bar=2)"
-    - "Again not existing: O(ns.col2.foo#module:foobar=1), RV(ns.col2.foo#module:barbaz=2)"
 options:
     foo:
-        The foo source.
+        description: The foo source.
+        type: str
     bar:
         description:
-          - A bar:
-            - foo
-            - bar
-            - baz
-          - true
-          - 42
-        type: list of ints
+          - Bar.
+        type: list
+        elements: int
     subfoo:
         description: Some recursive foo.
-        bam: baz
         type: dict
         suboptions:
             foo:
@@ -57,9 +48,6 @@ attributes:
         support: full
     platform:
         description: Target OS/families that can be operated against
-        details:
-          - The module M(boo) is not using an FQCN.
-          - Sometimes our markup is B(broken.
         support: N/A
         platforms: posix
 '''

--- a/tests/functional/collections/ansible_collections/ns2/col/plugins/modules/foo2.py
+++ b/tests/functional/collections/ansible_collections/ns2/col/plugins/modules/foo2.py
@@ -16,7 +16,10 @@ author:
 short_description: Another foo
 description:
     - Foo bar.
-options: {}
+options:
+    bar:
+        description: Some bar.
+        type: str
 
 attributes:
     check_mode:

--- a/tests/functional/test_docs_linting.py
+++ b/tests/functional/test_docs_linting.py
@@ -181,6 +181,15 @@ TEST_CASES = [
             '                            doc -> options -> subfoo -> bam',
             '                              extra fields not permitted (type=value_error.extra)',
             'plugins/modules/foo.py:0:0: Did not return correct DOCUMENTATION',
+            'plugins/modules/foo2.py:0:0: DOCUMENTATION -> attributes -> platform -> details: Markup error: While parsing B() at index 25 of paragraph 2: Cannot find closing ")" after last parameter',
+            'plugins/modules/foo2.py:0:0: DOCUMENTATION -> attributes -> platform -> details: Markup error: While parsing M() at index 12 of paragraph 1: Module name "boo" is not a FQCN',
+            'plugins/modules/foo2.py:0:0: DOCUMENTATION -> description: option name reference "foobar" does not reference to an existing option of the module ns.col2.foo2',
+            'plugins/modules/foo2.py:0:0: DOCUMENTATION -> description: return value name reference "barbaz" does not reference to an existing return value of the module ns.col2.foo2',
+            'plugins/modules/foo3.py:0:0: Unable to normalize foo3: return due to: 2 validation errors for PluginReturnSchema',
+            '                             return -> bar -> type',
+            '                               string does not match regex "^(any|bits|bool|bytes|complex|dict|float|int|json|jsonarg|list|path|sid|str|pathspec|pathlist)$" (type=value_error.str.regex; pattern=^(any|bits|bool|bytes|complex|dict|float|int|json|jsonarg|list|path|sid|str|pathspec|pathlist)$)',
+            '                             return -> baz',
+            '                               value is not a valid dict (type=type_error.dict)',
         ],
     ),
     (
@@ -210,6 +219,6 @@ def test_lint_collection_plugin_docs(namespace, name, rc, errors):
         with redirect_stdout(stdout):
             actual_rc = run(['antsibull-docs', 'lint-collection-docs', '.', '--plugin-docs'])
     actual_errors = stdout.getvalue().splitlines()
-    print('\n'.join(stdout))
+    print('\n'.join(actual_errors))
     assert actual_rc == rc
     assert actual_errors == errors


### PR DESCRIPTION
Provides markup validation similar to https://github.com/ansible/ansible/pull/80243. Also allows to ensure that no semantic markup is used.