### PR TITLE
Add plugin reference role to the Sphinx extension and use it

### DIFF
--- a/changelogs/fragments/180-plugin-role.yml
+++ b/changelogs/fragments/180-plugin-role.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Add a ``:ansplugin:`` role to the Sphinx extension. This allows to reference a module, plugin, or role with the ``fqcn#type`` syntax from semantic markup instead of having to manually compose a ``ansible_collections.{fqcn}_{type}`` label (https://github.com/ansible-community/antsibull-docs/pull/180)."

--- a/changelogs/fragments/180-plugin-role.yml
+++ b/changelogs/fragments/180-plugin-role.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - "Add a ``:ansplugin:`` role to the Sphinx extension. This allows to reference a module, plugin, or role with the ``fqcn#type`` syntax from semantic markup instead of having to manually compose a ``ansible_collections.{fqcn}_{type}`` label (https://github.com/ansible-community/antsibull-docs/pull/180)."
+  - "Add a ``:ansplugin:`` role to the Sphinx extension. This allows to reference a module, plugin, or role with the ``fqcn#type`` syntax from semantic markup instead of having to manually compose a ``ansible_collections.{fqcn}_{type}`` label. An explicit reference title can also be provided with the ``title <fqcn#type>`` syntax similar to the ``:ref:`` role (https://github.com/ansible-community/antsibull-docs/pull/180)."

--- a/src/antsibull_docs/data/docsite/ansible-docsite/list_of_callback_plugins.rst.j2
+++ b/src/antsibull_docs/data/docsite/ansible-docsite/list_of_callback_plugins.rst.j2
@@ -18,7 +18,7 @@ See :ref:`list_of_callback_plugins` for the list of *all* callback plugins.
 @{ '-' * (collection_name | length) }@
 
 {%   for plugin_name, plugin_desc in plugins.items() | sort %}
-* :ref:`@{ collection_name }@.@{ plugin_name }@ <ansible_collections.@{ collection_name }@.@{ plugin_name }@_callback>` -- @{ plugin_desc | rst_ify(plugin_fqcn=collection_name ~ '.' ~ plugin_name, plugin_type='callback') }@
+* :ansplugin:`@{ collection_name }@.@{ plugin_name }@#callback` -- @{ plugin_desc | rst_ify(plugin_fqcn=collection_name ~ '.' ~ plugin_name, plugin_type='callback') }@
 {%   endfor %}
 
 {% else %}

--- a/src/antsibull_docs/data/docsite/ansible-docsite/list_of_env_variables.rst.j2
+++ b/src/antsibull_docs/data/docsite/ansible-docsite/list_of_env_variables.rst.j2
@@ -30,7 +30,7 @@ Environment variables used by the ansible-core configuration are documented in :
 {%     endfor %}
 {%   endfor %}
 {%   for plugin_name, plugin_type in plugins_ | unique | sort %}
-    :ref:`@{ plugin_name | rst_escape }@ {% if plugin_type == 'module' %}module{% else %}@{ plugin_type }@ plugin{% endif %} <ansible_collections.@{ plugin_name }@_@{ plugin_type }@>`
+    :ansplugin:`@{ plugin_name | rst_escape }@ {% if plugin_type == 'module' %}module{% else %}@{ plugin_type }@ plugin{% endif %} <@{ plugin_name }@#@{ plugin_type }@>`
 {%-    if not loop.last -%}
 ,
 {%     endif -%}

--- a/src/antsibull_docs/data/docsite/ansible-docsite/list_of_plugins.rst.j2
+++ b/src/antsibull_docs/data/docsite/ansible-docsite/list_of_plugins.rst.j2
@@ -34,7 +34,7 @@ Index of all @{ plugin_type | capitalize }@ Plugins
 @{ '-' * (collection_name | length) }@
 
 {%   for plugin_name, plugin_desc in plugins.items() | sort %}
-* :ref:`@{ collection_name }@.@{ plugin_name }@ <ansible_collections.@{ collection_name }@.@{ plugin_name }@_@{ plugin_type }@>` -- @{ plugin_desc | rst_ify(plugin_fqcn=collection_name ~ '.' ~ plugin_name, plugin_type=plugin_type) }@
+* :ansplugin:`@{ collection_name }@.@{ plugin_name }@#@{ plugin_type }@` -- @{ plugin_desc | rst_ify(plugin_fqcn=collection_name ~ '.' ~ plugin_name, plugin_type=plugin_type) }@
 {%   endfor %}
 
 {% else %}

--- a/src/antsibull_docs/data/docsite/ansible-docsite/plugin-redirect.rst.j2
+++ b/src/antsibull_docs/data/docsite/ansible-docsite/plugin-redirect.rst.j2
@@ -48,7 +48,7 @@
   It will eventually be removed from @{ collection_name }@.
 {%   endif %}
 {% endif %}
-- This is a redirect to the :ref:`@{ redirect }@ {% if plugin_type == 'module' %}module{% else %}@{ plugin_type }@ plugin{% endif %} <ansible_collections.@{ redirect }@_@{ plugin_type }@>`.
+- This is a redirect to the :ansplugin:`@{ redirect }@ {% if plugin_type == 'module' %}module{% else %}@{ plugin_type }@ plugin{% endif %} <@{ redirect }@#@{ plugin_type }@>`.
 {% if collection != 'ansible.builtin' -%}
 {%   if redirect_is_symlink %}
 - This redirect also works with Ansible 2.9.

--- a/src/antsibull_docs/data/docsite/ansible-docsite/plugins_by_collection.rst.j2
+++ b/src/antsibull_docs/data/docsite/ansible-docsite/plugins_by_collection.rst.j2
@@ -10,7 +10,7 @@
 
 {% macro list_plugins(plugin_type) %}
 {%   for name, desc in plugin_maps[plugin_type].items() | sort %}
-* :ref:`@{ name }@ @{ plugin_type }@ <ansible_collections.@{ collection_name }@.@{ name }@_@{ plugin_type }@>` -- @{ desc | rst_ify(plugin_fqcn=collection_name ~ '.' ~ name, plugin_type=plugin_type) | indent(width=2) }@
+* :ansplugin:`@{ name }@ @{ plugin_type }@ <@{ collection_name }@.@{ name }@#@{ plugin_type }@>` -- @{ desc | rst_ify(plugin_fqcn=collection_name ~ '.' ~ name, plugin_type=plugin_type) | indent(width=2) }@
 {%   endfor %}
 {%   if breadcrumbs %}
 

--- a/src/antsibull_docs/markup/semantic_helper.py
+++ b/src/antsibull_docs/markup/semantic_helper.py
@@ -13,6 +13,7 @@ import re
 
 _ARRAY_STUB_RE = re.compile(r"\[([^\]]*)\]")
 _ARRAY_STUB_SEP_START_RE = re.compile(r"[\[.]")
+_FQCN_TYPE_RE = re.compile(r"^([^.]+\.[^.]+\.[^#]+)#([a-z]+)$")
 _FQCN_TYPE_PREFIX_RE = re.compile(r"^([^.]+\.[^.]+\.[^#]+)#([a-z]+):(.*)$")
 _IGNORE_MARKER = "ignore:"
 
@@ -123,3 +124,10 @@ def split_option_like_name(name: str) -> list[tuple[str, str | None]]:
             f" at position {index + 1} of {name!r}"
         )
     return result
+
+
+def parse_plugin_name(text: str) -> tuple[str, str]:
+    m = _FQCN_TYPE_RE.match(text)
+    if not m:
+        raise ValueError("Cannot extract plugin name and type")
+    return m.group(1), m.group(2)

--- a/src/sphinx_antsibull_ext/roles.py
+++ b/src/sphinx_antsibull_ext/roles.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import typing as t
 
 from docutils import nodes
