### PR TITLE
Fix redirect finding and alias reporting

### DIFF
--- a/changelogs/fragments/183-routing.yml
+++ b/changelogs/fragments/183-routing.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - "When looking for redirects, the ``aliases`` field and filesystem redirects in ansible-core were not properly considered.
+     This ensures that all redirect stubs are created, and that no duplicates show up, not depending on whether ansible-core is installed in editable mode or not
+     (https://github.com/ansible-community/antsibull-docs/pull/183)."

--- a/changelogs/fragments/183-routing.yml
+++ b/changelogs/fragments/183-routing.yml
@@ -2,3 +2,4 @@ bugfixes:
   - "When looking for redirects, the ``aliases`` field and filesystem redirects in ansible-core were not properly considered.
      This ensures that all redirect stubs are created, and that no duplicates show up, not depending on whether ansible-core is installed in editable mode or not
      (https://github.com/ansible-community/antsibull-docs/pull/183)."
+  - "Make sure that all aliases are actually listed for plugins (https://github.com/ansible-community/antsibull-docs/pull/183)."

--- a/src/antsibull_docs/augment_docs.py
+++ b/src/antsibull_docs/augment_docs.py
@@ -8,9 +8,11 @@
 from __future__ import annotations
 
 import typing as t
+from collections import defaultdict
 from collections.abc import Mapping, MutableMapping
 
-from antsibull_docs.utils.rst import massage_rst_label
+from .docs_parsing.routing import CollectionRoutingT
+from .utils.rst import massage_rst_label
 
 
 def add_full_key(
@@ -99,7 +101,25 @@ def _add_seealso(
             entry["description"] = desc
 
 
-def augment_docs(plugin_info: MutableMapping[str, MutableMapping[str, t.Any]]) -> None:
+def _add_aliases(
+    plugin_name: str,
+    plugin_record: MutableMapping[str, t.Any],
+    routing_sources: list[str],
+) -> None:
+    collection_prefix = ".".join(plugin_name.split(".", 2)[:2]) + "."
+    for redirect in routing_sources:
+        if redirect.startswith(collection_prefix):
+            alias = redirect[len(collection_prefix) :]
+            if "aliases" not in plugin_record:
+                plugin_record["aliases"] = []
+            if alias not in plugin_record["aliases"]:
+                plugin_record["aliases"].append(alias)
+
+
+def augment_docs(
+    plugin_info: MutableMapping[str, MutableMapping[str, t.Any]],
+    collection_routing: CollectionRoutingT,
+) -> None:
     """
     Add additional data to the data extracted from the plugins.
 
@@ -115,14 +135,24 @@ def augment_docs(plugin_info: MutableMapping[str, MutableMapping[str, t.Any]]) -
     .. warning:: This function operates by side-effect.  The plugin_info dictionay is modified
         directly.
     """
-    for _, plugin_map in plugin_info.items():
-        for _, plugin_record in plugin_map.items():
+    for plugin_type, plugin_map in plugin_info.items():
+        # First collect all routing targets
+        routing_sources: defaultdict[str, list[str]] = defaultdict(list)
+        for plugin_name, plugin_meta in collection_routing[plugin_type].items():
+            redirect = plugin_meta.get("redirect")
+            if isinstance(redirect, str):
+                routing_sources[redirect].append(plugin_name)
+        # Now augment all plugin records
+        for plugin_name, plugin_record in plugin_map.items():
             if plugin_record.get("return"):
                 add_full_key(plugin_record["return"], "contains")
             if plugin_record.get("doc"):
                 add_full_key(plugin_record["doc"]["options"], "suboptions")
                 if plugin_record["doc"].get("seealso"):
                     _add_seealso(plugin_record["doc"]["seealso"], plugin_info)
+                _add_aliases(
+                    plugin_name, plugin_record["doc"], routing_sources[plugin_name]
+                )
             if plugin_record.get("entry_points"):
                 for entry_point in plugin_record["entry_points"].values():
                     add_full_key(entry_point["options"], "options")

--- a/src/antsibull_docs/augment_docs.py
+++ b/src/antsibull_docs/augment_docs.py
@@ -138,7 +138,7 @@ def augment_docs(
     for plugin_type, plugin_map in plugin_info.items():
         # First collect all routing targets
         routing_sources: defaultdict[str, list[str]] = defaultdict(list)
-        for plugin_name, plugin_meta in collection_routing[plugin_type].items():
+        for plugin_name, plugin_meta in collection_routing.get(plugin_type, {}).items():
             redirect = plugin_meta.get("redirect")
             if isinstance(redirect, str):
                 routing_sources[redirect].append(plugin_name)

--- a/src/antsibull_docs/cli/doc_commands/_build.py
+++ b/src/antsibull_docs/cli/doc_commands/_build.py
@@ -119,6 +119,8 @@ def generate_docs_for_all_collections(
 
     remove_redirect_duplicates(plugin_info, collection_routing)
     stubs_info = find_stubs(plugin_info, collection_routing)
+    if collection_names is not None and "ansible.builtin" not in collection_names:
+        stubs_info.pop("ansible.builtin", None)
     # flog.fields(stubs_info=stubs_info).debug('Stubs info')
 
     new_plugin_info, nonfatal_errors = asyncio.run(

--- a/src/antsibull_docs/cli/doc_commands/_build.py
+++ b/src/antsibull_docs/cli/doc_commands/_build.py
@@ -127,7 +127,7 @@ def generate_docs_for_all_collections(
         normalize_all_plugin_info(plugin_info)
     )
     flog.fields(errors=len(nonfatal_errors)).notice("Finished data validation")
-    augment_docs(new_plugin_info)
+    augment_docs(new_plugin_info, collection_routing)
     flog.notice("Finished calculating new data")
 
     # Load collection extra docs data

--- a/src/antsibull_docs/cli/doc_commands/plugin.py
+++ b/src/antsibull_docs/cli/doc_commands/plugin.py
@@ -103,7 +103,8 @@ def generate_plugin_docs(
         t.cast(
             MutableMapping[str, MutableMapping[str, t.Any]],
             {plugin_type: {plugin_name: plugin_info}},
-        )
+        ),
+        {},
     )
 
     # Setup the jinja environment

--- a/src/antsibull_docs/data/docsite/ansible-docsite/plugin.rst.j2
+++ b/src/antsibull_docs/data/docsite/ansible-docsite/plugin.rst.j2
@@ -57,16 +57,6 @@
 .. _@{ doc['name'] }@_@{ plugin_type }@:
 {% endif -%}
 
-.. Anchors: aliases
-
-{# TODO: This assumes that aliases will be short names.
-   If they're FQCN, then we need to change this
-#}
-
-{% for alias in doc['aliases'] -%}
-.. _ansible_collections.@{collection}@.@{ alias }@_@{ plugin_type }@:
-{% endfor %}
-
 .. Title
 
 {% if doc['short_description'] -%}

--- a/src/antsibull_docs/data/docsite/ansible-docsite/plugin.rst.j2
+++ b/src/antsibull_docs/data/docsite/ansible-docsite/plugin.rst.j2
@@ -162,7 +162,7 @@ Synopsis
 .. Aliases
 
 {% if doc['aliases'] -%}
-Aliases: @{ ','.join(aliases) }@
+Aliases: @{ ', '.join(doc['aliases'] | sort) }@
 {% endif %}
 
 .. Requirements

--- a/src/antsibull_docs/data/docsite/ansible-docsite/role.rst.j2
+++ b/src/antsibull_docs/data/docsite/ansible-docsite/role.rst.j2
@@ -40,12 +40,6 @@
 
 .. _ansible_collections.@{plugin_name}@_@{plugin_type}@:
 
-.. Anchors: aliases
-
-{# TODO: This assumes that aliases will be short names.
-   If they're FQCN, then we need to change this
-#}
-
 .. Title
 
 {% if entry_points.main and entry_points.main.short_description -%}

--- a/src/antsibull_docs/lint_plugin_docs.py
+++ b/src/antsibull_docs/lint_plugin_docs.py
@@ -584,7 +584,7 @@ def _lint_collection_plugin_docs(
     new_plugin_info, nonfatal_errors = asyncio.run(
         normalize_all_plugin_info(plugin_info)
     )
-    augment_docs(new_plugin_info)
+    augment_docs(new_plugin_info, collection_routing)
     # Load link data
     link_data = asyncio.run(
         load_collections_links(

--- a/tests/functional/baseline-default/collections/ns/col2/bar_role.rst
+++ b/tests/functional/baseline-default/collections/ns/col2/bar_role.rst
@@ -22,9 +22,6 @@
 
 .. _ansible_collections.ns.col2.bar_role:
 
-.. Anchors: aliases
-
-
 .. Title
 
 ns.col2.bar role -- Bar role

--- a/tests/functional/baseline-default/collections/ns/col2/foo2_module.rst
+++ b/tests/functional/baseline-default/collections/ns/col2/foo2_module.rst
@@ -30,10 +30,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns.col2.foo2 module -- Foo two

--- a/tests/functional/baseline-default/collections/ns/col2/foo3_module.rst
+++ b/tests/functional/baseline-default/collections/ns/col2/foo3_module.rst
@@ -30,10 +30,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns.col2.foo3 module -- Foo III

--- a/tests/functional/baseline-default/collections/ns/col2/foo4_module.rst
+++ b/tests/functional/baseline-default/collections/ns/col2/foo4_module.rst
@@ -30,10 +30,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns.col2.foo4 module -- Markup reference linting test

--- a/tests/functional/baseline-default/collections/ns2/col/bar_filter.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/bar_filter.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.bar filter -- The bar filter

--- a/tests/functional/baseline-default/collections/ns2/col/bar_test.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/bar_test.rst
@@ -31,11 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-.. _ansible_collections.ns2.col.is_bar_test:
-
 .. Title
 
 ns2.col.bar test -- Is something a bar

--- a/tests/functional/baseline-default/collections/ns2/col/bar_test.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/bar_test.rst
@@ -65,7 +65,7 @@ Synopsis
 
 .. Aliases
 
-Aliases: 
+Aliases: is_bar
 
 .. Requirements
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo2_module.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo2_module.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo2 module -- Another foo

--- a/tests/functional/baseline-default/collections/ns2/col/foo_become.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_become.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo become -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_cache.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_cache.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo cache -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_callback.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_callback.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo callback -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_cliconf.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_cliconf.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo cliconf -- Foo router CLI config

--- a/tests/functional/baseline-default/collections/ns2/col/foo_connection.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_connection.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo connection -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_filter.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_filter.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo filter -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_inventory.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_inventory.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo inventory -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_lookup.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_lookup.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo lookup -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_module.rst
@@ -72,6 +72,7 @@ Synopsis
 
 .. Aliases
 
+Aliases: foo_redirect
 
 .. Requirements
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_module.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo module -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_redirect_module.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_redirect_module.rst
@@ -1,0 +1,23 @@
+
+.. Document meta
+
+:orphan:
+
+.. Anchors
+
+.. _ansible_collections.ns2.col.foo_redirect_module:
+
+.. Title
+
+ns2.col.foo_redirect module
++++++++++++++++++++++++++++
+
+.. Collection note
+
+.. note::
+    This redirect is part of the `ns2.col collection <https://galaxy.ansible.com/ns2/col>`_ (version 2.1.0).
+
+    To use it in a playbook, specify: :code:`ns2.col.foo_redirect`.
+
+- This is a redirect to the :ref:`ns2.col.foo module <ansible_collections.ns2.col.foo_module>`.
+- This redirect does **not** work with Ansible 2.9.

--- a/tests/functional/baseline-default/collections/ns2/col/foo_role.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_role.rst
@@ -23,9 +23,6 @@
 
 .. _ansible_collections.ns2.col.foo_role:
 
-.. Anchors: aliases
-
-
 .. Title
 
 ns2.col.foo role -- Foo role

--- a/tests/functional/baseline-default/collections/ns2/col/foo_shell.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_shell.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo shell -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_strategy.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_strategy.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo strategy -- Executes tasks in foo

--- a/tests/functional/baseline-default/collections/ns2/col/foo_test.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_test.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo test -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_vars.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_vars.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo vars -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 

--- a/tests/functional/baseline-default/collections/ns2/col/sub.foo3_module.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/sub.foo3_module.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.sub.foo3 module -- A sub-foo

--- a/tests/functional/baseline-default/collections/ns2/flatcol/foo2_module.rst
+++ b/tests/functional/baseline-default/collections/ns2/flatcol/foo2_module.rst
@@ -30,10 +30,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.flatcol.foo2 module -- Another foo

--- a/tests/functional/baseline-default/collections/ns2/flatcol/foo_module.rst
+++ b/tests/functional/baseline-default/collections/ns2/flatcol/foo_module.rst
@@ -30,10 +30,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.flatcol.foo module -- Do some foo \ :ansopt:`ns2.flatcol.foo#module:bar`\ 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/bar_role.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/bar_role.rst
@@ -22,9 +22,6 @@
 
 .. _ansible_collections.ns.col2.bar_role:
 
-.. Anchors: aliases
-
-
 .. Title
 
 ns.col2.bar role -- Bar role

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/foo2_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/foo2_module.rst
@@ -30,10 +30,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns.col2.foo2 module -- Foo two

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/foo3_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/foo3_module.rst
@@ -30,10 +30,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns.col2.foo3 module -- Foo III

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/foo4_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/foo4_module.rst
@@ -30,10 +30,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns.col2.foo4 module -- Markup reference linting test

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/bar_filter.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/bar_filter.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.bar filter -- The bar filter

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/bar_test.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/bar_test.rst
@@ -31,11 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-.. _ansible_collections.ns2.col.is_bar_test:
-
 .. Title
 
 ns2.col.bar test -- Is something a bar

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/bar_test.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/bar_test.rst
@@ -65,7 +65,7 @@ Synopsis
 
 .. Aliases
 
-Aliases: 
+Aliases: is_bar
 
 .. Requirements
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo2_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo2_module.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo2 module -- Another foo

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_become.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_become.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo become -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_cache.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_cache.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo cache -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_callback.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_callback.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo callback -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_cliconf.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_cliconf.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo cliconf -- Foo router CLI config

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_connection.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_connection.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo connection -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_filter.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_filter.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo filter -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_inventory.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_inventory.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo inventory -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_lookup.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_lookup.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo lookup -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_module.rst
@@ -72,6 +72,7 @@ Synopsis
 
 .. Aliases
 
+Aliases: foo_redirect
 
 .. Requirements
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_module.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo module -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_redirect_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_redirect_module.rst
@@ -1,0 +1,23 @@
+
+.. Document meta
+
+:orphan:
+
+.. Anchors
+
+.. _ansible_collections.ns2.col.foo_redirect_module:
+
+.. Title
+
+ns2.col.foo_redirect module
++++++++++++++++++++++++++++
+
+.. Collection note
+
+.. note::
+    This redirect is part of the `ns2.col collection <https://galaxy.ansible.com/ns2/col>`_ (version 2.1.0).
+
+    To use it in a playbook, specify: :code:`ns2.col.foo_redirect`.
+
+- This is a redirect to the :ref:`ns2.col.foo module <ansible_collections.ns2.col.foo_module>`.
+- This redirect does **not** work with Ansible 2.9.

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_role.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_role.rst
@@ -23,9 +23,6 @@
 
 .. _ansible_collections.ns2.col.foo_role:
 
-.. Anchors: aliases
-
-
 .. Title
 
 ns2.col.foo role -- Foo role

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_shell.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_shell.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo shell -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_strategy.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_strategy.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo strategy -- Executes tasks in foo

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_test.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_test.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo test -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_vars.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_vars.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo vars -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/sub.foo3_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/sub.foo3_module.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.sub.foo3 module -- A sub-foo

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/flatcol/foo2_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/flatcol/foo2_module.rst
@@ -30,10 +30,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.flatcol.foo2 module -- Another foo

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/flatcol/foo_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/flatcol/foo_module.rst
@@ -30,10 +30,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.flatcol.foo module -- Do some foo \ :ansopt:`ns2.flatcol.foo#module:bar`\ 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/bar_filter.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/bar_filter.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.bar filter -- The bar filter

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/bar_test.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/bar_test.rst
@@ -31,11 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-.. _ansible_collections.ns2.col.is_bar_test:
-
 .. Title
 
 ns2.col.bar test -- Is something a bar

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/bar_test.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/bar_test.rst
@@ -65,7 +65,7 @@ Synopsis
 
 .. Aliases
 
-Aliases: 
+Aliases: is_bar
 
 .. Requirements
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo2_module.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo2_module.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo2 module -- Another foo

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_become.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_become.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo become -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_cache.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_cache.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo cache -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_callback.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_callback.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo callback -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_cliconf.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_cliconf.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo cliconf -- Foo router CLI config

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_connection.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_connection.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo connection -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_filter.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_filter.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo filter -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_inventory.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_inventory.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo inventory -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_lookup.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_lookup.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo lookup -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_module.rst
@@ -72,6 +72,7 @@ Synopsis
 
 .. Aliases
 
+Aliases: foo_redirect
 
 .. Requirements
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_module.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo module -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_redirect_module.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_redirect_module.rst
@@ -1,0 +1,23 @@
+
+.. Document meta
+
+:orphan:
+
+.. Anchors
+
+.. _ansible_collections.ns2.col.foo_redirect_module:
+
+.. Title
+
+ns2.col.foo_redirect module
++++++++++++++++++++++++++++
+
+.. Collection note
+
+.. note::
+    This redirect is part of the `ns2.col collection <https://galaxy.ansible.com/ns2/col>`_ (version 2.1.0).
+
+    To use it in a playbook, specify: :code:`ns2.col.foo_redirect`.
+
+- This is a redirect to the :ref:`ns2.col.foo module <ansible_collections.ns2.col.foo_module>`.
+- This redirect does **not** work with Ansible 2.9.

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_role.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_role.rst
@@ -23,9 +23,6 @@
 
 .. _ansible_collections.ns2.col.foo_role:
 
-.. Anchors: aliases
-
-
 .. Title
 
 ns2.col.foo role -- Foo role

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_shell.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_shell.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo shell -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_strategy.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_strategy.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo strategy -- Executes tasks in foo

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_test.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_test.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo test -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_vars.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_vars.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo vars -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/sub.foo3_module.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/sub.foo3_module.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.sub.foo3 module -- A sub-foo

--- a/tests/functional/baseline-no-indexes/collections/ns2/flatcol/foo2_module.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/flatcol/foo2_module.rst
@@ -30,10 +30,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.flatcol.foo2 module -- Another foo

--- a/tests/functional/baseline-no-indexes/collections/ns2/flatcol/foo_module.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/flatcol/foo_module.rst
@@ -30,10 +30,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.flatcol.foo module -- Do some foo \ :ansopt:`ns2.flatcol.foo#module:bar`\ 

--- a/tests/functional/baseline-squash-hierarchy/bar_filter.rst
+++ b/tests/functional/baseline-squash-hierarchy/bar_filter.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.bar filter -- The bar filter

--- a/tests/functional/baseline-squash-hierarchy/bar_test.rst
+++ b/tests/functional/baseline-squash-hierarchy/bar_test.rst
@@ -31,11 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-.. _ansible_collections.ns2.col.is_bar_test:
-
 .. Title
 
 ns2.col.bar test -- Is something a bar

--- a/tests/functional/baseline-squash-hierarchy/bar_test.rst
+++ b/tests/functional/baseline-squash-hierarchy/bar_test.rst
@@ -65,7 +65,7 @@ Synopsis
 
 .. Aliases
 
-Aliases: 
+Aliases: is_bar
 
 .. Requirements
 

--- a/tests/functional/baseline-squash-hierarchy/foo2_module.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo2_module.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo2 module -- Another foo

--- a/tests/functional/baseline-squash-hierarchy/foo_become.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_become.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo become -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 

--- a/tests/functional/baseline-squash-hierarchy/foo_cache.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_cache.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo cache -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 

--- a/tests/functional/baseline-squash-hierarchy/foo_callback.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_callback.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo callback -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 

--- a/tests/functional/baseline-squash-hierarchy/foo_cliconf.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_cliconf.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo cliconf -- Foo router CLI config

--- a/tests/functional/baseline-squash-hierarchy/foo_connection.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_connection.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo connection -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 

--- a/tests/functional/baseline-squash-hierarchy/foo_filter.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_filter.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo filter -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 

--- a/tests/functional/baseline-squash-hierarchy/foo_inventory.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_inventory.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo inventory -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 

--- a/tests/functional/baseline-squash-hierarchy/foo_lookup.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_lookup.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo lookup -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 

--- a/tests/functional/baseline-squash-hierarchy/foo_module.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_module.rst
@@ -72,6 +72,7 @@ Synopsis
 
 .. Aliases
 
+Aliases: foo_redirect
 
 .. Requirements
 

--- a/tests/functional/baseline-squash-hierarchy/foo_module.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_module.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo module -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 

--- a/tests/functional/baseline-squash-hierarchy/foo_redirect_module.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_redirect_module.rst
@@ -1,0 +1,23 @@
+
+.. Document meta
+
+:orphan:
+
+.. Anchors
+
+.. _ansible_collections.ns2.col.foo_redirect_module:
+
+.. Title
+
+ns2.col.foo_redirect module
++++++++++++++++++++++++++++
+
+.. Collection note
+
+.. note::
+    This redirect is part of the `ns2.col collection <https://galaxy.ansible.com/ns2/col>`_ (version 2.1.0).
+
+    To use it in a playbook, specify: :code:`ns2.col.foo_redirect`.
+
+- This is a redirect to the :ref:`ns2.col.foo module <ansible_collections.ns2.col.foo_module>`.
+- This redirect does **not** work with Ansible 2.9.

--- a/tests/functional/baseline-squash-hierarchy/foo_role.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_role.rst
@@ -23,9 +23,6 @@
 
 .. _ansible_collections.ns2.col.foo_role:
 
-.. Anchors: aliases
-
-
 .. Title
 
 ns2.col.foo role -- Foo role

--- a/tests/functional/baseline-squash-hierarchy/foo_shell.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_shell.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo shell -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 

--- a/tests/functional/baseline-squash-hierarchy/foo_strategy.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_strategy.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo strategy -- Executes tasks in foo

--- a/tests/functional/baseline-squash-hierarchy/foo_test.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_test.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo test -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 

--- a/tests/functional/baseline-squash-hierarchy/foo_vars.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_vars.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo vars -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 

--- a/tests/functional/baseline-squash-hierarchy/sub.foo3_module.rst
+++ b/tests/functional/baseline-squash-hierarchy/sub.foo3_module.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.sub.foo3 module -- A sub-foo

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/bar_filter.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/bar_filter.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.bar filter -- The bar filter

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/bar_test.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/bar_test.rst
@@ -31,11 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-.. _ansible_collections.ns2.col.is_bar_test:
-
 .. Title
 
 ns2.col.bar test -- Is something a bar

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/bar_test.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/bar_test.rst
@@ -65,7 +65,7 @@ Synopsis
 
 .. Aliases
 
-Aliases: 
+Aliases: is_bar
 
 .. Requirements
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo2_module.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo2_module.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo2 module -- Another foo

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_become.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_become.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo become -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_cache.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_cache.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo cache -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_callback.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_callback.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo callback -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_cliconf.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_cliconf.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo cliconf -- Foo router CLI config

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_connection.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_connection.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo connection -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_filter.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_filter.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo filter -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_inventory.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_inventory.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo inventory -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_lookup.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_lookup.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo lookup -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_module.rst
@@ -72,6 +72,7 @@ Synopsis
 
 .. Aliases
 
+Aliases: foo_redirect
 
 .. Requirements
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_module.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo module -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_redirect_module.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_redirect_module.rst
@@ -1,0 +1,23 @@
+
+.. Document meta
+
+:orphan:
+
+.. Anchors
+
+.. _ansible_collections.ns2.col.foo_redirect_module:
+
+.. Title
+
+ns2.col.foo_redirect module
++++++++++++++++++++++++++++
+
+.. Collection note
+
+.. note::
+    This redirect is part of the `ns2.col collection <https://galaxy.ansible.com/ns2/col>`_ (version 2.1.0).
+
+    To use it in a playbook, specify: :code:`ns2.col.foo_redirect`.
+
+- This is a redirect to the :ref:`ns2.col.foo module <ansible_collections.ns2.col.foo_module>`.
+- This redirect does **not** work with Ansible 2.9.

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_role.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_role.rst
@@ -23,9 +23,6 @@
 
 .. _ansible_collections.ns2.col.foo_role:
 
-.. Anchors: aliases
-
-
 .. Title
 
 ns2.col.foo role -- Foo role

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_shell.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_shell.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo shell -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_strategy.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_strategy.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo strategy -- Executes tasks in foo

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_test.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_test.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo test -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_vars.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_vars.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.foo vars -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/sub.foo3_module.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/sub.foo3_module.rst
@@ -31,10 +31,6 @@
 
 .. Anchors: short name for ansible.builtin
 
-.. Anchors: aliases
-
-
-
 .. Title
 
 ns2.col.sub.foo3 module -- A sub-foo

--- a/tests/functional/collections/ansible_collections/ns2/col/meta/runtime.yml
+++ b/tests/functional/collections/ansible_collections/ns2/col/meta/runtime.yml
@@ -18,3 +18,6 @@ plugin_routing:
       deprecation:
         removal_version: 5.0.0
         warning_text: It will be gone
+  modules:
+    foo_redirect:
+      redirect: ns2.col.foo


### PR DESCRIPTION
Ref: https://github.com/ansible/ansible/issues/81148

Now scan ansible-core for symlinks to avoid problems with editable installs. Also make sure that duplicates are removed when non-editable installs are used: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/ has both systemd and systemd_service listed as separate modules.