### PR TITLE
Functional tests: use better paths

### DIFF
--- a/tests/functional/test_docs_linting.py
+++ b/tests/functional/test_docs_linting.py
@@ -248,7 +248,7 @@ def change_cwd(directory):
 
 @pytest.mark.parametrize("namespace, name, rc, errors", TEST_CASES)
 def test_lint_collection_plugin_docs(namespace, name, rc, errors, tmp_path):
-    tests_root = os.path.join("tests", "functional")
+    tests_root = os.path.dirname(__file__)
     collection_root = os.path.join(
         tests_root, "collections", "ansible_collections", namespace, name
     )

--- a/tests/functional/test_sphinx_init_baseline.py
+++ b/tests/functional/test_sphinx_init_baseline.py
@@ -32,7 +32,7 @@ TEST_CASES = [
             "--lenient",
             "--fail-on-error",
             "--index-rst-source",
-            "tests/functional/test.rst",
+            os.path.join(os.path.dirname(__file__), "test.rst"),
             "--intersphinx",
             "identifier:https://server/path",
             "--intersphinx",
@@ -134,7 +134,7 @@ def _compare_directories(source, dest):
 
 @pytest.mark.parametrize("arguments, directory", TEST_CASES)
 def test_baseline(arguments, directory, tmp_path):
-    tests_root = os.path.join("tests", "functional")
+    tests_root = os.path.dirname(__file__)
 
     # Re-build baseline
     command = ["antsibull-docs", "sphinx-init", "--dest-dir", str(tmp_path)] + arguments


### PR DESCRIPTION
I am experiencing some trouble running tests locally. This seems to fix it.

I wonder whether there's a new nox/pytest/... version that is doing something different than before...