### PR TITLE
Fix codecov paths

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,3 +5,6 @@
 
 github_checks:
   annotations: false
+
+fixes:
+  - "antsibull-docs/::"


### PR DESCRIPTION
The web UI cannot show code coverage based on lines since there is an additional antsibull-docs/ prefix for the paths.