### PR TITLE
nox bump: always commit pyproject.toml

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -265,6 +265,9 @@ def bump(session: nox.Session):
         "CHANGELOG.rst",
         "changelogs/changelog.yaml",
         "changelogs/fragments/",
+        # pyproject.toml is not committed in the last step
+        # when the release_summary fragment is created manually
+        "pyproject.toml",
         external=True,
     )
     install(session, ".")  # Smoke test


### PR DESCRIPTION
Previously, when the release summary (session.posargs[1]) wasn't
specified, the pyproject.toml version bump wasn't committed.

Relates: https://github.com/ansible-community/antsibull-docs/issues/190
