### PR TITLE
Fix dict modifying error

### DIFF
--- a/changelogs/fragments/169-seealso-desc-copying.yml
+++ b/changelogs/fragments/169-seealso-desc-copying.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "When trying to copying descriptions of non-existing plugins to ``seealso``, references to these non-existing plugins were added in some cases, crashing the docs augmentation process (https://github.com/ansible-community/antsibull-docs/pull/169)."

--- a/src/antsibull_docs/augment_docs.py
+++ b/src/antsibull_docs/augment_docs.py
@@ -83,6 +83,10 @@ def _add_seealso(
             plugin_type = entry["plugin_type"]
         else:
             continue
+        if plugin_type not in plugin_info or plugin not in plugin_info[plugin_type]:
+            # We cannot use KeyError in the following try/except since plugin_info could
+            # be a defaultdict, which effectively creates new entries.
+            continue
         try:
             desc = plugin_info[plugin_type][plugin]["doc"]["short_description"]
         except (KeyError, TypeError):


### PR DESCRIPTION
The construct
```
try:
  foo[bar]...
except KeyError:
  ...
```
is dangerous: if `foo` is a `defaultdict`, you end up with a new entry, instead of the `except` handler being executed. In case of docs augmentation, this can lead to a crash if a seealso without description is present for a non-existing plugin/module.