### PR TITLE
Use modern typing syntax and run isort

### DIFF
--- a/src/antsibull_docs/app_context.py
+++ b/src/antsibull_docs/app_context.py
@@ -5,6 +5,8 @@
 # SPDX-FileCopyrightText: 2022, Ansible Project
 """Local app and lib context provider"""
 
+from __future__ import annotations
+
 # pylint: disable-next=unused-import
 from antsibull_core.app_context import lib_ctx  # noqa
 from antsibull_core.app_context import AppContextWrapper

--- a/src/antsibull_docs/augment_docs.py
+++ b/src/antsibull_docs/augment_docs.py
@@ -5,12 +5,15 @@
 # SPDX-FileCopyrightText: 2020, Ansible Project
 """Augment data from plugin documenation with additional values."""
 
+from __future__ import annotations
+
 import typing as t
+from collections.abc import Mapping, MutableMapping
 
 
-def add_full_key(options_data: t.Mapping[str, t.Any], suboption_entry: str,
-                 _full_key: t.Optional[t.List[str]] = None,
-                 _full_keys: t.Optional[t.List[t.List[str]]] = None) -> None:
+def add_full_key(options_data: Mapping[str, t.Any], suboption_entry: str,
+                 _full_key: list[str] | None = None,
+                 _full_keys: list[list[str]] | None = None) -> None:
     """
     Add information on the strucfture of a dict value in options or returns.
 
@@ -60,8 +63,8 @@ def add_full_key(options_data: t.Mapping[str, t.Any], suboption_entry: str,
                 _full_keys=full_keys_k)
 
 
-def _add_seealso(seealso: t.List[t.MutableMapping[str, t.Any]],
-                 plugin_info: t.Mapping[str, t.Mapping[str, t.Any]],
+def _add_seealso(seealso: list[MutableMapping[str, t.Any]],
+                 plugin_info: Mapping[str, Mapping[str, t.Any]],
                  ) -> None:
     for entry in seealso:
         if entry.get('description'):
@@ -85,7 +88,7 @@ def _add_seealso(seealso: t.List[t.MutableMapping[str, t.Any]],
             entry['description'] = desc
 
 
-def augment_docs(plugin_info: t.MutableMapping[str, t.MutableMapping[str, t.Any]]) -> None:
+def augment_docs(plugin_info: MutableMapping[str, MutableMapping[str, t.Any]]) -> None:
     """
     Add additional data to the data extracted from the plugins.
 

--- a/src/antsibull_docs/cli/__init__.py
+++ b/src/antsibull_docs/cli/__init__.py
@@ -4,3 +4,5 @@
 # SPDX-FileCopyrightText: 2020, Ansible Project
 
 """Entrypoints to scripts"""
+
+from __future__ import annotations

--- a/src/antsibull_docs/cli/antsibull_docs.py
+++ b/src/antsibull_docs/cli/antsibull_docs.py
@@ -5,16 +5,18 @@
 # SPDX-FileCopyrightText: 2020, Ansible Project
 """Entrypoint to the antsibull-docs script."""
 
+from __future__ import annotations
+
 import argparse
 import os
 import os.path
 import stat
 import sys
-from typing import Callable, Dict, List
+from collections.abc import Callable
 
 import twiggy  # type: ignore[import]
-
 from antsibull_core.logging import initialize_app_logging, log
+
 initialize_app_logging()
 
 # We have to call initialize_app_logging() before these imports so that the log object is configured
@@ -50,7 +52,7 @@ mlog = log.fields(mod=__name__)
 
 #: Mapping from command line subcommand names to functions which implement those
 #: The functions need to take a single argument, the processed list of args.
