### PR TITLE
Use doc_parsing_backend from app_ctx and not lib_ctx

### DIFF
--- a/changelogs/fragments/125-parsing-backend-use-app_ctx.yml
+++ b/changelogs/fragments/125-parsing-backend-use-app_ctx.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Use ``doc_parsing_backend`` from the application context instead of the library context. This prevents removal of ``doc_parsing_backend`` from the antsibull-core library context (https://github.com/ansible-community/antsibull-docs/pull/125)."

--- a/src/antsibull_docs/docs_parsing/parsing.py
+++ b/src/antsibull_docs/docs_parsing/parsing.py
@@ -51,9 +51,9 @@ async def get_ansible_plugin_info(venv: t.Union['VenvRunner', 'FakeVenvRunner'],
     """
     flog = mlog.fields(func='get_ansible_plugin_info')
 
-    lib_ctx = app_context.lib_ctx.get()
+    app_ctx = app_context.app_ctx.get()
 
-    doc_parsing_backend = lib_ctx.doc_parsing_backend
+    doc_parsing_backend = app_ctx.doc_parsing_backend
     if doc_parsing_backend == 'auto':
         version = get_ansible_core_version(venv)
         flog.debug(f'Ansible-core version: {version}')

--- a/src/antsibull_docs/docs_parsing/parsing.py
+++ b/src/antsibull_docs/docs_parsing/parsing.py
@@ -7,10 +7,10 @@
 
 import typing as t
 
-from antsibull_core import app_context
 from antsibull_core.logging import log
 from packaging.version import Version as PypiVer
 
+from .. import app_context
 from . import AnsibleCollectionMetadata
 from .ansible_doc import get_ansible_core_version
 from .ansible_doc_core_213 import \


### PR DESCRIPTION
This is needed to make https://github.com/ansible-community/antsibull-core/pull/54 work fully. (Ref: https://github.com/ansible-community/antsibull-core/pull/59.)