### PR TITLE
Setting default contents of the description key of the role endpoint schema

### DIFF
--- a/src/antsibull_docs/schemas/docs/role.py
+++ b/src/antsibull_docs/schemas/docs/role.py
@@ -50,7 +50,7 @@ class RoleOptionsSchema(OptionsSchema):
 class RoleEntrypointSchema(BaseModel):
     """Documentation for role entrypoints."""
 
-    description: list[str]
+    description: list[str] = []
     short_description: str
     author: list[str] = []
     deprecated: DeprecationSchema = p.Field({})


### PR DESCRIPTION
Existing ansible role documentation doesn't imply that the key is required. In fact the examples seem to indicate the opposite [0].

This is potentially confusing to developers working on documenting their ansible collections.

The proposed change should simplify implementing new argument specs. 

[0] https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_reuse_roles.html#sample-specification