+from docutils.utils import unescape  # pyre-ignore[21]
 from sphinx import addnodes
 
 from antsibull_docs.markup.semantic_helper import (
@@ -20,6 +21,8 @@ from antsibull_docs.markup.semantic_helper import (
     parse_return_value,
 )
 from antsibull_docs.utils.rst import massage_rst_label
+
+from .sphinx_helper import extract_explicit_title
 
 
 def _plugin_ref(plugin_fqcn: str, plugin_type: str) -> str:
@@ -182,7 +185,7 @@ def option_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     classes = []
     try:
         plugin_fqcn, plugin_type, entrypoint, option_link, option, value = parse_option(
-            text.replace("\x00", ""), "", "", require_plugin=False
+            unescape(text), "", "", require_plugin=False
         )
     except ValueError as exc:
         return _create_error(rawtext, text, str(exc))
@@ -243,7 +246,7 @@ def return_value_role(name, rawtext, text, lineno, inliner, options={}, content=
     classes = ["ansible-return-value"]
     try:
         plugin_fqcn, plugin_type, entrypoint, rv_link, rv, value = parse_return_value(
-            text.replace("\x00", ""), "", "", require_plugin=False
+            unescape(text), "", "", require_plugin=False
         )
     except ValueError as exc:
         return _create_error(rawtext, text, str(exc))
@@ -293,7 +296,7 @@ def environment_variable_reference(
     content=[],
 ):
     # Extract the name of the environment variable
-    ref = text.replace("\x00", "").split("=", 1)[0].strip()
+    ref = unescape(text).split("=", 1)[0].strip()
 
     classes = ["xref", "std", "std-envvar"]
     content = nodes.literal(rawtext, text, classes=classes)
@@ -326,10 +329,15 @@ def plugin_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     :param options: Directive options for customization.
     :param content: The directive content for customization.
     """
+    target, title = extract_explicit_title(text)
+
     try:
-        plugin_fqcn, plugin_type = parse_plugin_name(text.replace("\x00", ""))
+        plugin_fqcn, plugin_type = parse_plugin_name(target)
     except ValueError as exc:
         return _create_error(rawtext, text, str(exc))
+
+    if title is None:
+        title = plugin_fqcn
 
     options = {
         "reftype": "ref",
@@ -338,7 +346,7 @@ def plugin_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
         "refwarn": True,
     }
     refnode = addnodes.pending_xref(
-        plugin_fqcn, nodes.inline(rawtext, plugin_fqcn), **options
+        plugin_fqcn, nodes.inline(rawtext, title), **options
     )
     refnode["reftarget"] = _plugin_ref(plugin_fqcn, plugin_type)
 

--- a/src/sphinx_antsibull_ext/roles.py
+++ b/src/sphinx_antsibull_ext/roles.py
@@ -14,8 +14,16 @@ import typing as t
 from docutils import nodes
 from sphinx import addnodes
 
-from antsibull_docs.markup.semantic_helper import parse_option, parse_return_value
+from antsibull_docs.markup.semantic_helper import (
+    parse_option,
+    parse_plugin_name,
+    parse_return_value,
+)
 from antsibull_docs.utils.rst import massage_rst_label
+
+
+def _plugin_ref(plugin_fqcn: str, plugin_type: str) -> str:
+    return f"ansible_collections.{plugin_fqcn}_{plugin_type}"
 
 
 # pylint:disable-next=unused-argument,dangerous-default-value
@@ -104,7 +112,7 @@ def _create_option_reference(
         return None
     ref = massage_rst_label(option.replace(".", "/"))
     ep = f"{entrypoint}__" if entrypoint is not None else ""
-    return f"ansible_collections.{plugin_fqcn}_{plugin_type}__parameter-{ep}{ref}"
+    return f"{_plugin_ref(plugin_fqcn, plugin_type)}__parameter-{ep}{ref}"
 
 
 def _create_return_value_reference(
@@ -117,7 +125,7 @@ def _create_return_value_reference(
         return None
     ref = massage_rst_label(return_value.replace(".", "/"))
     ep = f"{entrypoint}__" if entrypoint is not None else ""
-    return f"ansible_collections.{plugin_fqcn}_{plugin_type}__return-{ep}{ref}"
+    return f"{_plugin_ref(plugin_fqcn, plugin_type)}__return-{ep}{ref}"
 
 
 def _create_ref_or_not(
@@ -302,6 +310,41 @@ def environment_variable_reference(
     return [refnode], []
 
 
+# pylint:disable-next=unused-argument,dangerous-default-value
+def plugin_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
+    """Format Ansible plugin.
+
+    Returns 2 part tuple containing list of nodes to insert into the
+    document and a list of system messages.  Both are allowed to be
+    empty.
+
+    :param name: The role name used in the document.
+    :param rawtext: The entire markup snippet, with role.
+    :param text: The text marked with the role.
+    :param lineno: The line number where rawtext appears in the input.
+    :param inliner: The inliner instance that called us.
+    :param options: Directive options for customization.
+    :param content: The directive content for customization.
+    """
+    try:
+        plugin_fqcn, plugin_type = parse_plugin_name(text.replace("\x00", ""))
+    except ValueError as exc:
+        return _create_error(rawtext, text, str(exc))
+
+    options = {
+        "reftype": "ref",
+        "refdomain": "std",
+        "refexplicit": True,
+        "refwarn": True,
+    }
+    refnode = addnodes.pending_xref(
+        plugin_fqcn, nodes.inline(rawtext, plugin_fqcn), **options
+    )
+    refnode["reftarget"] = _plugin_ref(plugin_fqcn, plugin_type)
+
+    return [refnode], []
+
+
 ROLES = {
     "ansible-option-choices-entry": option_choice,
     "ansible-option-choices-entry-default": option_choice_default,
@@ -312,6 +355,7 @@ ROLES = {
     "ansretval": return_value_role,
     "ansenvvar": environment_variable,
     "ansenvvarref": environment_variable_reference,
+    "ansplugin": plugin_role,
 }
 
 

--- a/src/sphinx_antsibull_ext/sphinx_helper.py
+++ b/src/sphinx_antsibull_ext/sphinx_helper.py
@@ -1,0 +1,31 @@
+# Author: Sphinx team
+# two clause BSD licence (see LICENSES/BSD-2-Clause.txt or
+# https://github.com/sphinx-doc/sphinx/blob/master/LICENSE)
+# SPDX-License-Identifier: BSD-2-Clause
+# SPDX-FileCopyrightText: 2007-2023, Sphinx team (see Sphinx's AUTHORS file)
+#
+# The code in here has been extracted and adjusted from
+# https://github.com/sphinx-doc/sphinx/blob/d3c91f951255c6729a53e38c895ddc0af036b5b9/sphinx/util/docutils.py#L520-L537
+"""
+Helpers vendored from Sphinx.
+"""
+
+from __future__ import annotations
+
+import re
+
+from docutils.utils import unescape  # pyre-ignore[21]
+
+# \x00 means the "<" was backslash-escaped
+_EXPLICIT_TITLE_RE = re.compile(r"^(.+?)\s*(?<!\x00)<(.*?)>$", re.DOTALL)
+
+
+def extract_explicit_title(text: str) -> tuple[str, str | None]:
+    """
+    Given the parameter to a reference role, extract the unescaped target and
+    the optional unescaped title.
+    """
+    m = _EXPLICIT_TITLE_RE.match(text)
+    if not m:
+        return unescape(text), None
+    return unescape(m.group(2)), unescape(m.group(1))

--- a/tests/functional/baseline-default/collections/callback_index_stdout.rst
+++ b/tests/functional/baseline-default/collections/callback_index_stdout.rst
@@ -11,5 +11,5 @@ See :ref:`list_of_callback_plugins` for the list of *all* callback plugins.
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_callback>` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
+* :ansplugin:`ns2.col.foo#callback` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
 

--- a/tests/functional/baseline-default/collections/environment_variables.rst
+++ b/tests/functional/baseline-default/collections/environment_variables.rst
@@ -14,28 +14,28 @@ Environment variables used by the ansible-core configuration are documented in :
     Foo executable.
 
     *Used by:*
-    :ref:`ns2.col.foo become plugin <ansible_collections.ns2.col.foo_become>`
+    :ansplugin:`ns2.col.foo become plugin <ns2.col.foo#become>`
 .. envvar:: ANSIBLE_FOO_FILENAME_EXT
 
     All extensions to check.
 
     *Used by:*
-    :ref:`ns2.col.foo vars plugin <ansible_collections.ns2.col.foo_vars>`
+    :ansplugin:`ns2.col.foo vars plugin <ns2.col.foo#vars>`
 .. envvar:: ANSIBLE_FOO_USER
 
     User you 'become' to execute the task.
 
     *Used by:*
-    :ref:`ns2.col.foo become plugin <ansible_collections.ns2.col.foo_become>`
+    :ansplugin:`ns2.col.foo become plugin <ns2.col.foo#become>`
 .. envvar:: ANSIBLE_REMOTE_TEMP
 
     Temporary directory to use on targets when executing tasks.
 
     *Used by:*
-    :ref:`ns2.col.foo shell plugin <ansible_collections.ns2.col.foo_shell>`
+    :ansplugin:`ns2.col.foo shell plugin <ns2.col.foo#shell>`
 .. envvar:: ANSIBLE_REMOTE_TMP
 
     Temporary directory to use on targets when executing tasks.
 
     *Used by:*
-    :ref:`ns2.col.foo shell plugin <ansible_collections.ns2.col.foo_shell>`
+    :ansplugin:`ns2.col.foo shell plugin <ns2.col.foo#shell>`

--- a/tests/functional/baseline-default/collections/index_become.rst
+++ b/tests/functional/baseline-default/collections/index_become.rst
@@ -9,5 +9,5 @@ Index of all Become Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_become>` -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
+* :ansplugin:`ns2.col.foo#become` -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
 

--- a/tests/functional/baseline-default/collections/index_cache.rst
+++ b/tests/functional/baseline-default/collections/index_cache.rst
@@ -9,5 +9,5 @@ Index of all Cache Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_cache>` -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
+* :ansplugin:`ns2.col.foo#cache` -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
 

--- a/tests/functional/baseline-default/collections/index_callback.rst
+++ b/tests/functional/baseline-default/collections/index_callback.rst
@@ -17,5 +17,5 @@ Index of all Callback Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_callback>` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
+* :ansplugin:`ns2.col.foo#callback` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
 

--- a/tests/functional/baseline-default/collections/index_cliconf.rst
+++ b/tests/functional/baseline-default/collections/index_cliconf.rst
@@ -9,5 +9,5 @@ Index of all Cliconf Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_cliconf>` -- Foo router CLI config
+* :ansplugin:`ns2.col.foo#cliconf` -- Foo router CLI config
 

--- a/tests/functional/baseline-default/collections/index_connection.rst
+++ b/tests/functional/baseline-default/collections/index_connection.rst
@@ -9,5 +9,5 @@ Index of all Connection Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_connection>` -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
+* :ansplugin:`ns2.col.foo#connection` -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
 

--- a/tests/functional/baseline-default/collections/index_filter.rst
+++ b/tests/functional/baseline-default/collections/index_filter.rst
@@ -9,6 +9,6 @@ Index of all Filter Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.bar <ansible_collections.ns2.col.bar_filter>` -- The bar filter
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_filter>` -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
+* :ansplugin:`ns2.col.bar#filter` -- The bar filter
+* :ansplugin:`ns2.col.foo#filter` -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
 

--- a/tests/functional/baseline-default/collections/index_inventory.rst
+++ b/tests/functional/baseline-default/collections/index_inventory.rst
@@ -9,5 +9,5 @@ Index of all Inventory Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_inventory>` -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
+* :ansplugin:`ns2.col.foo#inventory` -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
 

--- a/tests/functional/baseline-default/collections/index_lookup.rst
+++ b/tests/functional/baseline-default/collections/index_lookup.rst
@@ -9,5 +9,5 @@ Index of all Lookup Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>` -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
+* :ansplugin:`ns2.col.foo#lookup` -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
 

--- a/tests/functional/baseline-default/collections/index_module.rst
+++ b/tests/functional/baseline-default/collections/index_module.rst
@@ -9,21 +9,21 @@ Index of all Modules
 ns.col2
 -------
 
-* :ref:`ns.col2.foo <ansible_collections.ns.col2.foo_module>` -- 
-* :ref:`ns.col2.foo2 <ansible_collections.ns.col2.foo2_module>` -- Foo two
-* :ref:`ns.col2.foo3 <ansible_collections.ns.col2.foo3_module>` -- Foo III
-* :ref:`ns.col2.foo4 <ansible_collections.ns.col2.foo4_module>` -- Markup reference linting test
+* :ansplugin:`ns.col2.foo#module` -- 
+* :ansplugin:`ns.col2.foo2#module` -- Foo two
+* :ansplugin:`ns.col2.foo3#module` -- Foo III
+* :ansplugin:`ns.col2.foo4#module` -- Markup reference linting test
 
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_module>` -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
-* :ref:`ns2.col.foo2 <ansible_collections.ns2.col.foo2_module>` -- Another foo
-* :ref:`ns2.col.sub.foo3 <ansible_collections.ns2.col.sub.foo3_module>` -- A sub-foo
+* :ansplugin:`ns2.col.foo#module` -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
+* :ansplugin:`ns2.col.foo2#module` -- Another foo
+* :ansplugin:`ns2.col.sub.foo3#module` -- A sub-foo
 
 ns2.flatcol
 -----------
 
-* :ref:`ns2.flatcol.foo <ansible_collections.ns2.flatcol.foo_module>` -- Do some foo \ :ansopt:`ns2.flatcol.foo#module:bar`\ 
-* :ref:`ns2.flatcol.foo2 <ansible_collections.ns2.flatcol.foo2_module>` -- Another foo
+* :ansplugin:`ns2.flatcol.foo#module` -- Do some foo \ :ansopt:`ns2.flatcol.foo#module:bar`\ 
+* :ansplugin:`ns2.flatcol.foo2#module` -- Another foo
 

--- a/tests/functional/baseline-default/collections/index_role.rst
+++ b/tests/functional/baseline-default/collections/index_role.rst
@@ -9,10 +9,10 @@ Index of all Roles
 ns.col2
 -------
 
-* :ref:`ns.col2.bar <ansible_collections.ns.col2.bar_role>` -- Bar role
+* :ansplugin:`ns.col2.bar#role` -- Bar role
 
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_role>` -- Foo role
+* :ansplugin:`ns2.col.foo#role` -- Foo role
 

--- a/tests/functional/baseline-default/collections/index_shell.rst
+++ b/tests/functional/baseline-default/collections/index_shell.rst
@@ -9,5 +9,5 @@ Index of all Shell Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_shell>` -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
+* :ansplugin:`ns2.col.foo#shell` -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
 

--- a/tests/functional/baseline-default/collections/index_strategy.rst
+++ b/tests/functional/baseline-default/collections/index_strategy.rst
@@ -9,5 +9,5 @@ Index of all Strategy Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_strategy>` -- Executes tasks in foo
+* :ansplugin:`ns2.col.foo#strategy` -- Executes tasks in foo
 

--- a/tests/functional/baseline-default/collections/index_test.rst
+++ b/tests/functional/baseline-default/collections/index_test.rst
@@ -9,6 +9,6 @@ Index of all Test Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.bar <ansible_collections.ns2.col.bar_test>` -- Is something a bar
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_test>` -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
+* :ansplugin:`ns2.col.bar#test` -- Is something a bar
+* :ansplugin:`ns2.col.foo#test` -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
 

--- a/tests/functional/baseline-default/collections/index_vars.rst
+++ b/tests/functional/baseline-default/collections/index_vars.rst
@@ -9,5 +9,5 @@ Index of all Vars Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_vars>` -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
+* :ansplugin:`ns2.col.foo#vars` -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
 

--- a/tests/functional/baseline-default/collections/ns/col2/index.rst
+++ b/tests/functional/baseline-default/collections/ns/col2/index.rst
@@ -40,10 +40,10 @@ These are the plugins in the ns.col2 collection:
 Modules
 ~~~~~~~
 
-* :ref:`foo module <ansible_collections.ns.col2.foo_module>` -- 
-* :ref:`foo2 module <ansible_collections.ns.col2.foo2_module>` -- Foo two
-* :ref:`foo3 module <ansible_collections.ns.col2.foo3_module>` -- Foo III
-* :ref:`foo4 module <ansible_collections.ns.col2.foo4_module>` -- Markup reference linting test
+* :ansplugin:`foo module <ns.col2.foo#module>` -- 
+* :ansplugin:`foo2 module <ns.col2.foo2#module>` -- Foo two
+* :ansplugin:`foo3 module <ns.col2.foo3#module>` -- Foo III
+* :ansplugin:`foo4 module <ns.col2.foo4#module>` -- Markup reference linting test
 
 .. toctree::
     :maxdepth: 1
@@ -60,7 +60,7 @@ Role Index
 
 These are the roles in the ns.col2 collection:
 
-* :ref:`bar role <ansible_collections.ns.col2.bar_role>` -- Bar role
+* :ansplugin:`bar role <ns.col2.bar#role>` -- Bar role
 
 .. toctree::
     :maxdepth: 1

--- a/tests/functional/baseline-default/collections/ns2/col/foo_redirect_module.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_redirect_module.rst
@@ -19,5 +19,5 @@ ns2.col.foo_redirect module
 
     To use it in a playbook, specify: :code:`ns2.col.foo_redirect`.
 
-- This is a redirect to the :ref:`ns2.col.foo module <ansible_collections.ns2.col.foo_module>`.
+- This is a redirect to the :ansplugin:`ns2.col.foo module <ns2.col.foo#module>`.
 - This redirect does **not** work with Ansible 2.9.

--- a/tests/functional/baseline-default/collections/ns2/col/index.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/index.rst
@@ -74,9 +74,9 @@ These are the plugins in the ns2.col collection:
 Modules
 ~~~~~~~
 
-* :ref:`foo module <ansible_collections.ns2.col.foo_module>` -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
-* :ref:`foo2 module <ansible_collections.ns2.col.foo2_module>` -- Another foo
-* :ref:`sub.foo3 module <ansible_collections.ns2.col.sub.foo3_module>` -- A sub-foo
+* :ansplugin:`foo module <ns2.col.foo#module>` -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
+* :ansplugin:`foo2 module <ns2.col.foo2#module>` -- Another foo
+* :ansplugin:`sub.foo3 module <ns2.col.sub.foo3#module>` -- A sub-foo
 
 .. toctree::
     :maxdepth: 1
@@ -90,7 +90,7 @@ Modules
 Become Plugins
 ~~~~~~~~~~~~~~
 
-* :ref:`foo become <ansible_collections.ns2.col.foo_become>` -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
+* :ansplugin:`foo become <ns2.col.foo#become>` -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -102,7 +102,7 @@ Become Plugins
 Cache Plugins
 ~~~~~~~~~~~~~
 
-* :ref:`foo cache <ansible_collections.ns2.col.foo_cache>` -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
+* :ansplugin:`foo cache <ns2.col.foo#cache>` -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -114,7 +114,7 @@ Cache Plugins
 Callback Plugins
 ~~~~~~~~~~~~~~~~
 
-* :ref:`foo callback <ansible_collections.ns2.col.foo_callback>` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
+* :ansplugin:`foo callback <ns2.col.foo#callback>` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -126,7 +126,7 @@ Callback Plugins
 Cliconf Plugins
 ~~~~~~~~~~~~~~~
 
-* :ref:`foo cliconf <ansible_collections.ns2.col.foo_cliconf>` -- Foo router CLI config
+* :ansplugin:`foo cliconf <ns2.col.foo#cliconf>` -- Foo router CLI config
 
 .. toctree::
     :maxdepth: 1
@@ -138,7 +138,7 @@ Cliconf Plugins
 Connection Plugins
 ~~~~~~~~~~~~~~~~~~
 
-* :ref:`foo connection <ansible_collections.ns2.col.foo_connection>` -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
+* :ansplugin:`foo connection <ns2.col.foo#connection>` -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -150,8 +150,8 @@ Connection Plugins
 Filter Plugins
 ~~~~~~~~~~~~~~
 
-* :ref:`bar filter <ansible_collections.ns2.col.bar_filter>` -- The bar filter
-* :ref:`foo filter <ansible_collections.ns2.col.foo_filter>` -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
+* :ansplugin:`bar filter <ns2.col.bar#filter>` -- The bar filter
+* :ansplugin:`foo filter <ns2.col.foo#filter>` -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -164,7 +164,7 @@ Filter Plugins
 Inventory Plugins
 ~~~~~~~~~~~~~~~~~
 
-* :ref:`foo inventory <ansible_collections.ns2.col.foo_inventory>` -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
+* :ansplugin:`foo inventory <ns2.col.foo#inventory>` -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -176,7 +176,7 @@ Inventory Plugins
 Lookup Plugins
 ~~~~~~~~~~~~~~
 
-* :ref:`foo lookup <ansible_collections.ns2.col.foo_lookup>` -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
+* :ansplugin:`foo lookup <ns2.col.foo#lookup>` -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -188,7 +188,7 @@ Lookup Plugins
 Shell Plugins
 ~~~~~~~~~~~~~
 
-* :ref:`foo shell <ansible_collections.ns2.col.foo_shell>` -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
+* :ansplugin:`foo shell <ns2.col.foo#shell>` -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -200,7 +200,7 @@ Shell Plugins
 Strategy Plugins
 ~~~~~~~~~~~~~~~~
 
-* :ref:`foo strategy <ansible_collections.ns2.col.foo_strategy>` -- Executes tasks in foo
+* :ansplugin:`foo strategy <ns2.col.foo#strategy>` -- Executes tasks in foo
 
 .. toctree::
     :maxdepth: 1
@@ -212,8 +212,8 @@ Strategy Plugins
 Test Plugins
 ~~~~~~~~~~~~
 
-* :ref:`bar test <ansible_collections.ns2.col.bar_test>` -- Is something a bar
-* :ref:`foo test <ansible_collections.ns2.col.foo_test>` -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
+* :ansplugin:`bar test <ns2.col.bar#test>` -- Is something a bar
+* :ansplugin:`foo test <ns2.col.foo#test>` -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -226,7 +226,7 @@ Test Plugins
 Vars Plugins
 ~~~~~~~~~~~~
 
-* :ref:`foo vars <ansible_collections.ns2.col.foo_vars>` -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
+* :ansplugin:`foo vars <ns2.col.foo#vars>` -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -240,7 +240,7 @@ Role Index
 
 These are the roles in the ns2.col collection:
 
-* :ref:`foo role <ansible_collections.ns2.col.foo_role>` -- Foo role
+* :ansplugin:`foo role <ns2.col.foo#role>` -- Foo role
 
 .. toctree::
     :maxdepth: 1

--- a/tests/functional/baseline-default/collections/ns2/col/is_bar_test.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/is_bar_test.rst
@@ -19,5 +19,5 @@ ns2.col.is_bar test
 
     To use it in a playbook, specify: :code:`ns2.col.is_bar`.
 
-- This is a redirect to the :ref:`ns2.col.bar test plugin <ansible_collections.ns2.col.bar_test>`.
+- This is a redirect to the :ansplugin:`ns2.col.bar test plugin <ns2.col.bar#test>`.
 - This redirect does **not** work with Ansible 2.9.

--- a/tests/functional/baseline-default/collections/ns2/flatcol/index.rst
+++ b/tests/functional/baseline-default/collections/ns2/flatcol/index.rst
@@ -36,8 +36,8 @@ These are the plugins in the ns2.flatcol collection:
 Modules
 ~~~~~~~
 
-* :ref:`foo module <ansible_collections.ns2.flatcol.foo_module>` -- Do some foo \ :ansopt:`ns2.flatcol.foo#module:bar`\ 
-* :ref:`foo2 module <ansible_collections.ns2.flatcol.foo2_module>` -- Another foo
+* :ansplugin:`foo module <ns2.flatcol.foo#module>` -- Do some foo \ :ansopt:`ns2.flatcol.foo#module:bar`\ 
+* :ansplugin:`foo2 module <ns2.flatcol.foo2#module>` -- Another foo
 
 .. toctree::
     :maxdepth: 1

--- a/tests/functional/baseline-no-breadcrumbs/collections/callback_index_stdout.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/callback_index_stdout.rst
@@ -11,5 +11,5 @@ See :ref:`list_of_callback_plugins` for the list of *all* callback plugins.
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_callback>` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
+* :ansplugin:`ns2.col.foo#callback` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/environment_variables.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/environment_variables.rst
@@ -14,28 +14,28 @@ Environment variables used by the ansible-core configuration are documented in :
     Foo executable.
 
     *Used by:*
-    :ref:`ns2.col.foo become plugin <ansible_collections.ns2.col.foo_become>`
+    :ansplugin:`ns2.col.foo become plugin <ns2.col.foo#become>`
 .. envvar:: ANSIBLE_FOO_FILENAME_EXT
 
     All extensions to check.
 
     *Used by:*
-    :ref:`ns2.col.foo vars plugin <ansible_collections.ns2.col.foo_vars>`
+    :ansplugin:`ns2.col.foo vars plugin <ns2.col.foo#vars>`
 .. envvar:: ANSIBLE_FOO_USER
 
     User you 'become' to execute the task.
 
     *Used by:*
-    :ref:`ns2.col.foo become plugin <ansible_collections.ns2.col.foo_become>`
+    :ansplugin:`ns2.col.foo become plugin <ns2.col.foo#become>`
 .. envvar:: ANSIBLE_REMOTE_TEMP
 
     Temporary directory to use on targets when executing tasks.
 
     *Used by:*
-    :ref:`ns2.col.foo shell plugin <ansible_collections.ns2.col.foo_shell>`
+    :ansplugin:`ns2.col.foo shell plugin <ns2.col.foo#shell>`
 .. envvar:: ANSIBLE_REMOTE_TMP
 
     Temporary directory to use on targets when executing tasks.
 
     *Used by:*
-    :ref:`ns2.col.foo shell plugin <ansible_collections.ns2.col.foo_shell>`
+    :ansplugin:`ns2.col.foo shell plugin <ns2.col.foo#shell>`

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_become.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_become.rst
@@ -9,5 +9,5 @@ Index of all Become Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_become>` -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
+* :ansplugin:`ns2.col.foo#become` -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_cache.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_cache.rst
@@ -9,5 +9,5 @@ Index of all Cache Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_cache>` -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
+* :ansplugin:`ns2.col.foo#cache` -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_callback.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_callback.rst
@@ -17,5 +17,5 @@ Index of all Callback Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_callback>` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
+* :ansplugin:`ns2.col.foo#callback` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_cliconf.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_cliconf.rst
@@ -9,5 +9,5 @@ Index of all Cliconf Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_cliconf>` -- Foo router CLI config
+* :ansplugin:`ns2.col.foo#cliconf` -- Foo router CLI config
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_connection.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_connection.rst
@@ -9,5 +9,5 @@ Index of all Connection Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_connection>` -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
+* :ansplugin:`ns2.col.foo#connection` -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_filter.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_filter.rst
@@ -9,6 +9,6 @@ Index of all Filter Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.bar <ansible_collections.ns2.col.bar_filter>` -- The bar filter
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_filter>` -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
+* :ansplugin:`ns2.col.bar#filter` -- The bar filter
+* :ansplugin:`ns2.col.foo#filter` -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_inventory.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_inventory.rst
@@ -9,5 +9,5 @@ Index of all Inventory Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_inventory>` -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
+* :ansplugin:`ns2.col.foo#inventory` -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_lookup.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_lookup.rst
@@ -9,5 +9,5 @@ Index of all Lookup Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>` -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
+* :ansplugin:`ns2.col.foo#lookup` -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_module.rst
@@ -9,21 +9,21 @@ Index of all Modules
 ns.col2
 -------
 
-* :ref:`ns.col2.foo <ansible_collections.ns.col2.foo_module>` -- 
-* :ref:`ns.col2.foo2 <ansible_collections.ns.col2.foo2_module>` -- Foo two
-* :ref:`ns.col2.foo3 <ansible_collections.ns.col2.foo3_module>` -- Foo III
-* :ref:`ns.col2.foo4 <ansible_collections.ns.col2.foo4_module>` -- Markup reference linting test
+* :ansplugin:`ns.col2.foo#module` -- 
+* :ansplugin:`ns.col2.foo2#module` -- Foo two
+* :ansplugin:`ns.col2.foo3#module` -- Foo III
+* :ansplugin:`ns.col2.foo4#module` -- Markup reference linting test
 
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_module>` -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
-* :ref:`ns2.col.foo2 <ansible_collections.ns2.col.foo2_module>` -- Another foo
-* :ref:`ns2.col.sub.foo3 <ansible_collections.ns2.col.sub.foo3_module>` -- A sub-foo
+* :ansplugin:`ns2.col.foo#module` -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
+* :ansplugin:`ns2.col.foo2#module` -- Another foo
+* :ansplugin:`ns2.col.sub.foo3#module` -- A sub-foo
 
 ns2.flatcol
 -----------
 
-* :ref:`ns2.flatcol.foo <ansible_collections.ns2.flatcol.foo_module>` -- Do some foo \ :ansopt:`ns2.flatcol.foo#module:bar`\ 
-* :ref:`ns2.flatcol.foo2 <ansible_collections.ns2.flatcol.foo2_module>` -- Another foo
+* :ansplugin:`ns2.flatcol.foo#module` -- Do some foo \ :ansopt:`ns2.flatcol.foo#module:bar`\ 
+* :ansplugin:`ns2.flatcol.foo2#module` -- Another foo
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_role.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_role.rst
@@ -9,10 +9,10 @@ Index of all Roles
 ns.col2
 -------
 
-* :ref:`ns.col2.bar <ansible_collections.ns.col2.bar_role>` -- Bar role
+* :ansplugin:`ns.col2.bar#role` -- Bar role
 
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_role>` -- Foo role
+* :ansplugin:`ns2.col.foo#role` -- Foo role
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_shell.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_shell.rst
@@ -9,5 +9,5 @@ Index of all Shell Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_shell>` -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
+* :ansplugin:`ns2.col.foo#shell` -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_strategy.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_strategy.rst
@@ -9,5 +9,5 @@ Index of all Strategy Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_strategy>` -- Executes tasks in foo
+* :ansplugin:`ns2.col.foo#strategy` -- Executes tasks in foo
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_test.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_test.rst
@@ -9,6 +9,6 @@ Index of all Test Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.bar <ansible_collections.ns2.col.bar_test>` -- Is something a bar
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_test>` -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
+* :ansplugin:`ns2.col.bar#test` -- Is something a bar
+* :ansplugin:`ns2.col.foo#test` -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_vars.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_vars.rst
@@ -9,5 +9,5 @@ Index of all Vars Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_vars>` -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
+* :ansplugin:`ns2.col.foo#vars` -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/index.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/index.rst
@@ -41,10 +41,10 @@ These are the plugins in the ns.col2 collection:
 Modules
 ~~~~~~~
 
-* :ref:`foo module <ansible_collections.ns.col2.foo_module>` -- 
-* :ref:`foo2 module <ansible_collections.ns.col2.foo2_module>` -- Foo two
-* :ref:`foo3 module <ansible_collections.ns.col2.foo3_module>` -- Foo III
-* :ref:`foo4 module <ansible_collections.ns.col2.foo4_module>` -- Markup reference linting test
+* :ansplugin:`foo module <ns.col2.foo#module>` -- 
+* :ansplugin:`foo2 module <ns.col2.foo2#module>` -- Foo two
+* :ansplugin:`foo3 module <ns.col2.foo3#module>` -- Foo III
+* :ansplugin:`foo4 module <ns.col2.foo4#module>` -- Markup reference linting test
 
 
 Role Index
@@ -52,7 +52,7 @@ Role Index
 
 These are the roles in the ns.col2 collection:
 
-* :ref:`bar role <ansible_collections.ns.col2.bar_role>` -- Bar role
+* :ansplugin:`bar role <ns.col2.bar#role>` -- Bar role
 
 
 .. seealso::

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_redirect_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_redirect_module.rst
@@ -19,5 +19,5 @@ ns2.col.foo_redirect module
 
     To use it in a playbook, specify: :code:`ns2.col.foo_redirect`.
 
-- This is a redirect to the :ref:`ns2.col.foo module <ansible_collections.ns2.col.foo_module>`.
+- This is a redirect to the :ansplugin:`ns2.col.foo module <ns2.col.foo#module>`.
 - This redirect does **not** work with Ansible 2.9.

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/index.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/index.rst
@@ -75,83 +75,83 @@ These are the plugins in the ns2.col collection:
 Modules
 ~~~~~~~
 
-* :ref:`foo module <ansible_collections.ns2.col.foo_module>` -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
-* :ref:`foo2 module <ansible_collections.ns2.col.foo2_module>` -- Another foo
-* :ref:`sub.foo3 module <ansible_collections.ns2.col.sub.foo3_module>` -- A sub-foo
+* :ansplugin:`foo module <ns2.col.foo#module>` -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
+* :ansplugin:`foo2 module <ns2.col.foo2#module>` -- Another foo
+* :ansplugin:`sub.foo3 module <ns2.col.sub.foo3#module>` -- A sub-foo
 
 
 Become Plugins
 ~~~~~~~~~~~~~~
 
-* :ref:`foo become <ansible_collections.ns2.col.foo_become>` -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
+* :ansplugin:`foo become <ns2.col.foo#become>` -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
 
 
 Cache Plugins
 ~~~~~~~~~~~~~
 
-* :ref:`foo cache <ansible_collections.ns2.col.foo_cache>` -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
+* :ansplugin:`foo cache <ns2.col.foo#cache>` -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
 
 
 Callback Plugins
 ~~~~~~~~~~~~~~~~
 
-* :ref:`foo callback <ansible_collections.ns2.col.foo_callback>` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
+* :ansplugin:`foo callback <ns2.col.foo#callback>` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
 
 
 Cliconf Plugins
 ~~~~~~~~~~~~~~~
 
-* :ref:`foo cliconf <ansible_collections.ns2.col.foo_cliconf>` -- Foo router CLI config
+* :ansplugin:`foo cliconf <ns2.col.foo#cliconf>` -- Foo router CLI config
 
 
 Connection Plugins
 ~~~~~~~~~~~~~~~~~~
 
-* :ref:`foo connection <ansible_collections.ns2.col.foo_connection>` -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
+* :ansplugin:`foo connection <ns2.col.foo#connection>` -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
 
 
 Filter Plugins
 ~~~~~~~~~~~~~~
 
-* :ref:`bar filter <ansible_collections.ns2.col.bar_filter>` -- The bar filter
-* :ref:`foo filter <ansible_collections.ns2.col.foo_filter>` -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
+* :ansplugin:`bar filter <ns2.col.bar#filter>` -- The bar filter
+* :ansplugin:`foo filter <ns2.col.foo#filter>` -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
 
 
 Inventory Plugins
 ~~~~~~~~~~~~~~~~~
 
-* :ref:`foo inventory <ansible_collections.ns2.col.foo_inventory>` -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
+* :ansplugin:`foo inventory <ns2.col.foo#inventory>` -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
 
 
 Lookup Plugins
 ~~~~~~~~~~~~~~
 
-* :ref:`foo lookup <ansible_collections.ns2.col.foo_lookup>` -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
+* :ansplugin:`foo lookup <ns2.col.foo#lookup>` -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
 
 
 Shell Plugins
 ~~~~~~~~~~~~~
 
-* :ref:`foo shell <ansible_collections.ns2.col.foo_shell>` -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
+* :ansplugin:`foo shell <ns2.col.foo#shell>` -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
 
 
 Strategy Plugins
 ~~~~~~~~~~~~~~~~
 
-* :ref:`foo strategy <ansible_collections.ns2.col.foo_strategy>` -- Executes tasks in foo
+* :ansplugin:`foo strategy <ns2.col.foo#strategy>` -- Executes tasks in foo
 
 
 Test Plugins
 ~~~~~~~~~~~~
 
-* :ref:`bar test <ansible_collections.ns2.col.bar_test>` -- Is something a bar
-* :ref:`foo test <ansible_collections.ns2.col.foo_test>` -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
+* :ansplugin:`bar test <ns2.col.bar#test>` -- Is something a bar
+* :ansplugin:`foo test <ns2.col.foo#test>` -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
 
 
 Vars Plugins
 ~~~~~~~~~~~~
 
-* :ref:`foo vars <ansible_collections.ns2.col.foo_vars>` -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
+* :ansplugin:`foo vars <ns2.col.foo#vars>` -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
 
 
 Role Index
@@ -159,7 +159,7 @@ Role Index
 
 These are the roles in the ns2.col collection:
 
-* :ref:`foo role <ansible_collections.ns2.col.foo_role>` -- Foo role
+* :ansplugin:`foo role <ns2.col.foo#role>` -- Foo role
 
 
 .. seealso::

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/is_bar_test.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/is_bar_test.rst
@@ -19,5 +19,5 @@ ns2.col.is_bar test
 
     To use it in a playbook, specify: :code:`ns2.col.is_bar`.
 
-- This is a redirect to the :ref:`ns2.col.bar test plugin <ansible_collections.ns2.col.bar_test>`.
+- This is a redirect to the :ansplugin:`ns2.col.bar test plugin <ns2.col.bar#test>`.
 - This redirect does **not** work with Ansible 2.9.

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/flatcol/index.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/flatcol/index.rst
@@ -37,8 +37,8 @@ These are the plugins in the ns2.flatcol collection:
 Modules
 ~~~~~~~
 
-* :ref:`foo module <ansible_collections.ns2.flatcol.foo_module>` -- Do some foo \ :ansopt:`ns2.flatcol.foo#module:bar`\ 
-* :ref:`foo2 module <ansible_collections.ns2.flatcol.foo2_module>` -- Another foo
+* :ansplugin:`foo module <ns2.flatcol.foo#module>` -- Do some foo \ :ansopt:`ns2.flatcol.foo#module:bar`\ 
+* :ansplugin:`foo2 module <ns2.flatcol.foo2#module>` -- Another foo
 
 
 

--- a/tests/functional/baseline-no-indexes/collections/environment_variables.rst
+++ b/tests/functional/baseline-no-indexes/collections/environment_variables.rst
@@ -14,28 +14,28 @@ Environment variables used by the ansible-core configuration are documented in :
     Foo executable.
 
     *Used by:*
-    :ref:`ns2.col.foo become plugin <ansible_collections.ns2.col.foo_become>`
+    :ansplugin:`ns2.col.foo become plugin <ns2.col.foo#become>`
 .. envvar:: ANSIBLE_FOO_FILENAME_EXT
 
     All extensions to check.
 
     *Used by:*
-    :ref:`ns2.col.foo vars plugin <ansible_collections.ns2.col.foo_vars>`
+    :ansplugin:`ns2.col.foo vars plugin <ns2.col.foo#vars>`
 .. envvar:: ANSIBLE_FOO_USER
 
     User you 'become' to execute the task.
 
     *Used by:*
-    :ref:`ns2.col.foo become plugin <ansible_collections.ns2.col.foo_become>`
+    :ansplugin:`ns2.col.foo become plugin <ns2.col.foo#become>`
 .. envvar:: ANSIBLE_REMOTE_TEMP
 
     Temporary directory to use on targets when executing tasks.
 
     *Used by:*
-    :ref:`ns2.col.foo shell plugin <ansible_collections.ns2.col.foo_shell>`
+    :ansplugin:`ns2.col.foo shell plugin <ns2.col.foo#shell>`
 .. envvar:: ANSIBLE_REMOTE_TMP
 
     Temporary directory to use on targets when executing tasks.
 
     *Used by:*
-    :ref:`ns2.col.foo shell plugin <ansible_collections.ns2.col.foo_shell>`
+    :ansplugin:`ns2.col.foo shell plugin <ns2.col.foo#shell>`

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_redirect_module.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_redirect_module.rst
@@ -19,5 +19,5 @@ ns2.col.foo_redirect module
 
     To use it in a playbook, specify: :code:`ns2.col.foo_redirect`.
 
-- This is a redirect to the :ref:`ns2.col.foo module <ansible_collections.ns2.col.foo_module>`.
+- This is a redirect to the :ansplugin:`ns2.col.foo module <ns2.col.foo#module>`.
 - This redirect does **not** work with Ansible 2.9.

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/index.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/index.rst
@@ -74,9 +74,9 @@ These are the plugins in the ns2.col collection:
 Modules
 ~~~~~~~
 
-* :ref:`foo module <ansible_collections.ns2.col.foo_module>` -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
-* :ref:`foo2 module <ansible_collections.ns2.col.foo2_module>` -- Another foo
-* :ref:`sub.foo3 module <ansible_collections.ns2.col.sub.foo3_module>` -- A sub-foo
+* :ansplugin:`foo module <ns2.col.foo#module>` -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
+* :ansplugin:`foo2 module <ns2.col.foo2#module>` -- Another foo
+* :ansplugin:`sub.foo3 module <ns2.col.sub.foo3#module>` -- A sub-foo
 
 .. toctree::
     :maxdepth: 1
@@ -90,7 +90,7 @@ Modules
 Become Plugins
 ~~~~~~~~~~~~~~
 
-* :ref:`foo become <ansible_collections.ns2.col.foo_become>` -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
+* :ansplugin:`foo become <ns2.col.foo#become>` -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -102,7 +102,7 @@ Become Plugins
 Cache Plugins
 ~~~~~~~~~~~~~
 
-* :ref:`foo cache <ansible_collections.ns2.col.foo_cache>` -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
+* :ansplugin:`foo cache <ns2.col.foo#cache>` -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -114,7 +114,7 @@ Cache Plugins
 Callback Plugins
 ~~~~~~~~~~~~~~~~
 
-* :ref:`foo callback <ansible_collections.ns2.col.foo_callback>` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
+* :ansplugin:`foo callback <ns2.col.foo#callback>` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -126,7 +126,7 @@ Callback Plugins
 Cliconf Plugins
 ~~~~~~~~~~~~~~~
 
-* :ref:`foo cliconf <ansible_collections.ns2.col.foo_cliconf>` -- Foo router CLI config
+* :ansplugin:`foo cliconf <ns2.col.foo#cliconf>` -- Foo router CLI config
 
 .. toctree::
     :maxdepth: 1
@@ -138,7 +138,7 @@ Cliconf Plugins
 Connection Plugins
 ~~~~~~~~~~~~~~~~~~
 
-* :ref:`foo connection <ansible_collections.ns2.col.foo_connection>` -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
+* :ansplugin:`foo connection <ns2.col.foo#connection>` -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -150,8 +150,8 @@ Connection Plugins
 Filter Plugins
 ~~~~~~~~~~~~~~
 
-* :ref:`bar filter <ansible_collections.ns2.col.bar_filter>` -- The bar filter
-* :ref:`foo filter <ansible_collections.ns2.col.foo_filter>` -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
+* :ansplugin:`bar filter <ns2.col.bar#filter>` -- The bar filter
+* :ansplugin:`foo filter <ns2.col.foo#filter>` -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -164,7 +164,7 @@ Filter Plugins
 Inventory Plugins
 ~~~~~~~~~~~~~~~~~
 
-* :ref:`foo inventory <ansible_collections.ns2.col.foo_inventory>` -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
+* :ansplugin:`foo inventory <ns2.col.foo#inventory>` -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -176,7 +176,7 @@ Inventory Plugins
 Lookup Plugins
 ~~~~~~~~~~~~~~
 
-* :ref:`foo lookup <ansible_collections.ns2.col.foo_lookup>` -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
+* :ansplugin:`foo lookup <ns2.col.foo#lookup>` -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -188,7 +188,7 @@ Lookup Plugins
 Shell Plugins
 ~~~~~~~~~~~~~
 
-* :ref:`foo shell <ansible_collections.ns2.col.foo_shell>` -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
+* :ansplugin:`foo shell <ns2.col.foo#shell>` -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -200,7 +200,7 @@ Shell Plugins
 Strategy Plugins
 ~~~~~~~~~~~~~~~~
 
-* :ref:`foo strategy <ansible_collections.ns2.col.foo_strategy>` -- Executes tasks in foo
+* :ansplugin:`foo strategy <ns2.col.foo#strategy>` -- Executes tasks in foo
 
 .. toctree::
     :maxdepth: 1
@@ -212,8 +212,8 @@ Strategy Plugins
 Test Plugins
 ~~~~~~~~~~~~
 
-* :ref:`bar test <ansible_collections.ns2.col.bar_test>` -- Is something a bar
-* :ref:`foo test <ansible_collections.ns2.col.foo_test>` -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
+* :ansplugin:`bar test <ns2.col.bar#test>` -- Is something a bar
+* :ansplugin:`foo test <ns2.col.foo#test>` -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -226,7 +226,7 @@ Test Plugins
 Vars Plugins
 ~~~~~~~~~~~~
 
-* :ref:`foo vars <ansible_collections.ns2.col.foo_vars>` -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
+* :ansplugin:`foo vars <ns2.col.foo#vars>` -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -240,7 +240,7 @@ Role Index
 
 These are the roles in the ns2.col collection:
 
-* :ref:`foo role <ansible_collections.ns2.col.foo_role>` -- Foo role
+* :ansplugin:`foo role <ns2.col.foo#role>` -- Foo role
 
 .. toctree::
     :maxdepth: 1

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/is_bar_test.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/is_bar_test.rst
@@ -19,5 +19,5 @@ ns2.col.is_bar test
 
     To use it in a playbook, specify: :code:`ns2.col.is_bar`.
 
-- This is a redirect to the :ref:`ns2.col.bar test plugin <ansible_collections.ns2.col.bar_test>`.
+- This is a redirect to the :ansplugin:`ns2.col.bar test plugin <ns2.col.bar#test>`.
 - This redirect does **not** work with Ansible 2.9.

--- a/tests/functional/baseline-no-indexes/collections/ns2/flatcol/index.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/flatcol/index.rst
@@ -36,8 +36,8 @@ These are the plugins in the ns2.flatcol collection:
 Modules
 ~~~~~~~
 
-* :ref:`foo module <ansible_collections.ns2.flatcol.foo_module>` -- Do some foo \ :ansopt:`ns2.flatcol.foo#module:bar`\ 
-* :ref:`foo2 module <ansible_collections.ns2.flatcol.foo2_module>` -- Another foo
+* :ansplugin:`foo module <ns2.flatcol.foo#module>` -- Do some foo \ :ansopt:`ns2.flatcol.foo#module:bar`\ 
+* :ansplugin:`foo2 module <ns2.flatcol.foo2#module>` -- Another foo
 
 .. toctree::
     :maxdepth: 1

--- a/tests/functional/baseline-squash-hierarchy/environment_variables.rst
+++ b/tests/functional/baseline-squash-hierarchy/environment_variables.rst
@@ -14,28 +14,28 @@ Environment variables used by the ansible-core configuration are documented in :
     Foo executable.
 
     *Used by:*
-    :ref:`ns2.col.foo become plugin <ansible_collections.ns2.col.foo_become>`
+    :ansplugin:`ns2.col.foo become plugin <ns2.col.foo#become>`
 .. envvar:: ANSIBLE_FOO_FILENAME_EXT
 
     All extensions to check.
 
     *Used by:*
-    :ref:`ns2.col.foo vars plugin <ansible_collections.ns2.col.foo_vars>`
+    :ansplugin:`ns2.col.foo vars plugin <ns2.col.foo#vars>`
 .. envvar:: ANSIBLE_FOO_USER
 
     User you 'become' to execute the task.
 
     *Used by:*
-    :ref:`ns2.col.foo become plugin <ansible_collections.ns2.col.foo_become>`
+    :ansplugin:`ns2.col.foo become plugin <ns2.col.foo#become>`
 .. envvar:: ANSIBLE_REMOTE_TEMP
 
     Temporary directory to use on targets when executing tasks.
 
     *Used by:*
-    :ref:`ns2.col.foo shell plugin <ansible_collections.ns2.col.foo_shell>`
+    :ansplugin:`ns2.col.foo shell plugin <ns2.col.foo#shell>`
 .. envvar:: ANSIBLE_REMOTE_TMP
 
     Temporary directory to use on targets when executing tasks.
 
     *Used by:*
-    :ref:`ns2.col.foo shell plugin <ansible_collections.ns2.col.foo_shell>`
+    :ansplugin:`ns2.col.foo shell plugin <ns2.col.foo#shell>`

--- a/tests/functional/baseline-squash-hierarchy/foo_redirect_module.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_redirect_module.rst
@@ -19,5 +19,5 @@ ns2.col.foo_redirect module
 
     To use it in a playbook, specify: :code:`ns2.col.foo_redirect`.
 
-- This is a redirect to the :ref:`ns2.col.foo module <ansible_collections.ns2.col.foo_module>`.
+- This is a redirect to the :ansplugin:`ns2.col.foo module <ns2.col.foo#module>`.
 - This redirect does **not** work with Ansible 2.9.

--- a/tests/functional/baseline-squash-hierarchy/index.rst
+++ b/tests/functional/baseline-squash-hierarchy/index.rst
@@ -74,9 +74,9 @@ These are the plugins in the ns2.col collection:
 Modules
 ~~~~~~~
 
-* :ref:`foo module <ansible_collections.ns2.col.foo_module>` -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
-* :ref:`foo2 module <ansible_collections.ns2.col.foo2_module>` -- Another foo
-* :ref:`sub.foo3 module <ansible_collections.ns2.col.sub.foo3_module>` -- A sub-foo
+* :ansplugin:`foo module <ns2.col.foo#module>` -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
+* :ansplugin:`foo2 module <ns2.col.foo2#module>` -- Another foo
+* :ansplugin:`sub.foo3 module <ns2.col.sub.foo3#module>` -- A sub-foo
 
 .. toctree::
     :maxdepth: 1
@@ -90,7 +90,7 @@ Modules
 Become Plugins
 ~~~~~~~~~~~~~~
 
-* :ref:`foo become <ansible_collections.ns2.col.foo_become>` -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
+* :ansplugin:`foo become <ns2.col.foo#become>` -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -102,7 +102,7 @@ Become Plugins
 Cache Plugins
 ~~~~~~~~~~~~~
 
-* :ref:`foo cache <ansible_collections.ns2.col.foo_cache>` -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
+* :ansplugin:`foo cache <ns2.col.foo#cache>` -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -114,7 +114,7 @@ Cache Plugins
 Callback Plugins
 ~~~~~~~~~~~~~~~~
 
-* :ref:`foo callback <ansible_collections.ns2.col.foo_callback>` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
+* :ansplugin:`foo callback <ns2.col.foo#callback>` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -126,7 +126,7 @@ Callback Plugins
 Cliconf Plugins
 ~~~~~~~~~~~~~~~
 
-* :ref:`foo cliconf <ansible_collections.ns2.col.foo_cliconf>` -- Foo router CLI config
+* :ansplugin:`foo cliconf <ns2.col.foo#cliconf>` -- Foo router CLI config
 
 .. toctree::
     :maxdepth: 1
@@ -138,7 +138,7 @@ Cliconf Plugins
 Connection Plugins
 ~~~~~~~~~~~~~~~~~~
 
-* :ref:`foo connection <ansible_collections.ns2.col.foo_connection>` -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
+* :ansplugin:`foo connection <ns2.col.foo#connection>` -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -150,8 +150,8 @@ Connection Plugins
 Filter Plugins
 ~~~~~~~~~~~~~~
 
-* :ref:`bar filter <ansible_collections.ns2.col.bar_filter>` -- The bar filter
-* :ref:`foo filter <ansible_collections.ns2.col.foo_filter>` -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
+* :ansplugin:`bar filter <ns2.col.bar#filter>` -- The bar filter
+* :ansplugin:`foo filter <ns2.col.foo#filter>` -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -164,7 +164,7 @@ Filter Plugins
 Inventory Plugins
 ~~~~~~~~~~~~~~~~~
 
-* :ref:`foo inventory <ansible_collections.ns2.col.foo_inventory>` -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
+* :ansplugin:`foo inventory <ns2.col.foo#inventory>` -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -176,7 +176,7 @@ Inventory Plugins
 Lookup Plugins
 ~~~~~~~~~~~~~~
 
-* :ref:`foo lookup <ansible_collections.ns2.col.foo_lookup>` -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
+* :ansplugin:`foo lookup <ns2.col.foo#lookup>` -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -188,7 +188,7 @@ Lookup Plugins
 Shell Plugins
 ~~~~~~~~~~~~~
 
-* :ref:`foo shell <ansible_collections.ns2.col.foo_shell>` -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
+* :ansplugin:`foo shell <ns2.col.foo#shell>` -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -200,7 +200,7 @@ Shell Plugins
 Strategy Plugins
 ~~~~~~~~~~~~~~~~
 
-* :ref:`foo strategy <ansible_collections.ns2.col.foo_strategy>` -- Executes tasks in foo
+* :ansplugin:`foo strategy <ns2.col.foo#strategy>` -- Executes tasks in foo
 
 .. toctree::
     :maxdepth: 1
@@ -212,8 +212,8 @@ Strategy Plugins
 Test Plugins
 ~~~~~~~~~~~~
 
-* :ref:`bar test <ansible_collections.ns2.col.bar_test>` -- Is something a bar
-* :ref:`foo test <ansible_collections.ns2.col.foo_test>` -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
+* :ansplugin:`bar test <ns2.col.bar#test>` -- Is something a bar
+* :ansplugin:`foo test <ns2.col.foo#test>` -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -226,7 +226,7 @@ Test Plugins
 Vars Plugins
 ~~~~~~~~~~~~
 
-* :ref:`foo vars <ansible_collections.ns2.col.foo_vars>` -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
+* :ansplugin:`foo vars <ns2.col.foo#vars>` -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -240,7 +240,7 @@ Role Index
 
 These are the roles in the ns2.col collection:
 
-* :ref:`foo role <ansible_collections.ns2.col.foo_role>` -- Foo role
+* :ansplugin:`foo role <ns2.col.foo#role>` -- Foo role
 
 .. toctree::
     :maxdepth: 1

--- a/tests/functional/baseline-squash-hierarchy/is_bar_test.rst
+++ b/tests/functional/baseline-squash-hierarchy/is_bar_test.rst
@@ -19,5 +19,5 @@ ns2.col.is_bar test
 
     To use it in a playbook, specify: :code:`ns2.col.is_bar`.
 
-- This is a redirect to the :ref:`ns2.col.bar test plugin <ansible_collections.ns2.col.bar_test>`.
+- This is a redirect to the :ansplugin:`ns2.col.bar test plugin <ns2.col.bar#test>`.
 - This redirect does **not** work with Ansible 2.9.

--- a/tests/functional/baseline-use-html-blobs/collections/callback_index_stdout.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/callback_index_stdout.rst
@@ -11,5 +11,5 @@ See :ref:`list_of_callback_plugins` for the list of *all* callback plugins.
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_callback>` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
+* :ansplugin:`ns2.col.foo#callback` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
 

--- a/tests/functional/baseline-use-html-blobs/collections/environment_variables.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/environment_variables.rst
@@ -14,28 +14,28 @@ Environment variables used by the ansible-core configuration are documented in :
     Foo executable.
 
     *Used by:*
-    :ref:`ns2.col.foo become plugin <ansible_collections.ns2.col.foo_become>`
+    :ansplugin:`ns2.col.foo become plugin <ns2.col.foo#become>`
 .. envvar:: ANSIBLE_FOO_FILENAME_EXT
 
     All extensions to check.
 
     *Used by:*
-    :ref:`ns2.col.foo vars plugin <ansible_collections.ns2.col.foo_vars>`
+    :ansplugin:`ns2.col.foo vars plugin <ns2.col.foo#vars>`
 .. envvar:: ANSIBLE_FOO_USER
 
     User you 'become' to execute the task.
 
     *Used by:*
-    :ref:`ns2.col.foo become plugin <ansible_collections.ns2.col.foo_become>`
+    :ansplugin:`ns2.col.foo become plugin <ns2.col.foo#become>`
 .. envvar:: ANSIBLE_REMOTE_TEMP
 
     Temporary directory to use on targets when executing tasks.
 
     *Used by:*
-    :ref:`ns2.col.foo shell plugin <ansible_collections.ns2.col.foo_shell>`
+    :ansplugin:`ns2.col.foo shell plugin <ns2.col.foo#shell>`
 .. envvar:: ANSIBLE_REMOTE_TMP
 
     Temporary directory to use on targets when executing tasks.
 
     *Used by:*
-    :ref:`ns2.col.foo shell plugin <ansible_collections.ns2.col.foo_shell>`
+    :ansplugin:`ns2.col.foo shell plugin <ns2.col.foo#shell>`

--- a/tests/functional/baseline-use-html-blobs/collections/index_become.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_become.rst
@@ -9,5 +9,5 @@ Index of all Become Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_become>` -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
+* :ansplugin:`ns2.col.foo#become` -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
 

--- a/tests/functional/baseline-use-html-blobs/collections/index_cache.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_cache.rst
@@ -9,5 +9,5 @@ Index of all Cache Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_cache>` -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
+* :ansplugin:`ns2.col.foo#cache` -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
 

--- a/tests/functional/baseline-use-html-blobs/collections/index_callback.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_callback.rst
@@ -17,5 +17,5 @@ Index of all Callback Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_callback>` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
+* :ansplugin:`ns2.col.foo#callback` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
 

--- a/tests/functional/baseline-use-html-blobs/collections/index_cliconf.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_cliconf.rst
@@ -9,5 +9,5 @@ Index of all Cliconf Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_cliconf>` -- Foo router CLI config
+* :ansplugin:`ns2.col.foo#cliconf` -- Foo router CLI config
 

--- a/tests/functional/baseline-use-html-blobs/collections/index_connection.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_connection.rst
@@ -9,5 +9,5 @@ Index of all Connection Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_connection>` -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
+* :ansplugin:`ns2.col.foo#connection` -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
 

--- a/tests/functional/baseline-use-html-blobs/collections/index_filter.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_filter.rst
@@ -9,6 +9,6 @@ Index of all Filter Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.bar <ansible_collections.ns2.col.bar_filter>` -- The bar filter
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_filter>` -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
+* :ansplugin:`ns2.col.bar#filter` -- The bar filter
+* :ansplugin:`ns2.col.foo#filter` -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
 

--- a/tests/functional/baseline-use-html-blobs/collections/index_inventory.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_inventory.rst
@@ -9,5 +9,5 @@ Index of all Inventory Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_inventory>` -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
+* :ansplugin:`ns2.col.foo#inventory` -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
 

--- a/tests/functional/baseline-use-html-blobs/collections/index_lookup.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_lookup.rst
@@ -9,5 +9,5 @@ Index of all Lookup Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>` -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
+* :ansplugin:`ns2.col.foo#lookup` -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
 

--- a/tests/functional/baseline-use-html-blobs/collections/index_module.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_module.rst
@@ -9,7 +9,7 @@ Index of all Modules
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_module>` -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
-* :ref:`ns2.col.foo2 <ansible_collections.ns2.col.foo2_module>` -- Another foo
-* :ref:`ns2.col.sub.foo3 <ansible_collections.ns2.col.sub.foo3_module>` -- A sub-foo
+* :ansplugin:`ns2.col.foo#module` -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
+* :ansplugin:`ns2.col.foo2#module` -- Another foo
+* :ansplugin:`ns2.col.sub.foo3#module` -- A sub-foo
 

--- a/tests/functional/baseline-use-html-blobs/collections/index_role.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_role.rst
@@ -9,5 +9,5 @@ Index of all Roles
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_role>` -- Foo role
+* :ansplugin:`ns2.col.foo#role` -- Foo role
 

--- a/tests/functional/baseline-use-html-blobs/collections/index_shell.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_shell.rst
@@ -9,5 +9,5 @@ Index of all Shell Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_shell>` -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
+* :ansplugin:`ns2.col.foo#shell` -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
 

--- a/tests/functional/baseline-use-html-blobs/collections/index_strategy.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_strategy.rst
@@ -9,5 +9,5 @@ Index of all Strategy Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_strategy>` -- Executes tasks in foo
+* :ansplugin:`ns2.col.foo#strategy` -- Executes tasks in foo
 

--- a/tests/functional/baseline-use-html-blobs/collections/index_test.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_test.rst
@@ -9,6 +9,6 @@ Index of all Test Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.bar <ansible_collections.ns2.col.bar_test>` -- Is something a bar
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_test>` -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
+* :ansplugin:`ns2.col.bar#test` -- Is something a bar
+* :ansplugin:`ns2.col.foo#test` -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
 

--- a/tests/functional/baseline-use-html-blobs/collections/index_vars.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_vars.rst
@@ -9,5 +9,5 @@ Index of all Vars Plugins
 ns2.col
 -------
 
-* :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_vars>` -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
+* :ansplugin:`ns2.col.foo#vars` -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_redirect_module.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_redirect_module.rst
@@ -19,5 +19,5 @@ ns2.col.foo_redirect module
 
     To use it in a playbook, specify: :code:`ns2.col.foo_redirect`.
 
-- This is a redirect to the :ref:`ns2.col.foo module <ansible_collections.ns2.col.foo_module>`.
+- This is a redirect to the :ansplugin:`ns2.col.foo module <ns2.col.foo#module>`.
 - This redirect does **not** work with Ansible 2.9.

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/index.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/index.rst
@@ -74,9 +74,9 @@ These are the plugins in the ns2.col collection:
 Modules
 ~~~~~~~
 
-* :ref:`foo module <ansible_collections.ns2.col.foo_module>` -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
-* :ref:`foo2 module <ansible_collections.ns2.col.foo2_module>` -- Another foo
-* :ref:`sub.foo3 module <ansible_collections.ns2.col.sub.foo3_module>` -- A sub-foo
+* :ansplugin:`foo module <ns2.col.foo#module>` -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
+* :ansplugin:`foo2 module <ns2.col.foo2#module>` -- Another foo
+* :ansplugin:`sub.foo3 module <ns2.col.sub.foo3#module>` -- A sub-foo
 
 .. toctree::
     :maxdepth: 1
@@ -90,7 +90,7 @@ Modules
 Become Plugins
 ~~~~~~~~~~~~~~
 
-* :ref:`foo become <ansible_collections.ns2.col.foo_become>` -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
+* :ansplugin:`foo become <ns2.col.foo#become>` -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -102,7 +102,7 @@ Become Plugins
 Cache Plugins
 ~~~~~~~~~~~~~
 
-* :ref:`foo cache <ansible_collections.ns2.col.foo_cache>` -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
+* :ansplugin:`foo cache <ns2.col.foo#cache>` -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -114,7 +114,7 @@ Cache Plugins
 Callback Plugins
 ~~~~~~~~~~~~~~~~
 
-* :ref:`foo callback <ansible_collections.ns2.col.foo_callback>` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
+* :ansplugin:`foo callback <ns2.col.foo#callback>` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -126,7 +126,7 @@ Callback Plugins
 Cliconf Plugins
 ~~~~~~~~~~~~~~~
 
-* :ref:`foo cliconf <ansible_collections.ns2.col.foo_cliconf>` -- Foo router CLI config
+* :ansplugin:`foo cliconf <ns2.col.foo#cliconf>` -- Foo router CLI config
 
 .. toctree::
     :maxdepth: 1
@@ -138,7 +138,7 @@ Cliconf Plugins
 Connection Plugins
 ~~~~~~~~~~~~~~~~~~
 
-* :ref:`foo connection <ansible_collections.ns2.col.foo_connection>` -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
+* :ansplugin:`foo connection <ns2.col.foo#connection>` -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -150,8 +150,8 @@ Connection Plugins
 Filter Plugins
 ~~~~~~~~~~~~~~
 
-* :ref:`bar filter <ansible_collections.ns2.col.bar_filter>` -- The bar filter
-* :ref:`foo filter <ansible_collections.ns2.col.foo_filter>` -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
+* :ansplugin:`bar filter <ns2.col.bar#filter>` -- The bar filter
+* :ansplugin:`foo filter <ns2.col.foo#filter>` -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -164,7 +164,7 @@ Filter Plugins
 Inventory Plugins
 ~~~~~~~~~~~~~~~~~
 
-* :ref:`foo inventory <ansible_collections.ns2.col.foo_inventory>` -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
+* :ansplugin:`foo inventory <ns2.col.foo#inventory>` -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -176,7 +176,7 @@ Inventory Plugins
 Lookup Plugins
 ~~~~~~~~~~~~~~
 
-* :ref:`foo lookup <ansible_collections.ns2.col.foo_lookup>` -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
+* :ansplugin:`foo lookup <ns2.col.foo#lookup>` -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -188,7 +188,7 @@ Lookup Plugins
 Shell Plugins
 ~~~~~~~~~~~~~
 
-* :ref:`foo shell <ansible_collections.ns2.col.foo_shell>` -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
+* :ansplugin:`foo shell <ns2.col.foo#shell>` -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -200,7 +200,7 @@ Shell Plugins
 Strategy Plugins
 ~~~~~~~~~~~~~~~~
 
-* :ref:`foo strategy <ansible_collections.ns2.col.foo_strategy>` -- Executes tasks in foo
+* :ansplugin:`foo strategy <ns2.col.foo#strategy>` -- Executes tasks in foo
 
 .. toctree::
     :maxdepth: 1
@@ -212,8 +212,8 @@ Strategy Plugins
 Test Plugins
 ~~~~~~~~~~~~
 
-* :ref:`bar test <ansible_collections.ns2.col.bar_test>` -- Is something a bar
-* :ref:`foo test <ansible_collections.ns2.col.foo_test>` -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
+* :ansplugin:`bar test <ns2.col.bar#test>` -- Is something a bar
+* :ansplugin:`foo test <ns2.col.foo#test>` -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -226,7 +226,7 @@ Test Plugins
 Vars Plugins
 ~~~~~~~~~~~~
 
-* :ref:`foo vars <ansible_collections.ns2.col.foo_vars>` -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
+* :ansplugin:`foo vars <ns2.col.foo#vars>` -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
 
 .. toctree::
     :maxdepth: 1
@@ -240,7 +240,7 @@ Role Index
 
 These are the roles in the ns2.col collection:
 
-* :ref:`foo role <ansible_collections.ns2.col.foo_role>` -- Foo role
+* :ansplugin:`foo role <ns2.col.foo#role>` -- Foo role
 
 .. toctree::
     :maxdepth: 1

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/is_bar_test.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/is_bar_test.rst
@@ -19,5 +19,5 @@ ns2.col.is_bar test
 
     To use it in a playbook, specify: :code:`ns2.col.is_bar`.
 
-- This is a redirect to the :ref:`ns2.col.bar test plugin <ansible_collections.ns2.col.bar_test>`.
+- This is a redirect to the :ansplugin:`ns2.col.bar test plugin <ns2.col.bar#test>`.
 - This redirect does **not** work with Ansible 2.9.

--- a/tests/functional/build-docs-baseline.sh
+++ b/tests/functional/build-docs-baseline.sh
@@ -19,7 +19,7 @@ make_docsite_baseline() {
         set -e
     )
 
-    rstcheck --report-level warning --ignore-roles ansible-option-default,ansible-rv-sample-value,ansopt,ansval,ansretval,ansible-option-choices-entry-default,ansible-option-choices-entry,ansenvvar,ansenvvarref -r "${DEST}" 2>&1 | (
+    rstcheck --report-level warning --ignore-roles ansible-option-default,ansible-rv-sample-value,ansopt,ansval,ansretval,ansplugin,ansible-option-choices-entry-default,ansible-option-choices-entry,ansenvvar,ansenvvarref -r "${DEST}" 2>&1 | (
         set +e
         grep -v "CRITICAL:rstcheck_core.checker:An \`AttributeError\` error occured."
         set -e


### PR DESCRIPTION
This makes it easier to reference to modules, plugins, and roles from extra docsite documentation. There's no longer a need to manually and explicitly compose references.