### PR TITLE
Fix wrong typings

### DIFF
--- a/src/antsibull_docs/cli/doc_commands/collection.py
+++ b/src/antsibull_docs/cli/doc_commands/collection.py
@@ -12,7 +12,6 @@ import asyncio
 import os
 import os.path
 import tempfile
-import typing as t
 
 import aiohttp
 import asyncio_pool  # type: ignore[import]
@@ -23,10 +22,6 @@ from antsibull_core.venv import FakeVenvRunner
 
 from ... import app_context
 from ._build import generate_docs_for_all_collections
-
-if t.TYPE_CHECKING:
-    import semantic_version as semver
-
 
 mlog = log.fields(mod=__name__)
 
@@ -52,7 +47,7 @@ async def retrieve(collections: list[str],
                    collection_version: str | None,
                    tmp_dir: str,
                    galaxy_server: str,
-                   collection_cache: str | None = None) -> dict[str, semver.Version]:
+                   collection_cache: str | None = None) -> dict[str, str]:
     """
     Download collections, with specified version if applicable.
 

--- a/src/antsibull_docs/cli/doc_commands/devel.py
+++ b/src/antsibull_docs/cli/doc_commands/devel.py
@@ -11,7 +11,6 @@ import asyncio
 import os
 import os.path
 import tempfile
-import typing as t
 
 import aiohttp
 import asyncio_pool  # type: ignore[import]
@@ -25,10 +24,6 @@ from antsibull_core.venv import FakeVenvRunner, VenvRunner
 from ... import app_context
 from ._build import generate_docs_for_all_collections
 
-if t.TYPE_CHECKING:
-    import semantic_version as semver
-
-
 mlog = log.fields(mod=__name__)
 
 
@@ -38,7 +33,7 @@ async def retrieve(collections: list[str],
                    ansible_core_source: str | None = None,
                    collection_cache: str | None = None,
                    use_installed_ansible_core: bool = False,
-                   ) -> dict[str, semver.Version]:
+                   ) -> dict[str, str]:
     """
     Download ansible-core and the latest versions of the collections.
 

--- a/src/antsibull_docs/cli/doc_commands/stable.py
+++ b/src/antsibull_docs/cli/doc_commands/stable.py
@@ -11,7 +11,6 @@ import asyncio
 import os
 import os.path
 import tempfile
-import typing as t
 from collections.abc import Mapping
 
 import aiohttp
@@ -26,10 +25,6 @@ from antsibull_core.venv import FakeVenvRunner, VenvRunner
 from ... import app_context
 from ._build import generate_docs_for_all_collections
 
-if t.TYPE_CHECKING:
-    import semantic_version as semver
-
-
 mlog = log.fields(mod=__name__)
 
 
@@ -40,7 +35,7 @@ async def retrieve(ansible_core_version: str,
                    ansible_core_source: str | None = None,
                    collection_cache: str | None = None,
                    use_installed_ansible_core: bool = False,
-                   ) -> dict[str, semver.Version]:
+                   ) -> dict[str, str]:
     """
     Download ansible-core and the collections.
 


### PR DESCRIPTION
For some reason the `retrieve()` functions claimed to return versions and not paths. And for some other (unknown) reasons, the type checkers didn't complain that a list of versions was passed when a list of strings was expected.

I suddenly started to get error messages locally that I didn't see in CI:
```
src/antsibull_docs/cli/doc_commands/collection.py:141:37 Incompatible parameter type [6]: In call `install_together`, for 1st positional argument, expected `List[str]` but got `List[Version]`.
src/antsibull_docs/cli/doc_commands/devel.py:144:37 Incompatible parameter type [6]: In call `install_together`, for 1st positional argument, expected `List[str]` but got `List[Version]`.
src/antsibull_docs/cli/doc_commands/devel.py:153:33 Incompatible parameter type [6]: In call `VenvRunner.install_package`, for 1st positional argument, expected `str` but got `Version`.
src/antsibull_docs/cli/doc_commands/stable.py:146:37 Incompatible parameter type [6]: In call `install_together`, for 1st positional argument, expected `List[str]` but got `List[Version]`.
src/antsibull_docs/cli/doc_commands/stable.py:155:33 Incompatible parameter type [6]: In call `VenvRunner.install_package`, for 1st positional argument, expected `str` but got `Version`.
```