### PR TITLE
Sphinx extension: log build errors next to emitting error markup

### DIFF
--- a/changelogs/fragments/187-role-errors.yml
+++ b/changelogs/fragments/187-role-errors.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - "When parsing errors happen during in the Sphinx extension, the extension now emits error messages during the build process next to emitting error markup (https://github.com/ansible-community/antsibull-docs/pull/187)."
+  - "When parsing errors happen in the Sphinx extension, the extension now emits error messages during the build process next to emitting error markup (https://github.com/ansible-community/antsibull-docs/pull/187)."

--- a/changelogs/fragments/187-role-errors.yml
+++ b/changelogs/fragments/187-role-errors.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "When parsing errors happen during in the Sphinx extension, the extension now emits error messages during the build process next to emitting error markup (https://github.com/ansible-community/antsibull-docs/pull/187)."

--- a/changelogs/fragments/187-role-errors.yml
+++ b/changelogs/fragments/187-role-errors.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - "When parsing errors happen in the Sphinx extension, the extension now emits error messages during the build process next to emitting error markup (https://github.com/ansible-community/antsibull-docs/pull/187)."
+  - "When parsing errors happen in the Sphinx extension, the extension now emits error messages during the build process in addition to error markup (https://github.com/ansible-community/antsibull-docs/pull/187)."

--- a/src/sphinx_antsibull_ext/roles.py
+++ b/src/sphinx_antsibull_ext/roles.py
@@ -163,7 +163,6 @@ def _create_ref_or_not(
     return refnode
 
 
-# pylint:disable-next=unused-argument
 def _create_error(rawtext: str, text: str, error: str) -> tuple[list[t.Any], list[str]]:
     content = nodes.strong(text, error, classes=["error"])
     logger.error(

--- a/src/sphinx_antsibull_ext/roles.py
+++ b/src/sphinx_antsibull_ext/roles.py
@@ -14,6 +14,7 @@ import typing as t
 from docutils import nodes
 from docutils.utils import unescape  # pyre-ignore[21]
 from sphinx import addnodes
+from sphinx.util import logging
 
 from antsibull_docs.markup.semantic_helper import (
     parse_option,
@@ -23,6 +24,8 @@ from antsibull_docs.markup.semantic_helper import (
 from antsibull_docs.utils.rst import massage_rst_label
 
 from .sphinx_helper import extract_explicit_title
+
+logger = logging.getLogger(__name__)
 
 
 def _plugin_ref(plugin_fqcn: str, plugin_type: str) -> str:
@@ -163,6 +166,9 @@ def _create_ref_or_not(
 # pylint:disable-next=unused-argument
 def _create_error(rawtext: str, text: str, error: str) -> tuple[list[t.Any], list[str]]:
     content = nodes.strong(text, error, classes=["error"])
+    logger.error(
+        f"while processing {rawtext}: {error}", location=content, type="semantic-markup"
+    )
     return [content], []
 
 


### PR DESCRIPTION
So far, when the roles in the Sphinx extension were used with bad data, only error markup was generated, but no log output was printed during the build.

Example input:
```rst
[...]

:ansplugin:`foo.bar.baz`
:ansopt:`foo.bar.baz:bam`

:ansretval:`foo.bar.baz#bamboo`
:ansplugin:`foo.bar.baz#module`

[...]
```

Example output:
```
[..]
reading sources... [100%] index
/path/to/index.rst:7: ERROR: while processing :ansplugin:`foo.bar.baz`: Cannot extract plugin name and type
/path/to/index.rst:7: ERROR: while processing :ansopt:`foo.bar.baz:bam`: Invalid option name "foo.bar.baz:bam"
/path/to/index.rst:10: ERROR: while processing :ansretval:`foo.bar.baz#bamboo`: Invalid return value name "foo.bar.baz#bamboo"
looking for now-outdated files... none found
[...]
writing output... [100%] index
/path/to/index.rst:10: WARNING: undefined label: 'ansible_collections.foo.bar.baz_module'
generating indices... done
[...]
```
(The undefined label warning was already printed before when Sphinx tries to resolve the reference. What's new are the errors printed while processing the sources.)