### PR TITLE
CI: remove in valid GHA parameters

### DIFF
--- a/.github/workflows/antsibull-docs.yml
+++ b/.github/workflows/antsibull-docs.yml
@@ -137,7 +137,7 @@ jobs:
       - name: Upload coverage
         uses: codecov/codecov-action@v3
         with:
-          working-directory: antsibull-docs
+          directory: antsibull-docs
 
   build-stable:
     name: 'Build stable docsite'
@@ -193,7 +193,7 @@ jobs:
       - name: Upload coverage
         uses: codecov/codecov-action@v3
         with:
-          working-directory: antsibull-docs
+          directory: antsibull-docs
 
   build-devel:
     name: 'Build devel docsite'
@@ -249,4 +249,4 @@ jobs:
       - name: Upload coverage
         uses: codecov/codecov-action@v3
         with:
-          working-directory: antsibull-docs
+          directory: antsibull-docs

--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -82,4 +82,4 @@ jobs:
       - name: Upload coverage
         uses: codecov/codecov-action@v3
         with:
-          working-directory: antsibull-docs
+          directory: antsibull-docs


### PR DESCRIPTION
- The `codecov/codecov-action` GHA action does not support a `working-directory` option, it's called `directory` instead.