-ARGS_MAP: Dict[str, Callable] = {'devel': devel.generate_docs,
+ARGS_MAP: dict[str, Callable] = {'devel': devel.generate_docs,
                                  'stable': stable.generate_docs,
                                  'current': current.generate_docs,
                                  'collection': collection.generate_docs,
@@ -184,7 +186,7 @@ def _normalize_sphinx_init_options(args: argparse.Namespace) -> None:
                     f'Every `{option}` value must have at least one equal sign (=).')
 
 
-def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
+def parse_args(program_name: str, args: list[str]) -> argparse.Namespace:
     """
     Parse and coerce the command line arguments.
 
@@ -492,7 +494,7 @@ def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
     return parsed_args
 
 
-def run(args: List[str]) -> int:
+def run(args: list[str]) -> int:
     """
     Run the program.
 

--- a/src/antsibull_docs/cli/doc_commands/_build.py
+++ b/src/antsibull_docs/cli/doc_commands/_build.py
@@ -5,9 +5,10 @@
 # SPDX-FileCopyrightText: 2020, Ansible Project
 """Utilities for various docs build subcommands."""
 
+from __future__ import annotations
+
 import asyncio
 import textwrap
-import typing as t
 
 from antsibull_core.logging import log
 from antsibull_core.venv import FakeVenvRunner, VenvRunner
@@ -21,11 +22,24 @@ from ...docs_parsing.routing import (
     load_all_collection_routing,
     remove_redirect_duplicates,
 )
-from ...env_variables import collect_referenced_environment_variables, load_ansible_config
+from ...env_variables import (
+    collect_referenced_environment_variables,
+    load_ansible_config,
+)
 from ...extra_docs import load_collections_extra_docs
+from ...process_docs import (
+    get_callback_plugin_contents,
+    get_collection_contents,
+    get_collection_namespaces,
+    get_plugin_contents,
+    normalize_all_plugin_info,
+)
 from ...utils.collection_name_transformer import CollectionNameTransformer
 from ...write_docs.collections import output_extra_docs, output_indexes
-from ...write_docs.hierarchy import output_collection_index, output_collection_namespace_indexes
+from ...write_docs.hierarchy import (
+    output_collection_index,
+    output_collection_namespace_indexes,
+)
 from ...write_docs.indexes import (
     output_callback_indexes,
     output_environment_variables,
@@ -34,22 +48,13 @@ from ...write_docs.indexes import (
 from ...write_docs.plugin_stubs import output_all_plugin_stub_rst
 from ...write_docs.plugins import output_all_plugin_rst
 
-from ...process_docs import (
-    get_collection_namespaces,
-    normalize_all_plugin_info,
-    get_plugin_contents,
-    get_callback_plugin_contents,
-    get_collection_contents,
-)
-
-
 mlog = log.fields(mod=__name__)
 
 
-def generate_docs_for_all_collections(venv: t.Union[VenvRunner, FakeVenvRunner],
-                                      collection_dir: t.Optional[str],
+def generate_docs_for_all_collections(venv: VenvRunner | FakeVenvRunner,
+                                      collection_dir: str | None,
                                       dest_dir: str,
-                                      collection_names: t.Optional[t.List[str]] = None,
+                                      collection_names: list[str] | None = None,
                                       create_indexes: bool = True,
                                       squash_hierarchy: bool = False,
                                       breadcrumbs: bool = True,

--- a/src/antsibull_docs/cli/doc_commands/collection.py
+++ b/src/antsibull_docs/cli/doc_commands/collection.py
@@ -6,6 +6,8 @@
 # SPDX-FileCopyrightText: 2020, Ansible Project
 """Build documentation for one or more collections."""
 
+from __future__ import annotations
+
 import asyncio
 import os
 import os.path
@@ -29,7 +31,7 @@ if t.TYPE_CHECKING:
 mlog = log.fields(mod=__name__)
 
 
-def generate_collection_docs(collection_dir: t.Optional[str], squash_hierarchy: bool) -> int:
+def generate_collection_docs(collection_dir: str | None, squash_hierarchy: bool) -> int:
     flog = mlog.fields(func='generate_current_docs')
     flog.debug('Begin generating docs')
 
@@ -46,11 +48,11 @@ def generate_collection_docs(collection_dir: t.Optional[str], squash_hierarchy: 
         fail_on_error=app_ctx.extra['fail_on_error'])
 
 
-async def retrieve(collections: t.List[str],
-                   collection_version: t.Optional[str],
+async def retrieve(collections: list[str],
+                   collection_version: str | None,
                    tmp_dir: str,
                    galaxy_server: str,
-                   collection_cache: t.Optional[str] = None) -> t.Dict[str, 'semver.Version']:
+                   collection_cache: str | None = None) -> dict[str, semver.Version]:
     """
     Download collections, with specified version if applicable.
 

--- a/src/antsibull_docs/cli/doc_commands/current.py
+++ b/src/antsibull_docs/cli/doc_commands/current.py
@@ -5,6 +5,8 @@
 # SPDX-FileCopyrightText: 2020, Ansible Project
 """Entrypoint to the antsibull-docs script."""
 
+from __future__ import annotations
+
 from antsibull_core.logging import log
 from antsibull_core.venv import FakeVenvRunner
 

--- a/src/antsibull_docs/cli/doc_commands/devel.py
+++ b/src/antsibull_docs/cli/doc_commands/devel.py
@@ -5,6 +5,8 @@
 # SPDX-FileCopyrightText: 2022, Ansible Project
 """Build devel ansible(-core) docs."""
 
+from __future__ import annotations
+
 import asyncio
 import os
 import os.path
@@ -30,13 +32,13 @@ if t.TYPE_CHECKING:
 mlog = log.fields(mod=__name__)
 
 
-async def retrieve(collections: t.List[str],
+async def retrieve(collections: list[str],
                    tmp_dir: str,
                    galaxy_server: str,
-                   ansible_core_source: t.Optional[str] = None,
-                   collection_cache: t.Optional[str] = None,
+                   ansible_core_source: str | None = None,
+                   collection_cache: str | None = None,
                    use_installed_ansible_core: bool = False,
-                   ) -> t.Dict[str, 'semver.Version']:
+                   ) -> dict[str, semver.Version]:
     """
     Download ansible-core and the latest versions of the collections.
 
@@ -143,7 +145,7 @@ def generate_docs() -> int:
         flog.notice('Finished installing collections')
 
         # Create venv for ansible-core
-        venv: t.Union[FakeVenvRunner, VenvRunner]
+        venv: FakeVenvRunner | VenvRunner
         if ansible_core_path is None:
             venv = FakeVenvRunner()
         else:

--- a/src/antsibull_docs/cli/doc_commands/lint_collection_docs.py
+++ b/src/antsibull_docs/cli/doc_commands/lint_collection_docs.py
@@ -5,6 +5,8 @@
 # SPDX-FileCopyrightText: 2020, Ansible Project
 """Entrypoint to the antsibull-docs script."""
 
+from __future__ import annotations
+
 import os
 import textwrap
 

--- a/src/antsibull_docs/cli/doc_commands/plugin.py
+++ b/src/antsibull_docs/cli/doc_commands/plugin.py
@@ -6,12 +6,15 @@
 # SPDX-FileCopyrightText: 2020, Ansible Project
 """Render documentation for a single plugin."""
 
+from __future__ import annotations
+
 import asyncio
 import json
 import os
 import sys
 import traceback
 import typing as t
+from collections.abc import MutableMapping
 
 from antsibull_core.logging import log
 from antsibull_core.subprocess_util import CalledProcessError
@@ -27,7 +30,6 @@ from ...jinja2.environment import doc_environment
 from ...process_docs import normalize_plugin_info
 from ...utils.collection_name_transformer import CollectionNameTransformer
 from ...write_docs.plugins import write_plugin_rst
-
 
 mlog = log.fields(mod=__name__)
 
@@ -86,10 +88,10 @@ def generate_plugin_docs(plugin_type: str, plugin_name: str,
 
     # The cast is needed to make pyre happy. It seems to not being able to
     # understand that
-    #     t.Dict[str, t.Dict[str, t.Dict[str, typing.Any]]]
+    #     dict[str, dict[str, dict[str, typing.Any]]]
     # is acceptable for
-    #     t.MutableMapping[str, t.MutableMapping[str, typing.Any]].
-    augment_docs(t.cast(t.MutableMapping[str, t.MutableMapping[str, t.Any]], {
+    #     MutableMapping[str, MutableMapping[str, typing.Any]].
+    augment_docs(t.cast(MutableMapping[str, MutableMapping[str, t.Any]], {
         plugin_type: {
             plugin_name: plugin_info
         }

--- a/src/antsibull_docs/cli/doc_commands/sphinx_init.py
+++ b/src/antsibull_docs/cli/doc_commands/sphinx_init.py
@@ -5,6 +5,8 @@
 # SPDX-FileCopyrightText: 2021, Ansible Project
 """Entrypoint to the antsibull-docs script."""
 
+from __future__ import annotations
+
 import os
 import os.path
 import typing as t
@@ -34,7 +36,7 @@ def write_file(filename: str, content: str) -> None:
     Write content into a file.
     """
     if os.path.exists(filename):
-        with open(filename, 'r', encoding='utf-8') as f:
+        with open(filename, encoding='utf-8') as f:
             existing_content = f.read()
         if existing_content == content:
             print(f'Skipping {filename}')
@@ -77,8 +79,8 @@ def python_repr(value: t.Any) -> str:
     return repr(value)
 
 
-def split_kv(entries: t.Optional[t.List[str]]) -> t.List[t.Tuple[str, str]]:
-    result: t.List[t.Tuple[str, str]] = []
+def split_kv(entries: list[str] | None) -> list[tuple[str, str]]:
+    result: list[tuple[str, str]] = []
     for entry in entries or []:
         key, value = entry.split('=', 1)
         result.append((key, value))
@@ -116,11 +118,11 @@ def site_init() -> int:
     for intersphinx in app_ctx.extra['intersphinx'] or []:
         inventory, url = intersphinx.split(':', 1)
         intersphinx_parts.append((inventory.rstrip(' '), url.lstrip(' ')))
-    index_rst_source: t.Optional[str] = app_ctx.extra['index_rst_source']
+    index_rst_source: str | None = app_ctx.extra['index_rst_source']
     project: str = app_ctx.extra['project']
     conf_copyright: str = app_ctx.extra['copyright']
     title: str = app_ctx.extra['title']
-    html_short_title: t.Optional[str] = app_ctx.extra['html_short_title']
+    html_short_title: str | None = app_ctx.extra['html_short_title']
     if html_short_title is None:
         html_short_title = title
     extra_conf = split_kv(app_ctx.extra['extra_conf'])

--- a/src/antsibull_docs/cli/doc_commands/stable.py
+++ b/src/antsibull_docs/cli/doc_commands/stable.py
@@ -5,11 +5,14 @@
 # SPDX-FileCopyrightText: 2020, Ansible Project
 """Build stable ansible(-core) docs."""
 
+from __future__ import annotations
+
 import asyncio
 import os
 import os.path
 import tempfile
 import typing as t
+from collections.abc import Mapping
 
 import aiohttp
 import asyncio_pool  # type: ignore[import]
@@ -21,7 +24,6 @@ from antsibull_core.logging import log
 from antsibull_core.venv import FakeVenvRunner, VenvRunner
 
 from ... import app_context
-
 from ._build import generate_docs_for_all_collections
 
 if t.TYPE_CHECKING:
@@ -32,13 +34,13 @@ mlog = log.fields(mod=__name__)
 
 
 async def retrieve(ansible_core_version: str,
-                   collections: t.Mapping[str, str],
+                   collections: Mapping[str, str],
                    tmp_dir: str,
                    galaxy_server: str,
-                   ansible_core_source: t.Optional[str] = None,
-                   collection_cache: t.Optional[str] = None,
+                   ansible_core_source: str | None = None,
+                   collection_cache: str | None = None,
                    use_installed_ansible_core: bool = False,
-                   ) -> t.Dict[str, 'semver.Version']:
+                   ) -> dict[str, semver.Version]:
     """
     Download ansible-core and the collections.
 
@@ -145,7 +147,7 @@ def generate_docs() -> int:
         flog.notice('Finished installing collections')
 
         # Create venv for ansible-core
-        venv: t.Union[FakeVenvRunner, VenvRunner]
+        venv: FakeVenvRunner | VenvRunner
         if ansible_core_path is None:
             venv = FakeVenvRunner()
         else:

--- a/src/antsibull_docs/collection_links.py
+++ b/src/antsibull_docs/collection_links.py
@@ -10,6 +10,7 @@ import json
 import os
 import os.path
 import typing as t
+from collections.abc import Mapping
 
 import asyncio_pool  # type: ignore[import]
 from antsibull_core import app_context
@@ -61,7 +62,7 @@ _ANSIBLE_CORE_METADATA = {
 }
 
 
-def _extract_authors(data: t.Dict) -> t.List[str]:
+def _extract_authors(data: dict) -> list[str]:
     authors = data.get('authors')
     if not isinstance(authors, list):
         return []
@@ -69,16 +70,16 @@ def _extract_authors(data: t.Dict) -> t.List[str]:
     return [str(author) for author in authors]
 
 
-def _extract_description(data: t.Dict) -> t.Optional[str]:
+def _extract_description(data: dict) -> t.Optional[str]:
     desc = data.get('description')
     return desc if isinstance(desc, str) else None
 
 
-def _extract_galaxy_links(data: t.Dict) -> t.List[Link]:
+def _extract_galaxy_links(data: dict) -> list[Link]:
     result = []
 
     def extract(key: str, desc: str,
-                not_if_equals_one_of: t.Optional[t.List[str]] = None) -> None:
+                not_if_equals_one_of: t.Optional[list[str]] = None) -> None:
         url = data.get(key)
         if not_if_equals_one_of:
             for other_key in not_if_equals_one_of:
@@ -94,13 +95,13 @@ def _extract_galaxy_links(data: t.Dict) -> t.List[Link]:
     return result
 
 
-def _extract_issue_tracker(data: t.Dict) -> t.Optional[str]:
+def _extract_issue_tracker(data: dict) -> t.Optional[str]:
     url = data.get('issues')
     return url if url and isinstance(url, str) else None
 
 
-def load(links_data: t.Optional[t.Dict], galaxy_data: t.Optional[t.Dict],
-         manifest_data: t.Optional[t.Dict]) -> CollectionLinks:
+def load(links_data: t.Optional[dict], galaxy_data: t.Optional[dict],
+         manifest_data: t.Optional[dict]) -> CollectionLinks:
     if links_data:
         ld = links_data.copy()
         # The authors and description field always comes from collection metadata
@@ -177,8 +178,8 @@ async def load_collection_links(collection_name: str,
         flog.debug('Leave')
 
 
-async def load_collections_links(collection_paths: t.Mapping[str, str]
-                                 ) -> t.Mapping[str, CollectionLinks]:
+async def load_collections_links(collection_paths: Mapping[str, str]
+                                 ) -> Mapping[str, CollectionLinks]:
     '''Load links data.
 
     :arg collection_paths: Mapping of collection_name to the collection's path.
@@ -205,7 +206,7 @@ async def load_collections_links(collection_paths: t.Mapping[str, str]
     return result
 
 
-def lint_collection_links(collection_path: str) -> t.List[t.Tuple[str, int, int, str]]:
+def lint_collection_links(collection_path: str) -> list[tuple[str, int, int, str]]:
     '''Given a path, lint links data.
 
     :arg collection_path: Path to the collection.
@@ -214,7 +215,7 @@ def lint_collection_links(collection_path: str) -> t.List[t.Tuple[str, int, int,
     flog = mlog.fields(func='lint_collection_links')
     flog.debug('Enter')
 
-    result: t.List[t.Tuple[str, int, int, str]] = []
+    result: list[tuple[str, int, int, str]] = []
 
     for cls in (
             CollectionEditOnGitHub, Link, IRCChannel, MatrixRoom, MailingList, Communication,

--- a/src/antsibull_docs/constants.py
+++ b/src/antsibull_docs/constants.py
@@ -5,21 +5,22 @@
 # SPDX-FileCopyrightText: 2020, Ansible Project
 """Constant values for use throughout the antsibull codebase."""
 
-from typing import Dict, FrozenSet
+
+from __future__ import annotations
 
 #: All the types of ansible plugins
-PLUGIN_TYPES: FrozenSet[str] = frozenset(('become', 'cache', 'callback', 'cliconf', 'connection',
+PLUGIN_TYPES: frozenset[str] = frozenset(('become', 'cache', 'callback', 'cliconf', 'connection',
                                           'httpapi', 'inventory', 'lookup', 'shell', 'strategy',
                                           'vars', 'module', 'module_utils', 'role',))
 
 #: The subset of PLUGINS which we build documentation for
-DOCUMENTABLE_PLUGINS: FrozenSet[str] = frozenset(('become', 'cache', 'callback', 'cliconf',
+DOCUMENTABLE_PLUGINS: frozenset[str] = frozenset(('become', 'cache', 'callback', 'cliconf',
                                                   'connection', 'httpapi', 'inventory', 'lookup',
                                                   'netconf', 'shell', 'vars', 'module',
                                                   'strategy', 'role', 'filter', 'test'))
 
 
-DOCUMENTABLE_PLUGINS_MIN_VERSION: Dict[str, str] = {
+DOCUMENTABLE_PLUGINS_MIN_VERSION: dict[str, str] = {
     'filter': '2.14.0',
     'role': '2.11.0',
     'test': '2.14.0',

--- a/src/antsibull_docs/docs_parsing/__init__.py
+++ b/src/antsibull_docs/docs_parsing/__init__.py
@@ -5,13 +5,14 @@
 # SPDX-FileCopyrightText: 2020, Ansible Project
 """Parse documentation from ansible plugins using anible-doc."""
 
+from __future__ import annotations
+
 import os
-import typing as t
 
 from antsibull_core.venv import FakeVenvRunner, VenvRunner
 
 #: Clear Ansible environment variables that set paths where plugins could be found.
-ANSIBLE_PATH_ENVIRON: t.Dict[str, str] = os.environ.copy()
+ANSIBLE_PATH_ENVIRON: dict[str, str] = os.environ.copy()
 ANSIBLE_PATH_ENVIRON.update({'ANSIBLE_COLLECTIONS_PATH': '/dev/null',
                              'ANSIBLE_ACTION_PLUGINS': '/dev/null',
                              'ANSIBLE_CACHE_PLUGINS': '/dev/null',
@@ -44,9 +45,9 @@ class ParsingError(Exception):
     """Error raised while parsing plugins for documentation."""
 
 
-def _get_environment(collection_dir: t.Optional[str],
-                     venv: t.Union[VenvRunner, FakeVenvRunner],
-                     ) -> t.Dict[str, str]:
+def _get_environment(collection_dir: str | None,
+                     venv: VenvRunner | FakeVenvRunner,
+                     ) -> dict[str, str]:
     env = ANSIBLE_PATH_ENVIRON.copy()
     if isinstance(venv, VenvRunner):
         try:
@@ -72,13 +73,13 @@ def _get_environment(collection_dir: t.Optional[str],
 
 class AnsibleCollectionMetadata:
     path: str
-    version: t.Optional[str]
-    requires_ansible: t.Optional[str]
+    version: str | None
+    requires_ansible: str | None
 
     def __init__(self,
                  path: str,
-                 version: t.Optional[str] = None,
-                 requires_ansible: t.Optional[str] = None):
+                 version: str | None = None,
+                 requires_ansible: str | None = None):
         self.path = path
         self.version = version
         self.requires_ansible = requires_ansible

--- a/src/antsibull_docs/docs_parsing/fqcn.py
+++ b/src/antsibull_docs/docs_parsing/fqcn.py
@@ -16,8 +16,9 @@ Some definitions:
     what users would have to specify.
 """
 
+from __future__ import annotations
+
 import re
-import typing as t
 
 #: Format that a collection namespace and collection name must follow
 NAMESPACE_RE_STR = '[a-z0-9][a-z0-9_]+'
@@ -47,7 +48,7 @@ FQCN_STRICT_RE = re.compile(
 # 'a..c'               no       no              no
 
 
-def get_fqcn_parts(fqcn: str) -> t.Tuple[str, str, str]:
+def get_fqcn_parts(fqcn: str) -> tuple[str, str, str]:
     """
     Parse a fqcn into its three parts.
 

--- a/src/antsibull_docs/docs_parsing/parsing.py
+++ b/src/antsibull_docs/docs_parsing/parsing.py
@@ -5,7 +5,10 @@
 # SPDX-FileCopyrightText: 2020, Ansible Project
 """Parse documentation from ansible plugins using anible-doc."""
 
+from __future__ import annotations
+
 import typing as t
+from collections.abc import Mapping, MutableMapping
 
 from antsibull_core.logging import log
 from packaging.version import Version as PypiVer
@@ -13,8 +16,9 @@ from packaging.version import Version as PypiVer
 from .. import app_context
 from . import AnsibleCollectionMetadata
 from .ansible_doc import get_ansible_core_version
-from .ansible_doc_core_213 import \
-    get_ansible_plugin_info as ansible_doc_core_213_get_ansible_plugin_info
+from .ansible_doc_core_213 import (
+    get_ansible_plugin_info as ansible_doc_core_213_get_ansible_plugin_info,
+)
 
 if t.TYPE_CHECKING:
     from antsibull_core.venv import FakeVenvRunner, VenvRunner
@@ -23,12 +27,12 @@ if t.TYPE_CHECKING:
 mlog = log.fields(mod=__name__)
 
 
-async def get_ansible_plugin_info(venv: t.Union['VenvRunner', 'FakeVenvRunner'],
-                                  collection_dir: t.Optional[str],
-                                  collection_names: t.Optional[t.List[str]] = None
-                                  ) -> t.Tuple[
-                                    t.MutableMapping[str, t.MutableMapping[str, t.Any]],
-                                    t.Mapping[str, AnsibleCollectionMetadata]]:
+async def get_ansible_plugin_info(venv: VenvRunner | FakeVenvRunner,
+                                  collection_dir: str | None,
+                                  collection_names: list[str] | None = None
+                                  ) -> tuple[
+                                    MutableMapping[str, MutableMapping[str, t.Any]],
+                                    Mapping[str, AnsibleCollectionMetadata]]:
     """
     Retrieve information about all of the Ansible Plugins.
 

--- a/src/antsibull_docs/jinja2/environment.py
+++ b/src/antsibull_docs/jinja2/environment.py
@@ -4,9 +4,12 @@
 # SPDX-FileCopyrightText: 2019-2020, Ansible Project
 """Create Jinja2 environment for rendering Ansible documentation."""
 
+from __future__ import annotations
+
 import json
 import os.path
 import typing as t
+from collections.abc import Mapping
 
 from jinja2 import BaseLoader, Environment, FileSystemLoader, PackageLoader
 
@@ -16,15 +19,15 @@ from .filters import (
     do_max,
     documented_type,
     extract_options_from_list,
+    html_ify,
     massage_author_name,
     move_first,
     remove_options_from_list,
     rst_fmt,
+    rst_ify,
     rst_xline,
     to_ini_value,
     to_json,
-    html_ify,
-    rst_ify,
 )
 from .tests import still_relevant, test_list
 
@@ -50,12 +53,12 @@ def reference_plugin_rst(plugin_name: str, plugin_type: str) -> str:
     return f"\\ :ref:`{rst_escape(fqcn)} <ansible_collections.{fqcn}_{plugin_type}>`\\ "
 
 
-def doc_environment(template_location: t.Union[str, t.Tuple[str, str]],
+def doc_environment(template_location: str | tuple[str, str],
                     *,
-                    extra_filters: t.Optional[t.Mapping[str, t.Callable]] = None,
-                    extra_tests: t.Optional[t.Mapping[str, t.Callable]] = None,
-                    collection_url: t.Optional[CollectionNameTransformer] = None,
-                    collection_install: t.Optional[CollectionNameTransformer] = None,
+                    extra_filters: Mapping[str, t.Callable] | None = None,
+                    extra_tests: Mapping[str, t.Callable] | None = None,
+                    collection_url: CollectionNameTransformer | None = None,
+                    collection_install: CollectionNameTransformer | None = None,
                     ) -> Environment:
     loader: BaseLoader
     if isinstance(template_location, str) and os.path.exists(template_location):

--- a/src/antsibull_docs/jinja2/filters.py
+++ b/src/antsibull_docs/jinja2/filters.py
@@ -6,6 +6,8 @@
 Jinja2 filters for use in Ansible documentation.
 """
 
+from __future__ import annotations
+
 import json
 import re
 import typing as t
@@ -15,8 +17,8 @@ from antsibull_core.logging import log
 from jinja2.runtime import Context, Undefined
 from jinja2.utils import pass_context
 
-from ..markup.rstify import rst_ify as rst_ify_impl
 from ..markup.htmlify import html_ify as html_ify_impl
+from ..markup.rstify import rst_ify as rst_ify_impl
 
 mlog = log.fields(mod=__name__)
 
@@ -24,9 +26,9 @@ _EMAIL_ADDRESS = re.compile(r"(?:<{mail}>|\({mail}\)|{mail})".format(mail=r"[\w.
 
 
 def extract_plugin_data(context: Context,
-                        plugin_fqcn: t.Optional[str] = None,
-                        plugin_type: t.Optional[str] = None
-                        ) -> t.Tuple[t.Optional[str], t.Optional[str]]:
+                        plugin_fqcn: str | None = None,
+                        plugin_type: str | None = None
+                        ) -> tuple[str | None, str | None]:
     plugin_fqcn = context.get('plugin_name') if plugin_fqcn is None else plugin_fqcn
     plugin_type = context.get('plugin_type') if plugin_type is None else plugin_type
     if plugin_fqcn is None or plugin_type is None:
@@ -94,10 +96,10 @@ def massage_author_name(value):
     return value
 
 
-def extract_options_from_list(options: t.Dict[str, t.Any],
-                              options_to_extract: t.List[str],
-                              options_to_ignore: t.Optional[t.List[str]] = None
-                              ) -> t.List[t.Tuple[str, t.Any]]:
+def extract_options_from_list(options: dict[str, t.Any],
+                              options_to_extract: list[str],
+                              options_to_ignore: list[str] | None = None
+                              ) -> list[tuple[str, t.Any]]:
     ''' return list of tuples (option, option_data) with option from options_to_extract '''
     if options_to_ignore is None:
         options_to_ignore = []
@@ -107,8 +109,8 @@ def extract_options_from_list(options: t.Dict[str, t.Any],
     ]
 
 
-def remove_options_from_list(options: t.Dict[str, t.Any],
-                             options_to_remove: t.List[str]) -> t.Dict[str, t.Any]:
+def remove_options_from_list(options: dict[str, t.Any],
+                             options_to_remove: list[str]) -> dict[str, t.Any]:
     ''' return copy of dictionary with the options from options_to_remove removed '''
     result = options.copy()
     for option in options_to_remove:
@@ -136,9 +138,9 @@ def to_ini_value(data: t.Any) -> str:
 @pass_context
 def rst_ify(context: Context, text: str,
             *,
-            plugin_fqcn: t.Optional[str] = None,
-            plugin_type: t.Optional[str] = None,
-            role_entrypoint: t.Optional[str] = None,
+            plugin_fqcn: str | None = None,
+            plugin_type: str | None = None,
+            role_entrypoint: str | None = None,
             ) -> str:
     ''' convert symbols like I(this is in italics) to valid restructured text '''
     flog = mlog.fields(func='rst_ify')
@@ -162,9 +164,9 @@ def rst_ify(context: Context, text: str,
 @pass_context
 def html_ify(context: Context, text: str,
              *,
-             plugin_fqcn: t.Optional[str] = None,
-             plugin_type: t.Optional[str] = None,
-             role_entrypoint: t.Optional[str] = None,
+             plugin_fqcn: str | None = None,
+             plugin_type: str | None = None,
+             role_entrypoint: str | None = None,
              ) -> str:
     ''' convert symbols like I(this is in italics) to valid HTML '''
     flog = mlog.fields(func='html_ify')

--- a/src/antsibull_docs/jinja2/tests.py
+++ b/src/antsibull_docs/jinja2/tests.py
@@ -4,6 +4,8 @@
 # SPDX-FileCopyrightText: 2019, Ansible Project
 """Jinja2 tests for use in Ansible documentation."""
 
+from __future__ import annotations
+
 import typing as t
 import warnings
 from functools import partial

--- a/src/antsibull_docs/lint_extra_docs.py
+++ b/src/antsibull_docs/lint_extra_docs.py
@@ -5,10 +5,11 @@
 # SPDX-FileCopyrightText: 2021, Ansible Project
 """Lint extra collection documentation in docs/docsite/."""
 
+from __future__ import annotations
+
 import os
 import os.path
 import re
-import typing as t
 
 from sphinx_antsibull_ext import roles as antsibull_roles
 
@@ -26,7 +27,7 @@ _RST_LABEL_DEFINITION = re.compile(r'''^\.\. _([^:]+):''')
 
 # pylint:disable-next=unused-argument
 def lint_optional_conditions(content: str, path: str, collection_name: str
-                             ) -> t.List[t.Tuple[int, int, str]]:
+                             ) -> list[tuple[int, int, str]]:
     '''Check a extra docs RST file's content for whether it satisfied the required conditions.
 
     Return a list of errors.
@@ -35,20 +36,20 @@ def lint_optional_conditions(content: str, path: str, collection_name: str
 
 
 def lint_collection_extra_docs_files(path_to_collection: str
-                                     ) -> t.List[t.Tuple[str, int, int, str]]:
+                                     ) -> list[tuple[str, int, int, str]]:
     try:
         collection_name = load_collection_name(path_to_collection)
     except Exception:  # pylint:disable=broad-except
         return [(
             path_to_collection, 0, 0,
             'Cannot identify collection with galaxy.yml or MANIFEST.json at this path')]
-    result: t.List[t.Tuple[str, int, int, str]] = []
+    result: list[tuple[str, int, int, str]] = []
     all_labels = set()
     docs = find_extra_docs(path_to_collection)
     for doc in docs:
         try:
             # Load content
-            with open(doc[0], 'r', encoding='utf-8') as f:
+            with open(doc[0], encoding='utf-8') as f:
                 content = f.read()
             # Rstcheck
             errors = lint_optional_conditions(content, doc[0], collection_name)

--- a/src/antsibull_docs/lint_helpers.py
+++ b/src/antsibull_docs/lint_helpers.py
@@ -5,6 +5,8 @@
 # SPDX-FileCopyrightText: 2022, Ansible Project
 """Lint plugin docs."""
 
+from __future__ import annotations
+
 import json
 import os
 import os.path
@@ -13,7 +15,7 @@ import typing as t
 from antsibull_core.yaml import load_yaml_file
 
 
-def load_collection_info(path_to_collection: str) -> t.Dict[str, t.Any]:
+def load_collection_info(path_to_collection: str) -> dict[str, t.Any]:
     '''Load collection name (namespace.name) from collection's galaxy.yml.'''
     manifest_json_path = os.path.join(path_to_collection, 'MANIFEST.json')
     if os.path.isfile(manifest_json_path):

--- a/src/antsibull_docs/markup/_counter.py
+++ b/src/antsibull_docs/markup/_counter.py
@@ -7,13 +7,15 @@
 Count markup instructions in parsed markup.
 """
 
-import typing as t
+from __future__ import annotations
+
+from collections.abc import Sequence
 
 from antsibull_docs_parser import dom
 
 
 class _Counter(dom.Walker):
-    counts: t.Dict[str, int]
+    counts: dict[str, int]
 
     def __init__(self):
         self.counts = {
@@ -78,7 +80,7 @@ class _Counter(dom.Walker):
         self.counts['return-value'] += 1
 
 
-def count(paragraphs: t.Sequence[dom.Paragraph]) -> t.Dict[str, int]:
+def count(paragraphs: Sequence[dom.Paragraph]) -> dict[str, int]:
     counter = _Counter()
     for paragraph in paragraphs:
         dom.walk(paragraph, counter)

--- a/src/antsibull_docs/markup/htmlify.py
+++ b/src/antsibull_docs/markup/htmlify.py
@@ -6,28 +6,30 @@
 htmlify Jinja2 filter for use in Ansible documentation.
 """
 
-import typing as t
+from __future__ import annotations
 
+import typing as t
+from collections.abc import Mapping
 from urllib.parse import quote
 
 from antsibull_docs_parser import dom
-from antsibull_docs_parser.parser import parse, Context
-from antsibull_docs_parser.html import to_html
 from antsibull_docs_parser.format import LinkProvider
+from antsibull_docs_parser.html import to_html
+from antsibull_docs_parser.parser import Context, parse
 
 from ._counter import count as _count
 
 
 class _HTMLLinkProvider(LinkProvider):
-    def plugin_link(self, plugin: dom.PluginIdentifier) -> t.Optional[str]:
+    def plugin_link(self, plugin: dom.PluginIdentifier) -> str | None:
         name = '/'.join(plugin.fqcn.split('.', 2))
         return f'../../{name}_{plugin.type}.html'
 
     def plugin_option_like_link(self,
                                 plugin: dom.PluginIdentifier,
-                                entrypoint: t.Optional[str],
-                                what: "t.Union[t.Literal['option'], t.Literal['retval']]",
-                                name: t.List[str], current_plugin: bool) -> t.Optional[str]:
+                                entrypoint: str | None,
+                                what: t.Literal['option'] | t.Literal['retval'],
+                                name: list[str], current_plugin: bool) -> str | None:
         base = '' if current_plugin else self.plugin_link(plugin)
         w = 'parameter' if what == 'option' else 'return'
         slug = quote('/'.join(name))
@@ -38,12 +40,12 @@ class _HTMLLinkProvider(LinkProvider):
 
 def html_ify(text: str,
              *,
-             plugin_fqcn: t.Optional[str] = None,
-             plugin_type: t.Optional[str] = None,
-             role_entrypoint: t.Optional[str] = None,
-             ) -> t.Tuple[str, t.Mapping[str, int]]:
+             plugin_fqcn: str | None = None,
+             plugin_type: str | None = None,
+             role_entrypoint: str | None = None,
+             ) -> tuple[str, Mapping[str, int]]:
     ''' convert symbols like I(this is in italics) to valid HTML '''
-    current_plugin: t.Optional[dom.PluginIdentifier] = None
+    current_plugin: dom.PluginIdentifier | None = None
     if plugin_fqcn and plugin_type:
         current_plugin = dom.PluginIdentifier(fqcn=plugin_fqcn, type=plugin_type)
     context = Context(current_plugin=current_plugin, role_entrypoint=role_entrypoint)

--- a/src/antsibull_docs/markup/rstify.py
+++ b/src/antsibull_docs/markup/rstify.py
@@ -6,11 +6,15 @@
 rstify Jinja2 filter for use in Ansible documentation.
 """
 
+from __future__ import annotations
+
 import typing as t
+from collections.abc import Mapping
 
 from antsibull_docs_parser import dom
-from antsibull_docs_parser.parser import parse, Context
-from antsibull_docs_parser.rst import rst_escape as _rst_escape, to_rst
+from antsibull_docs_parser.parser import Context, parse
+from antsibull_docs_parser.rst import rst_escape as _rst_escape
+from antsibull_docs_parser.rst import to_rst
 
 from ._counter import count as _count
 
@@ -32,12 +36,12 @@ def rst_code(value: str) -> str:
 
 def rst_ify(text: str,
             *,
-            plugin_fqcn: t.Optional[str] = None,
-            plugin_type: t.Optional[str] = None,
-            role_entrypoint: t.Optional[str] = None,
-            ) -> t.Tuple[str, t.Mapping[str, int]]:
+            plugin_fqcn: str | None = None,
+            plugin_type: str | None = None,
+            role_entrypoint: str | None = None,
+            ) -> tuple[str, Mapping[str, int]]:
     ''' convert symbols like I(this is in italics) to valid restructured text '''
-    current_plugin: t.Optional[dom.PluginIdentifier] = None
+    current_plugin: dom.PluginIdentifier | None = None
     if plugin_fqcn and plugin_type:
         current_plugin = dom.PluginIdentifier(fqcn=plugin_fqcn, type=plugin_type)
     context = Context(current_plugin=current_plugin, role_entrypoint=role_entrypoint)

--- a/src/antsibull_docs/markup/semantic_helper.py
+++ b/src/antsibull_docs/markup/semantic_helper.py
@@ -7,9 +7,9 @@
 Helpers for parsing semantic markup.
 """
 
-import re
-import typing as t
+from __future__ import annotations
 
+import re
 
 _ARRAY_STUB_RE = re.compile(r'\[([^\]]*)\]')
 _FQCN_TYPE_PREFIX_RE = re.compile(r'^([^.]+\.[^.]+\.[^#]+)#([a-z]+):(.*)$')
@@ -20,10 +20,10 @@ def _remove_array_stubs(text: str) -> str:
     return _ARRAY_STUB_RE.sub('', text)
 
 
-def _parse(text: str, plugin_fqcn: t.Optional[str], plugin_type: t.Optional[str], what: str,
+def _parse(text: str, plugin_fqcn: str | None, plugin_type: str | None, what: str,
            require_plugin=False
-           ) -> t.Tuple[t.Optional[str], t.Optional[str],
-                        t.Optional[str], str, str, t.Optional[str]]:
+           ) -> tuple[str | None, str | None,
+                      str | None, str, str, str | None]:
     """
     Given the contents of O(...) / :ansopt:`...` with potential escaping removed,
     split it into plugin FQCN, plugin type, option link name, option name, and option value.
@@ -42,7 +42,7 @@ def _parse(text: str, plugin_fqcn: t.Optional[str], plugin_type: t.Optional[str]
         plugin_fqcn = ''
         plugin_type = ''
         text = text[len(_IGNORE_MARKER):]
-    entrypoint: t.Optional[str] = None
+    entrypoint: str | None = None
     if plugin_type == 'role':
         idx = text.find(':')
         if idx < 0:
@@ -54,10 +54,10 @@ def _parse(text: str, plugin_fqcn: t.Optional[str], plugin_type: t.Optional[str]
     return plugin_fqcn, plugin_type, entrypoint, _remove_array_stubs(text), text, value
 
 
-def parse_option(text: str, plugin_fqcn: t.Optional[str], plugin_type: t.Optional[str],
+def parse_option(text: str, plugin_fqcn: str | None, plugin_type: str | None,
                  require_plugin=False
-                 ) -> t.Tuple[t.Optional[str], t.Optional[str],
-                              t.Optional[str], str, str, t.Optional[str]]:
+                 ) -> tuple[str | None, str | None,
+                            str | None, str, str, str | None]:
     """
     Given the contents of O(...) / :ansopt:`...` with potential escaping removed,
     split it into plugin FQCN, plugin type, entrypoint, option link name, option name, and option
@@ -66,10 +66,10 @@ def parse_option(text: str, plugin_fqcn: t.Optional[str], plugin_type: t.Optiona
     return _parse(text, plugin_fqcn, plugin_type, 'option name', require_plugin=require_plugin)
 
 
-def parse_return_value(text: str, plugin_fqcn: t.Optional[str], plugin_type: t.Optional[str],
+def parse_return_value(text: str, plugin_fqcn: str | None, plugin_type: str | None,
                        require_plugin=False
-                       ) -> t.Tuple[t.Optional[str], t.Optional[str],
-                                    t.Optional[str], str, str, t.Optional[str]]:
+                       ) -> tuple[str | None, str | None,
+                                  str | None, str, str, str | None]:
     """
     Given the contents of RV(...) / :ansretval:`...` with potential escaping removed,
     split it into plugin FQCN, plugin type, entrypoint, return value link name, return value name,

--- a/src/antsibull_docs/rstcheck.py
+++ b/src/antsibull_docs/rstcheck.py
@@ -5,10 +5,11 @@
 # SPDX-FileCopyrightText: 2022, Ansible Project
 """Handle rstcheck."""
 
+from __future__ import annotations
+
 import os.path
 import pathlib
 import tempfile
-import typing as t
 
 # rstcheck >= 6.0.0 depends on rstcheck-core
 try:
@@ -21,10 +22,10 @@ except ImportError:
     import rstcheck
 
 
-def check_rst_content(content: str, filename: t.Optional[str] = None,
-                      ignore_directives: t.Optional[t.List[str]] = None,
-                      ignore_roles: t.Optional[t.List[str]] = None,
-                      ) -> t.List[t.Tuple[int, int, str]]:
+def check_rst_content(content: str, filename: str | None = None,
+                      ignore_directives: list[str] | None = None,
+                      ignore_roles: list[str] | None = None,
+                      ) -> list[tuple[int, int, str]]:
     '''
     Check the content with rstcheck. Return list of errors and warnings.
 

--- a/src/antsibull_docs/schemas/ansible_doc.py
+++ b/src/antsibull_docs/schemas/ansible_doc.py
@@ -5,6 +5,8 @@
 # SPDX-FileCopyrightText: 2021, Ansible Project
 """Compatibility package."""
 
+from __future__ import annotations
+
 import warnings
 
 # This module is just a backwards compatible location for ansible_doc so the wildcard

--- a/src/antsibull_docs/schemas/app_context.py
+++ b/src/antsibull_docs/schemas/app_context.py
@@ -9,7 +9,6 @@
 # to initialize the attributes when data is loaded into them.
 # pyre-ignore-all-errors[13]
 
-import typing as t
 
 import pydantic as p
 from antsibull_core.schemas.context import AppContext as CoreAppContext
@@ -28,10 +27,10 @@ class DocsAppContext(CoreAppContext):
     use_html_blobs: p.StrictBool = False
 
     # These are antsibull-docs specific
-    collection_url: t.Dict[str, str] = {
+    collection_url: dict[str, str] = {
         '*': 'https://galaxy.ansible.com/{namespace}/{name}',
     }
-    collection_install: t.Dict[str, str] = {
+    collection_install: dict[str, str] = {
         '*': 'ansible-galaxy collection install {namespace}.{name}',
     }
 

--- a/src/antsibull_docs/schemas/collection_links.py
+++ b/src/antsibull_docs/schemas/collection_links.py
@@ -76,9 +76,9 @@ class MailingList(p.BaseModel):
 
 
 class Communication(p.BaseModel):
-    irc_channels: t.List[IRCChannel] = []
-    matrix_rooms: t.List[MatrixRoom] = []
-    mailing_lists: t.List[MailingList] = []
+    irc_channels: list[IRCChannel] = []
+    matrix_rooms: list[MatrixRoom] = []
+    mailing_lists: list[MailingList] = []
 
     @property
     def empty(self):
@@ -87,9 +87,9 @@ class Communication(p.BaseModel):
 
 class CollectionLinks(p.BaseModel):
     edit_on_github: t.Optional[CollectionEditOnGitHub] = None
-    authors: t.List[str] = []
+    authors: list[str] = []
     description: t.Optional[str] = None
     issue_tracker: t.Optional[str] = None
-    links: t.List[Link] = []
-    extra_links: t.List[Link] = []
+    links: list[Link] = []
+    extra_links: list[Link] = []
     communication: Communication = Communication()

--- a/src/antsibull_docs/schemas/docs/__init__.py
+++ b/src/antsibull_docs/schemas/docs/__init__.py
@@ -10,6 +10,8 @@ This is a highlevel interface.  The hope is that developers can use either this 
 antsibull.schemas.docs.ansible_doc to handle all of their validation needs.
 """
 
+from __future__ import annotations
+
 from .callback import CallbackDocSchema, CallbackSchema
 from .module import ModuleDocSchema, ModuleSchema
 from .plugin import (

--- a/src/antsibull_docs/schemas/docs/ansible_doc.py
+++ b/src/antsibull_docs/schemas/docs/ansible_doc.py
@@ -10,11 +10,7 @@ This is a highlevel interface.  The hope is that developers can use either this 
 antsibull.schemas.docs to handle all of their validation needs.
 """
 
-# Ignore Unitialized attribute errors because BaseModel works some magic
-# to initialize the attributes when data is loaded into them.
-# pyre-ignore-all-errors[13]
-
-import typing as t
+from __future__ import annotations
 
 from .base import BaseModel
 from .callback import CallbackSchema
@@ -22,6 +18,11 @@ from .module import ModuleSchema
 from .plugin import PluginSchema
 from .positional import PositionalSchema
 from .role import RoleSchema
+
+# Ignore Unitialized attribute errors because BaseModel works some magic
+# to initialize the attributes when data is loaded into them.
+# pyre-ignore-all-errors[13]
+
 
 __all__ = ('ANSIBLE_DOC_SCHEMAS', 'AnsibleDocSchema', 'BecomePluginSchema', 'CachePluginSchema',
            'CallbackPluginSchema', 'CliConfPluginSchema', 'ConnectionPluginSchema',
@@ -50,22 +51,22 @@ class AnsibleDocSchema(BaseModel):
     a :python:obj:`dict` back out.
     """
 
-    become: t.Dict[str, PluginSchema]
-    cache: t.Dict[str, PluginSchema]
-    callback: t.Dict[str, CallbackSchema]
-    cliconf: t.Dict[str, PluginSchema]
-    connection: t.Dict[str, PluginSchema]
-    filter: t.Dict[str, PositionalSchema]
-    httpapi: t.Dict[str, PluginSchema]
-    inventory: t.Dict[str, PluginSchema]
-    lookup: t.Dict[str, PositionalSchema]
-    module: t.Dict[str, ModuleSchema]
-    netconf: t.Dict[str, PluginSchema]
-    shell: t.Dict[str, PluginSchema]
-    strategy: t.Dict[str, PluginSchema]
-    test: t.Dict[str, PositionalSchema]
-    vars: t.Dict[str, PluginSchema]
-    role: t.Dict[str, RoleSchema]
+    become: dict[str, PluginSchema]
+    cache: dict[str, PluginSchema]
+    callback: dict[str, CallbackSchema]
+    cliconf: dict[str, PluginSchema]
+    connection: dict[str, PluginSchema]
+    filter: dict[str, PositionalSchema]
+    httpapi: dict[str, PluginSchema]
+    inventory: dict[str, PluginSchema]
+    lookup: dict[str, PositionalSchema]
+    module: dict[str, ModuleSchema]
+    netconf: dict[str, PluginSchema]
+    shell: dict[str, PluginSchema]
+    strategy: dict[str, PluginSchema]
+    test: dict[str, PositionalSchema]
+    vars: dict[str, PluginSchema]
+    role: dict[str, RoleSchema]
 
 
 class GenericPluginSchema(BaseModel):
@@ -77,7 +78,7 @@ class GenericPluginSchema(BaseModel):
         a dynamic key which we can't automatically map to an attribute name.
     """
 
-    __root__: t.Dict[str, PluginSchema]
+    __root__: dict[str, PluginSchema]
 
 
 class CallbackPluginSchema(BaseModel):
@@ -89,7 +90,7 @@ class CallbackPluginSchema(BaseModel):
         a dynamic key which we can't automatically map to an attribute name.
     """
 
-    __root__: t.Dict[str, CallbackSchema]
+    __root__: dict[str, CallbackSchema]
 
 
 class PositionalPluginSchema(BaseModel):
@@ -101,7 +102,7 @@ class PositionalPluginSchema(BaseModel):
         a dynamic key which we can't automatically map to an attribute name.
     """
 
-    __root__: t.Dict[str, PositionalSchema]
+    __root__: dict[str, PositionalSchema]
 
 
 class ModulePluginSchema(BaseModel):
@@ -113,7 +114,7 @@ class ModulePluginSchema(BaseModel):
         a dynamic key which we can't automatically map to an attribute name.
     """
 
-    __root__: t.Dict[str, ModuleSchema]
+    __root__: dict[str, ModuleSchema]
 
 
 class RolePluginSchema(BaseModel):
@@ -125,7 +126,7 @@ class RolePluginSchema(BaseModel):
         a dynamic key which we can't automatically map to an attribute name.
     """
 
-    __root__: t.Dict[str, RoleSchema]
+    __root__: dict[str, RoleSchema]
 
 
 #: Make sure users can access plugins using the plugin type rather than having to guess that

--- a/src/antsibull_docs/schemas/docs/base.py
+++ b/src/antsibull_docs/schemas/docs/base.py
@@ -301,7 +301,7 @@ TYPE_CHECKERS: dict[str, t.Callable[[t.Any], t.Any]] = {
 }
 
 
-def normalize_value(values: t.Dict[str, t.Any], field: str,  # noqa: C901
+def normalize_value(values: dict[str, t.Any], field: str,  # noqa: C901
                     is_list_of_values: bool = False, accept_dict: bool = False) -> None:
     if 'type' not in values or values.get(field) is None:
         return
@@ -447,9 +447,9 @@ class DeprecationSchema(BaseModel):
 
 
 class OptionsSchema(BaseModel):
-    description: t.List[str]
-    aliases: t.List[str] = []
-    choices: t.Union[t.List[t.Any], t.Dict[t.Any, t.List[str]]] = []
+    description: list[str]
+    aliases: list[str] = []
+    choices: t.Union[list[t.Any], dict[t.Any, list[str]]] = []
     default: t.Any = None  # JSON value
     elements: str = OPTION_TYPE_F
     required: bool = False
@@ -548,8 +548,8 @@ class AttributeSchemaBase(BaseModel, metaclass=abc.ABCMeta):
     # We use an abstract base class instead of deriving the other classes directly from
     # AttributeSchema to make Union[AttributeSchema, ...] work with Pydantic and  Python 3.6.
     # Without this base class, we would hit https://github.com/samuelcolvin/pydantic/issues/1259
-    description: t.List[str]
-    details: t.List[str] = []
+    description: list[str]
+    details: list[str] = []
     support: str = p.Field('str', regex='^(full|partial|none|N/A)$')
     version_added: str = 'historical'
     version_added_collection: str = COLLECTION_NAME_F
@@ -565,7 +565,7 @@ class AttributeSchema(AttributeSchemaBase):
 
 
 class AttributeSchemaActionGroup(AttributeSchemaBase):  # for 'action_group'
-    membership: t.List[str]
+    membership: list[str]
 
     @p.validator('membership', pre=True)
     # pylint:disable=no-self-argument
@@ -574,7 +574,7 @@ class AttributeSchemaActionGroup(AttributeSchemaBase):  # for 'action_group'
 
 
 class AttributeSchemaPlatform(AttributeSchemaBase):  # for 'platform'
-    platforms: t.List[str]
+    platforms: list[str]
 
     @p.validator('platforms', pre=True)
     # pylint:disable=no-self-argument
@@ -587,23 +587,23 @@ SeeAlsoSchemaT = t.Union[SeeAlsoLinkSchema, SeeAlsoModSchema, SeeAlsoPluginSchem
 
 class DocSchema(BaseModel):
     collection: str = REQUIRED_COLLECTION_NAME_OR_EMPTY_STR_F
-    description: t.List[str]
+    description: list[str]
     name: str
     short_description: str
-    aliases: t.List[str] = []
-    author: t.List[str] = []
+    aliases: list[str] = []
+    author: list[str] = []
     deprecated: DeprecationSchema = p.Field({})
-    extends_documentation_fragment: t.List[str] = []
+    extends_documentation_fragment: list[str] = []
     filename: str = ''
-    notes: t.List[str] = []
-    requirements: t.List[str] = []
-    seealso: t.List[SeeAlsoSchemaT] = []
-    todo: t.List[str] = []
+    notes: list[str] = []
+    requirements: list[str] = []
+    seealso: list[SeeAlsoSchemaT] = []
+    todo: list[str] = []
     version_added: str = 'historical'
     version_added_collection: str = COLLECTION_NAME_F
-    attributes: t.Dict[str, t.Union[AttributeSchema,
-                                    AttributeSchemaActionGroup,
-                                    AttributeSchemaPlatform]] = {}
+    attributes: dict[str, t.Union[AttributeSchema,
+                                  AttributeSchemaActionGroup,
+                                  AttributeSchemaPlatform]] = {}
 
     @p.validator('author', 'description', 'extends_documentation_fragment', 'notes',
                  'requirements', 'todo', pre=True)

--- a/src/antsibull_docs/schemas/docs/callback.py
+++ b/src/antsibull_docs/schemas/docs/callback.py
@@ -8,7 +8,12 @@
 import pydantic as p
 
 from .base import BaseModel
-from .plugin import InnerDocSchema, PluginExamplesSchema, PluginMetadataSchema, PluginReturnSchema
+from .plugin import (
+    InnerDocSchema,
+    PluginExamplesSchema,
+    PluginMetadataSchema,
+    PluginReturnSchema,
+)
 
 REQUIRED_CALLBACK_TYPE_F = p.Field(..., regex='^(aggregate|notification|stdout)$')
 

--- a/src/antsibull_docs/schemas/docs/module.py
+++ b/src/antsibull_docs/schemas/docs/module.py
@@ -5,7 +5,6 @@
 # SPDX-FileCopyrightText: 2020, Ansible Project
 """Schemas for the plugin DOCUMENTATION data."""
 
-import typing as t
 
 import pydantic as p
 
@@ -14,7 +13,7 @@ from .plugin import PluginExamplesSchema, PluginMetadataSchema, PluginReturnSche
 
 
 class InnerModuleOptionsSchema(OptionsSchema):
-    suboptions: t.Dict[str, 'InnerModuleOptionsSchema'] = {}
+    suboptions: dict[str, 'InnerModuleOptionsSchema'] = {}
 
     @p.root_validator(pre=True)
     # pylint:disable=no-self-argument
@@ -29,11 +28,11 @@ InnerModuleOptionsSchema.update_forward_refs()
 
 
 class ModuleOptionsSchema(OptionsSchema):
-    suboptions: t.Dict[str, 'InnerModuleOptionsSchema'] = {}
+    suboptions: dict[str, 'InnerModuleOptionsSchema'] = {}
 
 
 class OuterModuleDocSchema(DocSchema):
-    options: t.Dict[str, ModuleOptionsSchema] = {}
+    options: dict[str, ModuleOptionsSchema] = {}
     has_action: bool = False
 
 

--- a/src/antsibull_docs/schemas/docs/plugin.py
+++ b/src/antsibull_docs/schemas/docs/plugin.py
@@ -86,8 +86,8 @@ class OptionKeywordSchema(BaseModel):
 class ReturnSchema(BaseModel):
     """Schema of plugin return data docs."""
 
-    description: t.List[str]
-    choices: t.Union[t.List[t.Any], t.Dict[t.Any, t.List[str]]] = []
+    description: list[str]
+    choices: t.Union[list[t.Any], dict[t.Any, list[str]]] = []
     elements: str = RETURN_TYPE_F
     returned: str = 'success'
     sample: t.Any = None  # JSON value
@@ -158,7 +158,7 @@ class ReturnSchema(BaseModel):
 class InnerReturnSchema(ReturnSchema):
     """Nested return schema which allows leaving out description."""
 
-    contains: t.Dict[str, 'InnerReturnSchema'] = {}
+    contains: dict[str, 'InnerReturnSchema'] = {}
 
     @p.root_validator(pre=True)
     # pylint:disable=no-self-argument
@@ -175,16 +175,16 @@ InnerReturnSchema.update_forward_refs()
 class OuterReturnSchema(ReturnSchema):
     """Toplevel return schema."""
 
-    contains: t.Dict[str, InnerReturnSchema] = {}
+    contains: dict[str, InnerReturnSchema] = {}
 
 
 class PluginOptionsSchema(OptionsSchema):
-    cli: t.List[OptionCliSchema] = []
-    env: t.List[OptionEnvSchema] = []
-    ini: t.List[OptionIniSchema] = []
-    suboptions: t.Dict[str, 'PluginOptionsSchema'] = {}
-    vars: t.List[OptionVarsSchema] = []
-    keyword: t.List[OptionKeywordSchema] = []
+    cli: list[OptionCliSchema] = []
+    env: list[OptionEnvSchema] = []
+    ini: list[OptionIniSchema] = []
+    suboptions: dict[str, 'PluginOptionsSchema'] = {}
+    vars: list[OptionVarsSchema] = []
+    keyword: list[OptionKeywordSchema] = []
     deprecated: DeprecationSchema = p.Field({})
 
 
@@ -192,7 +192,7 @@ PluginOptionsSchema.update_forward_refs()
 
 
 class InnerDocSchema(DocSchema):
-    options: t.Dict[str, PluginOptionsSchema] = {}
+    options: dict[str, PluginOptionsSchema] = {}
 
 
 class PluginDocSchema(BaseModel):
@@ -211,7 +211,7 @@ class PluginExamplesSchema(BaseModel):
 
 
 class PluginMetadataSchema(BaseModel):
-    metadata: t.Optional[t.Dict[str, t.Any]] = None
+    metadata: t.Optional[dict[str, t.Any]] = None
 
 
 class PluginReturnSchema(BaseModel):
@@ -219,7 +219,7 @@ class PluginReturnSchema(BaseModel):
         fields = {'return_': 'return',
                   }
 
-    return_: t.Dict[str, OuterReturnSchema] = {}
+    return_: dict[str, OuterReturnSchema] = {}
 
     @p.validator('return_', pre=True)
     # pylint:disable=no-self-argument

--- a/src/antsibull_docs/schemas/docs/positional.py
+++ b/src/antsibull_docs/schemas/docs/positional.py
@@ -6,12 +6,16 @@
 # SPDX-FileCopyrightText: 2022, Ansible Project
 """Schemas for the plugin DOCUMENTATION data."""
 
-import typing as t
 
 import pydantic as p
 
 from .base import BaseModel
-from .plugin import InnerDocSchema, PluginExamplesSchema, PluginMetadataSchema, PluginReturnSchema
+from .plugin import (
+    InnerDocSchema,
+    PluginExamplesSchema,
+    PluginMetadataSchema,
+    PluginReturnSchema,
+)
 
 
 class InnerPositionalDocSchema(InnerDocSchema):
@@ -19,7 +23,7 @@ class InnerPositionalDocSchema(InnerDocSchema):
     Schema describing the structure of documentation for plugins with positional parameters.
     """
 
-    positional: t.List[str] = []
+    positional: list[str] = []
 
     @p.root_validator(pre=True)
     # pylint:disable=no-self-argument

--- a/src/antsibull_docs/schemas/docs/role.py
+++ b/src/antsibull_docs/schemas/docs/role.py
@@ -29,7 +29,7 @@ from .base import (
 
 
 class InnerRoleOptionsSchema(OptionsSchema):
-    options: t.Dict[str, 'InnerRoleOptionsSchema'] = {}
+    options: dict[str, 'InnerRoleOptionsSchema'] = {}
 
     @p.root_validator(pre=True)
     # pylint:disable=no-self-argument
@@ -44,29 +44,29 @@ InnerRoleOptionsSchema.update_forward_refs()
 
 
 class RoleOptionsSchema(OptionsSchema):
-    options: t.Dict[str, 'InnerRoleOptionsSchema'] = {}
+    options: dict[str, 'InnerRoleOptionsSchema'] = {}
 
 
 class RoleEntrypointSchema(BaseModel):
     """Documentation for role entrypoints."""
-    description: t.List[str]
+    description: list[str]
     short_description: str
-    author: t.List[str] = []
+    author: list[str] = []
     deprecated: DeprecationSchema = p.Field({})
-    notes: t.List[str] = []
-    requirements: t.List[str] = []
-    seealso: t.List[t.Union[SeeAlsoModSchema, SeeAlsoRefSchema, SeeAlsoLinkSchema]] = []
-    todo: t.List[str] = []
+    notes: list[str] = []
+    requirements: list[str] = []
+    seealso: list[t.Union[SeeAlsoModSchema, SeeAlsoRefSchema, SeeAlsoLinkSchema]] = []
+    todo: list[str] = []
     version_added: str = 'historical'
-    attributes: t.Dict[str, t.Union[AttributeSchema,
-                                    AttributeSchemaActionGroup,
-                                    AttributeSchemaPlatform]] = {}
+    attributes: dict[str, t.Union[AttributeSchema,
+                                  AttributeSchemaActionGroup,
+                                  AttributeSchemaPlatform]] = {}
 
-    options: t.Dict[str, RoleOptionsSchema] = {}
+    options: dict[str, RoleOptionsSchema] = {}
 
 
 class RoleSchema(BaseModel):
     """Documentation for roles."""
     collection: str = COLLECTION_NAME_F
-    entry_points: t.Dict[str, RoleEntrypointSchema]
+    entry_points: dict[str, RoleEntrypointSchema]
     path: str

--- a/src/antsibull_docs/utils/collection_name_transformer.py
+++ b/src/antsibull_docs/utils/collection_name_transformer.py
@@ -5,13 +5,15 @@
 # SPDX-FileCopyrightText: 2022, Ansible Project
 """Helper to transform collection names based on a dictionary."""
 
-import typing as t
+from __future__ import annotations
+
+from collections.abc import Mapping
 
 
 class CollectionNameTransformer:
     """Helper to transform collection names based on a dictionary."""
 
-    def __init__(self, data: t.Mapping[str, str], default_transform: str):
+    def __init__(self, data: Mapping[str, str], default_transform: str):
         """Create a collection name transformer.
 
         :arg data: Maps collection names (with wildcards) to transformation strings.

--- a/src/antsibull_docs/utils/get_pkg_data.py
+++ b/src/antsibull_docs/utils/get_pkg_data.py
@@ -6,6 +6,8 @@
 # SPDX-FileCopyrightText: 2020, Ansible Project
 """Helper to use pkgutil.get_data without having to check the return value."""
 
+from __future__ import annotations
+
 import pkgutil
 
 

--- a/src/antsibull_docs/write_docs/__init__.py
+++ b/src/antsibull_docs/write_docs/__init__.py
@@ -5,7 +5,9 @@
 # SPDX-FileCopyrightText: 2020, Ansible Project
 """Output documentation."""
 
-import typing as t
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
 
 from antsibull_core.logging import log
 from jinja2 import Template
@@ -14,15 +16,15 @@ mlog = log.fields(mod=__name__)
 
 #: Mapping of plugins to nonfatal errors.  This is the type to use when accepting the plugin.
 #: The mapping is of plugin_type: plugin_name: [error_msgs]
-PluginErrorsT = t.Mapping[str, t.Mapping[str, t.Sequence[str]]]
+PluginErrorsT = Mapping[str, Mapping[str, Sequence[str]]]
 
 #: Mapping to collections to plugins.
 #: The mapping is collection_name: plugin_type: plugin_name: plugin_short_description
-CollectionInfoT = t.Mapping[str, t.Mapping[str, t.Mapping[str, str]]]
+CollectionInfoT = Mapping[str, Mapping[str, Mapping[str, str]]]
 
 #: Plugins grouped first by plugin type, then by collection
 #: The mapping is plugin_type: collection_name: plugin_name: plugin_short_description
-PluginCollectionInfoT = t.Mapping[str, t.Mapping[str, t.Mapping[str, str]]]
+PluginCollectionInfoT = Mapping[str, Mapping[str, Mapping[str, str]]]
 
 
 def _render_template(_template: Template, _name: str, **kwargs) -> str:

--- a/src/antsibull_docs/write_docs/collections.py
+++ b/src/antsibull_docs/write_docs/collections.py
@@ -5,9 +5,11 @@
 # SPDX-FileCopyrightText: 2020, Ansible Project
 """Output collection documentation."""
 
+from __future__ import annotations
+
 import asyncio
 import os
-import typing as t
+from collections.abc import Mapping
 
 import asyncio_pool  # type: ignore[import]
 from antsibull_core import app_context
@@ -26,7 +28,7 @@ from . import CollectionInfoT, _render_template
 mlog = log.fields(mod=__name__)
 
 
-def _parse_required_ansible(requires_ansible: str) -> t.List[str]:
+def _parse_required_ansible(requires_ansible: str) -> list[str]:
     result = []
     for specifier in reversed(sorted(
         SpecifierSet(requires_ansible),
@@ -50,7 +52,7 @@ def _parse_required_ansible(requires_ansible: str) -> t.List[str]:
 
 
 async def write_plugin_lists(collection_name: str,
-                             plugin_maps: t.Mapping[str, t.Mapping[str, str]],
+                             plugin_maps: Mapping[str, Mapping[str, str]],
                              template: Template,
                              dest_dir: str,
                              collection_meta: AnsibleCollectionMetadata,
@@ -122,9 +124,9 @@ async def write_plugin_lists(collection_name: str,
 
 async def output_indexes(collection_to_plugin_info: CollectionInfoT,
                          dest_dir: str,
-                         collection_metadata: t.Mapping[str, AnsibleCollectionMetadata],
-                         extra_docs_data: t.Mapping[str, CollectionExtraDocsInfoT],
-                         link_data: t.Mapping[str, CollectionLinks],
+                         collection_metadata: Mapping[str, AnsibleCollectionMetadata],
+                         extra_docs_data: Mapping[str, CollectionExtraDocsInfoT],
+                         link_data: Mapping[str, CollectionLinks],
                          collection_url: CollectionNameTransformer,
                          collection_install: CollectionNameTransformer,
                          squash_hierarchy: bool = False,
@@ -193,7 +195,7 @@ async def output_indexes(collection_to_plugin_info: CollectionInfoT,
 
 
 async def output_extra_docs(dest_dir: str,
-                            extra_docs_data: t.Mapping[str, CollectionExtraDocsInfoT],
+                            extra_docs_data: Mapping[str, CollectionExtraDocsInfoT],
                             squash_hierarchy: bool = False) -> None:
     """
     Write extra docs pages for the collections.

--- a/src/antsibull_docs/write_docs/hierarchy.py
+++ b/src/antsibull_docs/write_docs/hierarchy.py
@@ -5,10 +5,12 @@
 # SPDX-FileCopyrightText: 2020, Ansible Project
 """Output collection hierarchy."""
 
+from __future__ import annotations
+
 import asyncio
 import os
 import os.path
-import typing as t
+from collections.abc import Iterable, Mapping
 
 import asyncio_pool  # type: ignore[import]
 from antsibull_core import app_context
@@ -23,7 +25,7 @@ from . import CollectionInfoT, _render_template
 mlog = log.fields(mod=__name__)
 
 
-async def write_collection_list(collections: t.Iterable[str], namespaces: t.Iterable[str],
+async def write_collection_list(collections: Iterable[str], namespaces: Iterable[str],
                                 template: Template, dest_dir: str,
                                 breadcrumbs: bool = True,
                                 for_official_docsite: bool = False) -> None:
@@ -54,7 +56,7 @@ async def write_collection_list(collections: t.Iterable[str], namespaces: t.Iter
     await write_file(index_file, index_contents)
 
 
-async def write_collection_namespace_index(namespace: str, collections: t.Iterable[str],
+async def write_collection_namespace_index(namespace: str, collections: Iterable[str],
                                            template: Template, dest_dir: str,
                                            breadcrumbs: bool = True,
                                            for_official_docsite: bool = False) -> None:
@@ -86,7 +88,7 @@ async def write_collection_namespace_index(namespace: str, collections: t.Iterab
 
 
 async def output_collection_index(collection_to_plugin_info: CollectionInfoT,
-                                  collection_namespaces: t.Mapping[str, t.List[str]],
+                                  collection_namespaces: Mapping[str, list[str]],
                                   dest_dir: str,
                                   collection_url: CollectionNameTransformer,
                                   collection_install: CollectionNameTransformer,
@@ -128,7 +130,7 @@ async def output_collection_index(collection_to_plugin_info: CollectionInfoT,
     flog.debug('Leave')
 
 
-async def output_collection_namespace_indexes(collection_namespaces: t.Mapping[str, t.List[str]],
+async def output_collection_namespace_indexes(collection_namespaces: Mapping[str, list[str]],
                                               dest_dir: str,
                                               collection_url: CollectionNameTransformer,
                                               collection_install: CollectionNameTransformer,

--- a/src/antsibull_docs/write_docs/indexes.py
+++ b/src/antsibull_docs/write_docs/indexes.py
@@ -5,10 +5,12 @@
 # SPDX-FileCopyrightText: 2020, Ansible Project
 """Output indexes."""
 
+from __future__ import annotations
+
 import asyncio
 import os
 import os.path
-import typing as t
+from collections.abc import Mapping
 
 import asyncio_pool  # type: ignore[import]
 from antsibull_core import app_context
@@ -25,7 +27,7 @@ mlog = log.fields(mod=__name__)
 
 
 async def write_callback_type_index(callback_type: str,
-                                    per_collection_plugins: t.Mapping[str, t.Mapping[str, str]],
+                                    per_collection_plugins: Mapping[str, Mapping[str, str]],
                                     template: Template,
                                     dest_filename: str,
                                     for_official_docsite: bool = False) -> None:
@@ -52,7 +54,7 @@ async def write_callback_type_index(callback_type: str,
 
 
 async def write_plugin_type_index(plugin_type: str,
-                                  per_collection_plugins: t.Mapping[str, t.Mapping[str, str]],
+                                  per_collection_plugins: Mapping[str, Mapping[str, str]],
                                   template: Template,
                                   dest_filename: str,
                                   for_official_docsite: bool = False) -> None:
@@ -172,7 +174,7 @@ async def output_plugin_indexes(plugin_info: PluginCollectionInfoT,
 
 
 async def output_environment_variables(dest_dir: str,
-                                       env_variables: t.Mapping[str, EnvironmentVariableInfo],
+                                       env_variables: Mapping[str, EnvironmentVariableInfo],
                                        squash_hierarchy: bool = False
                                        ) -> None:
     """

--- a/src/antsibull_docs/write_docs/plugin_stubs.py
+++ b/src/antsibull_docs/write_docs/plugin_stubs.py
@@ -5,10 +5,13 @@
 # SPDX-FileCopyrightText: 2020, Ansible Project
 """Output plugin stubs."""
 
+from __future__ import annotations
+
 import asyncio
 import os
 import os.path
 import typing as t
+from collections.abc import Mapping
 
 import asyncio_pool  # type: ignore[import]
 from antsibull_core import app_context
@@ -28,11 +31,11 @@ mlog = log.fields(mod=__name__)
 async def write_stub_rst(collection_name: str, collection_meta: AnsibleCollectionMetadata,
                          collection_links: CollectionLinks,
                          plugin_short_name: str, plugin_type: str,
-                         routing_data: t.Mapping[str, t.Any],
+                         routing_data: Mapping[str, t.Any],
                          redirect_tmpl: Template,
                          tombstone_tmpl: Template,
                          dest_dir: str,
-                         path_override: t.Optional[str] = None,
+                         path_override: str | None = None,
                          squash_hierarchy: bool = False,
                          for_official_docsite: bool = False) -> None:
     """
@@ -109,14 +112,14 @@ async def write_stub_rst(collection_name: str, collection_meta: AnsibleCollectio
     flog.debug('Leave')
 
 
-async def output_all_plugin_stub_rst(stubs_info: t.Mapping[
-                                         str, t.Mapping[str, t.Mapping[str, t.Any]]],
+async def output_all_plugin_stub_rst(stubs_info: Mapping[
+                                         str, Mapping[str, Mapping[str, t.Any]]],
                                      dest_dir: str,
                                      collection_url: CollectionNameTransformer,
                                      collection_install: CollectionNameTransformer,
-                                     collection_metadata: t.Mapping[
+                                     collection_metadata: Mapping[
                                          str, AnsibleCollectionMetadata],
-                                     link_data: t.Mapping[str, CollectionLinks],
+                                     link_data: Mapping[str, CollectionLinks],
                                      squash_hierarchy: bool = False,
                                      for_official_docsite: bool = False) -> None:
     """

--- a/src/antsibull_docs/write_docs/plugins.py
+++ b/src/antsibull_docs/write_docs/plugins.py
@@ -5,10 +5,13 @@
 # SPDX-FileCopyrightText: 2020, Ansible Project
 """Output plugin documentation."""
 
+from __future__ import annotations
+
 import asyncio
 import os
 import os.path
 import typing as t
+from collections.abc import Mapping, Sequence
 
 import asyncio_pool  # type: ignore[import]
 from antsibull_core import app_context
@@ -35,7 +38,7 @@ def follow_relative_links(path: str) -> str:
     flog.fields(path=path).debug('Enter')
 
     original_path = path
-    loop_detection: t.Set[str] = set()
+    loop_detection: set[str] = set()
     while True:
         if path in loop_detection:
             flog.fields(
@@ -70,7 +73,7 @@ def follow_relative_links(path: str) -> str:
         path = os.path.join(os.path.dirname(path), link)
 
 
-def has_broken_docs(plugin_record: t.Mapping[str, t.Any], plugin_type: str) -> bool:
+def has_broken_docs(plugin_record: Mapping[str, t.Any], plugin_type: str) -> bool:
     """
     Determine whether the plugin record is completely broken or not.
     """
@@ -78,7 +81,7 @@ def has_broken_docs(plugin_record: t.Mapping[str, t.Any], plugin_type: str) -> b
     return not plugin_record or not all(field in plugin_record for field in expected_fields)
 
 
-def guess_relative_filename(plugin_record: t.Mapping[str, t.Any],
+def guess_relative_filename(plugin_record: Mapping[str, t.Any],
                             plugin_short_name: str,
                             plugin_type: str,
                             collection_name: str,
@@ -108,8 +111,8 @@ def create_plugin_rst(collection_name: str,
                       collection_links: CollectionLinks,
                       plugin_short_name: str,
                       plugin_type: str,
-                      plugin_record: t.Dict[str, t.Any],
-                      nonfatal_errors: t.Sequence[str],
+                      plugin_record: dict[str, t.Any],
+                      nonfatal_errors: Sequence[str],
                       plugin_tmpl: Template, error_tmpl: Template,
                       use_html_blobs: bool = False,
                       for_official_docsite: bool = False,
@@ -221,9 +224,9 @@ async def write_plugin_rst(collection_name: str,
                            collection_meta: AnsibleCollectionMetadata,
                            collection_links: CollectionLinks,
                            plugin_short_name: str, plugin_type: str,
-                           plugin_record: t.Dict[str, t.Any], nonfatal_errors: t.Sequence[str],
+                           plugin_record: dict[str, t.Any], nonfatal_errors: Sequence[str],
                            plugin_tmpl: Template, error_tmpl: Template, dest_dir: str,
-                           path_override: t.Optional[str] = None,
+                           path_override: str | None = None,
                            squash_hierarchy: bool = False,
                            use_html_blobs: bool = False,
                            for_official_docsite: bool = False) -> None:
@@ -290,13 +293,13 @@ async def write_plugin_rst(collection_name: str,
 
 
 async def output_all_plugin_rst(collection_to_plugin_info: CollectionInfoT,
-                                plugin_info: t.Dict[str, t.Any],
+                                plugin_info: dict[str, t.Any],
                                 nonfatal_errors: PluginErrorsT,
                                 dest_dir: str,
                                 collection_url: CollectionNameTransformer,
                                 collection_install: CollectionNameTransformer,
-                                collection_metadata: t.Mapping[str, AnsibleCollectionMetadata],
-                                link_data: t.Mapping[str, CollectionLinks],
+                                collection_metadata: Mapping[str, AnsibleCollectionMetadata],
+                                link_data: Mapping[str, CollectionLinks],
                                 squash_hierarchy: bool = False,
                                 use_html_blobs: bool = False,
                                 for_official_docsite: bool = False) -> None:

--- a/src/sphinx_antsibull_ext/__init__.py
+++ b/src/sphinx_antsibull_ext/__init__.py
@@ -7,6 +7,8 @@
 Antsibull minimal Sphinx extension which adds some features from the Ansible doc site.
 '''
 
+from __future__ import annotations
+
 __version__ = "0.1.1"
 __license__ = "BSD license"
 __author__ = "Felix Fontein"

--- a/src/sphinx_antsibull_ext/assets.py
+++ b/src/sphinx_antsibull_ext/assets.py
@@ -7,6 +7,8 @@
 Handling assets.
 '''
 
+from __future__ import annotations
+
 import os
 import pkgutil
 

--- a/src/sphinx_antsibull_ext/roles.py
+++ b/src/sphinx_antsibull_ext/roles.py
@@ -7,6 +7,8 @@
 Add roles for semantic markup.
 '''
 
+from __future__ import annotations
+
 import typing as t
 
 from docutils import nodes
@@ -91,9 +93,9 @@ def return_value_sample(name, rawtext, text, lineno, inliner, options={}, conten
     return [nodes.literal(rawtext, text, classes=['ansible-option-sample'])], []
 
 
-def _create_option_reference(plugin_fqcn: t.Optional[str], plugin_type: t.Optional[str],
-                             entrypoint: t.Optional[str],
-                             option: str) -> t.Optional[str]:
+def _create_option_reference(plugin_fqcn: str | None, plugin_type: str | None,
+                             entrypoint: str | None,
+                             option: str) -> str | None:
     if not plugin_fqcn or not plugin_type:
         return None
     ref = option.replace(".", "/")
@@ -101,9 +103,9 @@ def _create_option_reference(plugin_fqcn: t.Optional[str], plugin_type: t.Option
     return f'ansible_collections.{plugin_fqcn}_{plugin_type}__parameter-{ep}{ref}'
 
 
-def _create_return_value_reference(plugin_fqcn: t.Optional[str], plugin_type: t.Optional[str],
-                                   entrypoint: t.Optional[str],
-                                   return_value: str) -> t.Optional[str]:
+def _create_return_value_reference(plugin_fqcn: str | None, plugin_type: str | None,
+                                   entrypoint: str | None,
+                                   return_value: str) -> str | None:
     if not plugin_fqcn or not plugin_type:
         return None
     ref = return_value.replace(".", "/")
@@ -111,13 +113,13 @@ def _create_return_value_reference(plugin_fqcn: t.Optional[str], plugin_type: t.
     return f'ansible_collections.{plugin_fqcn}_{plugin_type}__return-{ep}{ref}'
 
 
-def _create_ref_or_not(create_ref: t.Callable[[t.Optional[str], t.Optional[str],
-                                               t.Optional[str], str],
-                                              t.Optional[str]],
-                       plugin_fqcn: t.Optional[str], plugin_type: t.Optional[str],
-                       entrypoint: t.Optional[str],
+def _create_ref_or_not(create_ref: t.Callable[[str | None, str | None,
+                                               str | None, str],
+                                              str | None],
+                       plugin_fqcn: str | None, plugin_type: str | None,
+                       entrypoint: str | None,
                        ref_parameter: str, text: str
-                       ) -> t.Tuple[str, t.List[t.Any]]:
+                       ) -> tuple[str, list[t.Any]]:
     ref = create_ref(plugin_fqcn, plugin_type, entrypoint, ref_parameter)
     if ref is None:
         return text, []
@@ -138,7 +140,7 @@ def _create_ref_or_not(create_ref: t.Callable[[t.Optional[str], t.Optional[str],
 
 
 # pylint:disable-next=unused-argument
-def _create_error(rawtext: str, text: str, error: str) -> t.Tuple[t.List[t.Any], t.List[str]]:
+def _create_error(rawtext: str, text: str, error: str) -> tuple[list[t.Any], list[str]]:
     node = ...  # FIXME
     return [node], []
 

--- a/stubs/ansible/constants.pyi
+++ b/stubs/ansible/constants.pyi
@@ -2,6 +2,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Tuple
 
-DOCUMENTABLE_PLUGINS: Tuple[str, ...]
+DOCUMENTABLE_PLUGINS: tuple[str, ...]

--- a/stubs/rstcheck.pyi
+++ b/stubs/rstcheck.pyi
@@ -2,14 +2,13 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import List, Optional, Tuple, Union
 
 import docutils.utils
 
 def check(source: str,
-          filename: Optional[str] = ...,
-          report_level: Union[docutils.utils.Reporter, int] = ...,
-          ignore: Union[dict, None] = ...,
-          debug: bool = ...) -> List[Tuple[int, str]]: ...
+          filename: str | None = ...,
+          report_level: docutils.utils.Reporter | int = ...,
+          ignore: dict | None = ...,
+          debug: bool = ...) -> list[tuple[int, str]]: ...
 
-def ignore_directives_and_roles(directives: List[str], roles: List[str]) -> None: ...
+def ignore_directives_and_roles(directives: list[str], roles: list[str]) -> None: ...

--- a/stubs/rstcheck_core/checker.pyi
+++ b/stubs/rstcheck_core/checker.pyi
@@ -2,9 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import enum
 import pathlib
-from typing import List, Optional, Tuple, Union
 
 from . import config, types
 
@@ -12,4 +10,4 @@ def check_file(
     source_file: pathlib.Path,
     rstcheck_config: config.RstcheckConfig,
     overwrite_with_file_config: bool = True,
-) -> List[types.LintError]: ...
+) -> list[types.LintError]: ...

--- a/stubs/rstcheck_core/config.pyi
+++ b/stubs/rstcheck_core/config.pyi
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import enum
-from typing import List, Optional, Tuple, Union
 
 class ReportLevel(enum.Enum):
     INFO = 1
@@ -16,9 +15,9 @@ class ReportLevel(enum.Enum):
 class RstcheckConfig:
     def __init__(
         self,
-        report_level: Optional[ReportLevel] = ...,
-        ignore_directives: Optional[List[str]] = ...,
-        ignore_roles: Optional[List[str]] = ...,
-        ignore_substitutions: Optional[List[str]] = ...,
-        ignore_languages: Optional[List[str]] = ...,
+        report_level: ReportLevel | None = ...,
+        ignore_directives: list[str] | None = ...,
+        ignore_roles: list[str] | None = ...,
+        ignore_substitutions: list[str] | None = ...,
+        ignore_languages: list[str] | None = ...,
     ): ...

--- a/stubs/rstcheck_core/types.pyi
+++ b/stubs/rstcheck_core/types.pyi
@@ -2,9 +2,8 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import enum
 import pathlib
-from typing import Literal, Union
+from typing import Literal
 
 try:
     from typing import TypedDict
@@ -13,6 +12,6 @@ except ImportError:
 
 
 class LintError(TypedDict):
-    source_origin: Union[pathlib.Path, Literal["<string>"], Literal["<stdin>"]]
+    source_origin: pathlib.Path | Literal["<string>"] | Literal["<stdin>"]
     line_number: int
     message: str

--- a/tests/functional/sanitize-ansible-doc-dump.py
+++ b/tests/functional/sanitize-ansible-doc-dump.py
@@ -3,11 +3,13 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import ansible
+from __future__ import annotations
+
 import json
 import os
 import sys
 
+import ansible
 
 root = os.path.join(os.getcwd(), 'collections')
 ansible_root = os.path.dirname(ansible.__file__)

--- a/tests/functional/sanitize-ansible-galaxy-list.py
+++ b/tests/functional/sanitize-ansible-galaxy-list.py
@@ -3,10 +3,11 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from __future__ import annotations
+
 import json
 import os
 import sys
-
 
 root = os.path.join(os.getcwd(), 'collections')
 data = json.load(sys.stdin)

--- a/tests/functional/schema/test_schema.py
+++ b/tests/functional/schema/test_schema.py
@@ -5,7 +5,8 @@
 """
 Test the set of Schemas altogether to see that they will parse information correctly.
 """
-import glob
+from __future__ import annotations
+
 import json
 import os.path
 
@@ -57,10 +58,10 @@ def test_one_plugin_of_each_type(test_file, test_schema):
     result_file = os.path.join(test_dir, 'good_data', 'one_%s_results.json' % plugin_type)
     full_path = os.path.join(test_dir, 'good_data', test_file)
 
-    with open(result_file, 'r') as f:
+    with open(result_file) as f:
         results = json.load(f)
 
-    with open(full_path, 'r') as f:
+    with open(full_path) as f:
         ansible_doc_output = f.read()
 
     model = test_schema.parse_raw(ansible_doc_output)
@@ -83,10 +84,10 @@ def test_ssh_connection():
     result_file = os.path.join(test_dir, 'good_data', 'ssh_connection_results.json')
     full_path = os.path.join(test_dir, 'good_data', test_file)
 
-    with open(result_file, 'r') as f:
+    with open(result_file) as f:
         results = json.load(f)
 
-    with open(full_path, 'r') as f:
+    with open(full_path) as f:
         ansible_doc_output = f.read()
 
     model = test_schema.parse_raw(ansible_doc_output)

--- a/tests/functional/test_docs_baseline.py
+++ b/tests/functional/test_docs_baseline.py
@@ -2,16 +2,17 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from __future__ import annotations
+
 import difflib
 import io
 import os
 from contextlib import redirect_stdout
 
 import pytest
+from ansible_doc_caching import ansible_doc_cache
 
 from antsibull_docs.cli.antsibull_docs import run
-
-from ansible_doc_caching import ansible_doc_cache
 
 pytest.importorskip('ansible')
 
@@ -48,9 +49,9 @@ def _scan_directories(root: str):
 
 
 def _compare_files(source, dest, path):
-    with open(source, 'rt') as f:
+    with open(source) as f:
         src = f.read()
-    with open(dest, 'rt') as f:
+    with open(dest) as f:
         dst = f.read()
     if src == dst:
         return 0
@@ -102,7 +103,7 @@ def test_baseline(arguments, directory, tmp_path):
     tests_root = os.path.join('tests', 'functional')
 
     config_file = tmp_path / 'antsibull.cfg'
-    with open(config_file, 'wt', encoding='utf-8') as f:
+    with open(config_file, "w", encoding='utf-8') as f:
         f.write('doc_parsing_backend = ansible-core-2.13\n')
 
     output_dir = tmp_path / 'output'

--- a/tests/functional/test_docs_linting.py
+++ b/tests/functional/test_docs_linting.py
@@ -2,15 +2,16 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from __future__ import annotations
+
 import io
 import os
 from contextlib import contextmanager, redirect_stdout
 
 import pytest
+from ansible_doc_caching import ansible_doc_cache
 
 from antsibull_docs.cli.antsibull_docs import run
-
-from ansible_doc_caching import ansible_doc_cache
 
 
 def write_file(path, content):
@@ -220,7 +221,7 @@ def test_lint_collection_plugin_docs(namespace, name, rc, errors, tmp_path):
 
     config_file = tmp_path / 'antsibull.cfg'
     print(config_file)
-    with open(config_file, 'wt', encoding='utf-8') as f:
+    with open(config_file, "w", encoding='utf-8') as f:
         f.write('doc_parsing_backend = ansible-core-2.13\n')
 
     command = [

--- a/tests/functional/test_sphinx_init_baseline.py
+++ b/tests/functional/test_sphinx_init_baseline.py
@@ -2,6 +2,8 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from __future__ import annotations
+
 import difflib
 import io
 import os
@@ -63,9 +65,9 @@ def _scan_directories(root: str):
 
 
 def _compare_files(source, dest, path):
-    with open(source, 'rt') as f:
+    with open(source) as f:
         src = f.read()
-    with open(dest, 'rt') as f:
+    with open(dest) as f:
         dst = f.read()
     if src == dst:
         return 0
@@ -127,7 +129,7 @@ def test_baseline(arguments, directory, tmp_path):
     try:
         # Adjust 'cd' in build.sh
         filename = os.path.join(tmp_path, 'build.sh')
-        with open(filename, 'r', encoding='utf-8') as f:
+        with open(filename, encoding='utf-8') as f:
             lines = list(f)
         for index, line in enumerate(lines):
             if line.startswith('cd '):

--- a/tests/units/markup/test_counter.py
+++ b/tests/units/markup/test_counter.py
@@ -4,14 +4,13 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # SPDX-FileCopyrightText: 2023, Ansible Project
 
-import typing as t
+
+from __future__ import annotations
 
 import pytest
-
 from antsibull_docs_parser import dom
 
 from antsibull_docs.markup._counter import count
-
 
 TEST_COUNTER = [
     (
@@ -118,6 +117,6 @@ TEST_COUNTER = [
 
 
 @pytest.mark.parametrize('paragraph, counter', TEST_COUNTER)
-def test_count(paragraph: dom.Paragraph, counter: t.Dict[str, int]) -> None:
+def test_count(paragraph: dom.Paragraph, counter: dict[str, int]) -> None:
     result = count([paragraph])
     assert result == counter

--- a/tests/units/markup/test_markup.py
+++ b/tests/units/markup/test_markup.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # SPDX-FileCopyrightText: 2020, Ansible Project
 
+from __future__ import annotations
+
 import pytest
 
 from antsibull_docs.markup.rstify import rst_escape, rst_ify

--- a/tests/units/test_jinja2.py
+++ b/tests/units/test_jinja2.py
@@ -2,9 +2,17 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # SPDX-FileCopyrightText: 2020, Ansible Project
 
+from __future__ import annotations
+
 import pytest
 
-from antsibull_docs.jinja2.filters import massage_author_name, move_first, to_ini_value, to_json, rst_ify
+from antsibull_docs.jinja2.filters import (
+    massage_author_name,
+    move_first,
+    rst_ify,
+    to_ini_value,
+    to_json,
+)
 
 RST_IFY_DATA = {
     # No substitutions

--- a/tests/validate-html.py
+++ b/tests/validate-html.py
@@ -3,6 +3,8 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from __future__ import annotations
+
 import os
 import sys
 


### PR DESCRIPTION
Update to the modern type annotation syntax instead of using the generics in the `typing` module. All of the files except those that import pydantic use `from __future__ import annotations`.

As part of this change, I ran isort over the whole codebase.