### PR TITLE
nox typing: always install self in editable mode

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -132,7 +132,8 @@ def codeqa(session: nox.Session):
 @nox.session
 def typing(session: nox.Session):
     others = other_antsibull()
-    install(session, ".[typing]", *others, editable=True)
+    # pyre does not work when we don't install ourself in editable mode 🙄.
+    install(session, "-e", ".[typing]", *others)
     session.run("mypy", "src/antsibull_docs", "src/sphinx_antsibull_ext")
 
     additional_libraries = []


### PR DESCRIPTION
pyre does not work when we don't install ourself in editable mode.
