### PR TITLE
Bump antsibull-docs-parser requirement to 1.x.y

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "ansible-pygments",
     # TODO: bump to >= 2.0.0
     "antsibull-core >= 2.0.0a2, < 3.0.0",
-    "antsibull-docs-parser ~= 0.4.0",
+    "antsibull-docs-parser >= 1.0.0, < 2.0.0",
     "asyncio-pool",
     "docutils",
     "jinja2 >= 3.0",


### PR DESCRIPTION
Now that antsibull-docs-parser 1.0.0 has been released. This will be the last such PRs for some time, since the range now covers all versions of the `main` branch of antsibull-docs-parser until we start preparing 2.0.0 of it. (If we ever do.)