### PR TITLE
Semantic markup validator: also consider option aliases

### DIFF
--- a/changelogs/fragments/155-aliases.yml
+++ b/changelogs/fragments/155-aliases.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "When linting semantic markup in collection docs, also accept aliases when checking ``O()`` values (https://github.com/ansible-community/antsibull-docs/pull/155)."

--- a/tests/functional/ansible-doc-cache-all.json
+++ b/tests/functional/ansible-doc-cache-all.json
@@ -1546,13 +1546,20 @@
        "type": "str"
       },
       "subfoo": {
+       "aliases": [
+        "subbaz"
+       ],
        "description": "Some recursive foo.",
        "suboptions": {
         "foo": {
+         "aliases": [
+          "bam"
+         ],
          "description": [
           "A sub foo.",
           "Whatever.",
-          "Also required when O(subfoo) is specified when O(foo=bar) or V(baz)."
+          "Also required when O(subfoo) is specified when O(foo=bar) or V(baz).",
+          "Note that O(subfoo.foo) is the same as O(subbaz.foo), O(subbaz.bam), and O(subfoo.bam)."
          ],
          "required": true,
          "type": "str"

--- a/tests/functional/ansible-doc-cache-ns2.flatcol.json
+++ b/tests/functional/ansible-doc-cache-ns2.flatcol.json
@@ -677,13 +677,20 @@
        "type": "str"
       },
       "subfoo": {
+       "aliases": [
+        "subbaz"
+       ],
        "description": "Some recursive foo.",
        "suboptions": {
         "foo": {
+         "aliases": [
+          "bam"
+         ],
          "description": [
           "A sub foo.",
           "Whatever.",
-          "Also required when O(subfoo) is specified when O(foo=bar) or V(baz)."
+          "Also required when O(subfoo) is specified when O(foo=bar) or V(baz).",
+          "Note that O(subfoo.foo) is the same as O(subbaz.foo), O(subbaz.bam), and O(subfoo.bam)."
          ],
          "required": true,
          "type": "str"

--- a/tests/functional/ansible-version.output
+++ b/tests/functional/ansible-version.output
@@ -1,9 +1,9 @@
-ansible [core 2.16.0.dev0] (devel abc58c026b) last updated 2023/04/25 07:58:13 (GMT +200)
+ansible [core 2.16.0.dev0] (devel 3a1d58bc58) last updated 2023/05/29 15:34:09 (GMT +200)
   config file = None
   configured module search path = ['<<<<<HOME>>>>>/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
   ansible python module location = <<<<<ANSIBLE>>>>>
   ansible collection location = <<<<<COLLECTIONS>>>>>
   executable location = <<<<<HOME>>>>>/.local/bin/ansible
-  python version = 3.10.10 (main, Mar  5 2023, 22:26:53) [GCC 12.2.1 20230201] (/usr/bin/python)
+  python version = 3.11.3 (main, Apr  5 2023, 15:52:25) [GCC 12.2.1 20230201] (/usr/bin/python)
   jinja version = 3.1.2
   libyaml = True

--- a/tests/functional/baseline-default/collections/ns2/flatcol/foo_module.rst
+++ b/tests/functional/baseline-default/collections/ns2/flatcol/foo_module.rst
@@ -177,7 +177,9 @@ Parameters
 
         <div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="parameter-subfoo"></div>
+        <div class="ansibleOptionAnchor" id="parameter-subbaz"></div>
 
+      .. _ansible_collections.ns2.flatcol.foo_module__parameter-subbaz:
       .. _ansible_collections.ns2.flatcol.foo_module__parameter-subfoo:
 
       .. rst-class:: ansible-option-title
@@ -187,6 +189,10 @@ Parameters
       .. raw:: html
 
         <a class="ansibleOptionLink" href="#parameter-subfoo" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-aliases:`aliases: subbaz`
 
       .. rst-class:: ansible-option-type-line
 
@@ -214,7 +220,13 @@ Parameters
 
         <div class="ansible-option-indent"></div><div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="parameter-subfoo/foo"></div>
+        <div class="ansibleOptionAnchor" id="parameter-subbaz/foo"></div>
+        <div class="ansibleOptionAnchor" id="parameter-subfoo/bam"></div>
+        <div class="ansibleOptionAnchor" id="parameter-subbaz/bam"></div>
 
+      .. _ansible_collections.ns2.flatcol.foo_module__parameter-subbaz/bam:
+      .. _ansible_collections.ns2.flatcol.foo_module__parameter-subbaz/foo:
+      .. _ansible_collections.ns2.flatcol.foo_module__parameter-subfoo/bam:
       .. _ansible_collections.ns2.flatcol.foo_module__parameter-subfoo/foo:
 
       .. rst-class:: ansible-option-title
@@ -224,6 +236,10 @@ Parameters
       .. raw:: html
 
         <a class="ansibleOptionLink" href="#parameter-subfoo/foo" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-aliases:`aliases: bam`
 
       .. rst-class:: ansible-option-type-line
 
@@ -242,6 +258,8 @@ Parameters
       Whatever.
 
       Also required when \ :ansopt:`ns2.flatcol.foo#module:subfoo`\  is specified when \ :ansopt:`ns2.flatcol.foo#module:foo=bar`\  or \ :ansval:`baz`\ .
+
+      Note that \ :ansopt:`ns2.flatcol.foo#module:subfoo.foo`\  is the same as \ :ansopt:`ns2.flatcol.foo#module:subbaz.foo`\ , \ :ansopt:`ns2.flatcol.foo#module:subbaz.bam`\ , and \ :ansopt:`ns2.flatcol.foo#module:subfoo.bam`\ .
 
 
       .. raw:: html

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/flatcol/foo_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/flatcol/foo_module.rst
@@ -177,7 +177,9 @@ Parameters
 
         <div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="parameter-subfoo"></div>
+        <div class="ansibleOptionAnchor" id="parameter-subbaz"></div>
 
+      .. _ansible_collections.ns2.flatcol.foo_module__parameter-subbaz:
       .. _ansible_collections.ns2.flatcol.foo_module__parameter-subfoo:
 
       .. rst-class:: ansible-option-title
@@ -187,6 +189,10 @@ Parameters
       .. raw:: html
 
         <a class="ansibleOptionLink" href="#parameter-subfoo" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-aliases:`aliases: subbaz`
 
       .. rst-class:: ansible-option-type-line
 
@@ -214,7 +220,13 @@ Parameters
 
         <div class="ansible-option-indent"></div><div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="parameter-subfoo/foo"></div>
+        <div class="ansibleOptionAnchor" id="parameter-subbaz/foo"></div>
+        <div class="ansibleOptionAnchor" id="parameter-subfoo/bam"></div>
+        <div class="ansibleOptionAnchor" id="parameter-subbaz/bam"></div>
 
+      .. _ansible_collections.ns2.flatcol.foo_module__parameter-subbaz/bam:
+      .. _ansible_collections.ns2.flatcol.foo_module__parameter-subbaz/foo:
+      .. _ansible_collections.ns2.flatcol.foo_module__parameter-subfoo/bam:
       .. _ansible_collections.ns2.flatcol.foo_module__parameter-subfoo/foo:
 
       .. rst-class:: ansible-option-title
@@ -224,6 +236,10 @@ Parameters
       .. raw:: html
 
         <a class="ansibleOptionLink" href="#parameter-subfoo/foo" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-aliases:`aliases: bam`
 
       .. rst-class:: ansible-option-type-line
 
@@ -242,6 +258,8 @@ Parameters
       Whatever.
 
       Also required when \ :ansopt:`ns2.flatcol.foo#module:subfoo`\  is specified when \ :ansopt:`ns2.flatcol.foo#module:foo=bar`\  or \ :ansval:`baz`\ .
+
+      Note that \ :ansopt:`ns2.flatcol.foo#module:subfoo.foo`\  is the same as \ :ansopt:`ns2.flatcol.foo#module:subbaz.foo`\ , \ :ansopt:`ns2.flatcol.foo#module:subbaz.bam`\ , and \ :ansopt:`ns2.flatcol.foo#module:subfoo.bam`\ .
 
 
       .. raw:: html

--- a/tests/functional/baseline-no-indexes/collections/ns2/flatcol/foo_module.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/flatcol/foo_module.rst
@@ -177,7 +177,9 @@ Parameters
 
         <div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="parameter-subfoo"></div>
+        <div class="ansibleOptionAnchor" id="parameter-subbaz"></div>
 
+      .. _ansible_collections.ns2.flatcol.foo_module__parameter-subbaz:
       .. _ansible_collections.ns2.flatcol.foo_module__parameter-subfoo:
 
       .. rst-class:: ansible-option-title
@@ -187,6 +189,10 @@ Parameters
       .. raw:: html
 
         <a class="ansibleOptionLink" href="#parameter-subfoo" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-aliases:`aliases: subbaz`
 
       .. rst-class:: ansible-option-type-line
 
@@ -214,7 +220,13 @@ Parameters
 
         <div class="ansible-option-indent"></div><div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="parameter-subfoo/foo"></div>
+        <div class="ansibleOptionAnchor" id="parameter-subbaz/foo"></div>
+        <div class="ansibleOptionAnchor" id="parameter-subfoo/bam"></div>
+        <div class="ansibleOptionAnchor" id="parameter-subbaz/bam"></div>
 
+      .. _ansible_collections.ns2.flatcol.foo_module__parameter-subbaz/bam:
+      .. _ansible_collections.ns2.flatcol.foo_module__parameter-subbaz/foo:
+      .. _ansible_collections.ns2.flatcol.foo_module__parameter-subfoo/bam:
       .. _ansible_collections.ns2.flatcol.foo_module__parameter-subfoo/foo:
 
       .. rst-class:: ansible-option-title
@@ -224,6 +236,10 @@ Parameters
       .. raw:: html
 
         <a class="ansibleOptionLink" href="#parameter-subfoo/foo" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-aliases:`aliases: bam`
 
       .. rst-class:: ansible-option-type-line
 
@@ -242,6 +258,8 @@ Parameters
       Whatever.
 
       Also required when \ :ansopt:`ns2.flatcol.foo#module:subfoo`\  is specified when \ :ansopt:`ns2.flatcol.foo#module:foo=bar`\  or \ :ansval:`baz`\ .
+
+      Note that \ :ansopt:`ns2.flatcol.foo#module:subfoo.foo`\  is the same as \ :ansopt:`ns2.flatcol.foo#module:subbaz.foo`\ , \ :ansopt:`ns2.flatcol.foo#module:subbaz.bam`\ , and \ :ansopt:`ns2.flatcol.foo#module:subfoo.bam`\ .
 
 
       .. raw:: html

--- a/tests/functional/collections/ansible_collections/ns2/flatcol/plugins/modules/foo.py
+++ b/tests/functional/collections/ansible_collections/ns2/flatcol/plugins/modules/foo.py
@@ -83,9 +83,13 @@ def main():
         argument_spec=dict(
             foo=dict(type="str", required=True),
             bar=dict(type="list", elements="int", aliases=["baz"]),
-            subfoo=dict(type="dict", aliases=["subbaz"], options=dict(
-                foo=dict(type="str", required=True, aliases=["bam"]),
-            )),
+            subfoo=dict(
+                type="dict",
+                aliases=["subbaz"],
+                options=dict(
+                    foo=dict(type="str", required=True, aliases=["bam"]),
+                ),
+            ),
         ),
         supports_check_mode=True,
     )

--- a/tests/functional/collections/ansible_collections/ns2/flatcol/plugins/modules/foo.py
+++ b/tests/functional/collections/ansible_collections/ns2/flatcol/plugins/modules/foo.py
@@ -37,14 +37,19 @@ options:
         description: Some recursive foo.
         version_added: 2.0.0
         type: dict
+        aliases:
+          - subbaz
         suboptions:
             foo:
                 description:
                     - A sub foo.
                     - Whatever.
                     - Also required when O(subfoo) is specified when O(foo=bar) or V(baz).
+                    - Note that O(subfoo.foo) is the same as O(subbaz.foo), O(subbaz.bam), and O(subfoo.bam).
                 type: str
                 required: true
+                aliases:
+                  - bam
 """
 
 EXAMPLES = """
@@ -78,7 +83,9 @@ def main():
         argument_spec=dict(
             foo=dict(type="str", required=True),
             bar=dict(type="list", elements="int", aliases=["baz"]),
-            subfoo=dict(type="dict", options=dict(foo=dict(type="str", required=True))),
+            subfoo=dict(type="dict", aliases=["subbaz"], options=dict(
+                foo=dict(type="str", required=True, aliases=["bam"]),
+            )),
         ),
         supports_check_mode=True,
     )


### PR DESCRIPTION
Right now something like
```yaml
   username:
     description:
     - Username that will be used to authenticate against InfluxDB server.
     - Alias O(login_username) added in Ansible 2.5.
     type: str
     default: root
     aliases: [ login_username ]
```
will cause validation to fail, since `login_username` is not considered a module/plugin option. (The validation in `ansible-test sanity --test validate-modules` already accepts this, so this PR makes the checks more similar.)