### PR TITLE
LaTeX builder: add indent for nested options and return values

### DIFF
--- a/changelogs/fragments/195-problems.yml
+++ b/changelogs/fragments/195-problems.yml
@@ -1,3 +1,3 @@
 known_issues:
-  - "When using Sphinx builders other than HTML, the indentation for nested options and return values is missing,
-     and the collection links section is empty (https://github.com/ansible-community/antsibull-docs/pull/195)."
+  - "When using Sphinx builders other than HTML, the collection links section is empty (https://github.com/ansible-community/antsibull-docs/pull/195)."
+  - "When using Sphinx builders other than HTML and LaTeX, the indentation for nested options and return values is missing (https://github.com/ansible-community/antsibull-docs/pull/195)."

--- a/changelogs/fragments/198-latex-indent.yml
+++ b/changelogs/fragments/198-latex-indent.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Fix indent for nested options and return values with Spinx's LaTeX builder (https://github.com/ansible-community/antsibull-docs/pull/198)."

--- a/src/antsibull_docs/data/docsite/ansible-docsite/macros/parameters.rst.j2
+++ b/src/antsibull_docs/data/docsite/ansible-docsite/macros/parameters.rst.j2
@@ -30,6 +30,12 @@
 {% for full_key in value['full_keys'] %}
         <div class="ansibleOptionAnchor" id="parameter-@{ parameter_html_prefix }@{% for part in full_key %}@{ part | urlencode }@{% if not loop.last %}/{% endif %}{% endfor %}"></div>
 {% endfor %}
+{% if loop.depth > 1 %}
+
+      .. raw:: latex
+
+        \hspace{@{ 0.02 * loop.depth0 }@\textwidth}\begin{minipage}[t]{@{ 0.32 - 0.02 * loop.depth0 }@\textwidth}
+{% endif %}
 
 {% for full_key in value['full_keys_rst'] %}
       .. _ansible_collections.@{plugin_name}@_@{plugin_type}@__parameter-@{ parameter_rst_prefix }@{% for part in full_key %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}:
@@ -69,6 +75,12 @@
       .. raw:: html
 
         </div>
+{% if loop.depth > 1 %}
+
+      .. raw:: latex
+
+        \end{minipage}
+{% endif %}
 
 {#   description #}
     - .. raw:: html

--- a/src/antsibull_docs/data/docsite/ansible-docsite/macros/returnvalues.rst.j2
+++ b/src/antsibull_docs/data/docsite/ansible-docsite/macros/returnvalues.rst.j2
@@ -28,6 +28,12 @@
 {% for full_key in value['full_keys'] %}
         <div class="ansibleOptionAnchor" id="return-{% for part in full_key %}@{ part | urlencode }@{% if not loop.last %}/{% endif %}{% endfor %}"></div>
 {% endfor %}
+{% if loop.depth > 1 %}
+
+      .. raw:: latex
+
+        \hspace{@{ 0.02 * loop.depth0 }@\textwidth}\begin{minipage}[t]{@{ 0.32 - 0.02 * loop.depth0 }@\textwidth}
+{% endif %}
 
 {% for full_key in value['full_keys_rst'] %}
       .. _ansible_collections.@{plugin_name}@_@{plugin_type}@__return-{% for part in full_key %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}:
@@ -56,6 +62,12 @@
       .. raw:: html
 
         </div>
+{% if loop.depth > 1 %}
+
+      .. raw:: latex
+
+        \end{minipage}
+{% endif %}
 
     - .. raw:: html
 

--- a/tests/functional/baseline-default/collections/ns/col2/foo2_module.rst
+++ b/tests/functional/baseline-default/collections/ns/col2/foo2_module.rst
@@ -212,6 +212,10 @@ Parameters
         <div class="ansible-option-indent"></div><div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="parameter-subfoo/BaZ"></div>
 
+      .. raw:: latex
+
+        \hspace{0.02\textwidth}\begin{minipage}[t]{0.3\textwidth}
+
       .. _ansible_collections.ns.col2.foo2_module__parameter-subfoo/baz:
 
       .. rst-class:: ansible-option-title
@@ -230,6 +234,10 @@ Parameters
 
         </div>
 
+      .. raw:: latex
+
+        \end{minipage}
+
     - .. raw:: html
 
         <div class="ansible-option-indent-desc"></div><div class="ansible-option-cell">
@@ -245,6 +253,10 @@ Parameters
 
         <div class="ansible-option-indent"></div><div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="parameter-subfoo/foo"></div>
+
+      .. raw:: latex
+
+        \hspace{0.02\textwidth}\begin{minipage}[t]{0.3\textwidth}
 
       .. _ansible_collections.ns.col2.foo2_module__parameter-subfoo/foo:
 
@@ -263,6 +275,10 @@ Parameters
       .. raw:: html
 
         </div>
+
+      .. raw:: latex
+
+        \end{minipage}
 
     - .. raw:: html
 

--- a/tests/functional/baseline-default/collections/ns/col2/foo3_module.rst
+++ b/tests/functional/baseline-default/collections/ns/col2/foo3_module.rst
@@ -205,6 +205,10 @@ Parameters
         <div class="ansible-option-indent"></div><div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="parameter-subfoo/foo"></div>
 
+      .. raw:: latex
+
+        \hspace{0.02\textwidth}\begin{minipage}[t]{0.3\textwidth}
+
       .. _ansible_collections.ns.col2.foo3_module__parameter-subfoo/foo:
 
       .. rst-class:: ansible-option-title
@@ -222,6 +226,10 @@ Parameters
       .. raw:: html
 
         </div>
+
+      .. raw:: latex
+
+        \end{minipage}
 
     - .. raw:: html
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_module.rst
@@ -225,6 +225,10 @@ Parameters
         <div class="ansible-option-indent"></div><div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="parameter-subfoo/foo"></div>
 
+      .. raw:: latex
+
+        \hspace{0.02\textwidth}\begin{minipage}[t]{0.3\textwidth}
+
       .. _ansible_collections.ns2.col.foo_module__parameter-subfoo/foo:
 
       .. rst-class:: ansible-option-title
@@ -242,6 +246,10 @@ Parameters
       .. raw:: html
 
         </div>
+
+      .. raw:: latex
+
+        \end{minipage}
 
     - .. raw:: html
 

--- a/tests/functional/baseline-default/collections/ns2/flatcol/foo_module.rst
+++ b/tests/functional/baseline-default/collections/ns2/flatcol/foo_module.rst
@@ -221,6 +221,10 @@ Parameters
         <div class="ansibleOptionAnchor" id="parameter-subfoo/bam"></div>
         <div class="ansibleOptionAnchor" id="parameter-subbaz/bam"></div>
 
+      .. raw:: latex
+
+        \hspace{0.02\textwidth}\begin{minipage}[t]{0.3\textwidth}
+
       .. _ansible_collections.ns2.flatcol.foo_module__parameter-subbaz/bam:
       .. _ansible_collections.ns2.flatcol.foo_module__parameter-subbaz/foo:
       .. _ansible_collections.ns2.flatcol.foo_module__parameter-subfoo/bam:
@@ -245,6 +249,10 @@ Parameters
       .. raw:: html
 
         </div>
+
+      .. raw:: latex
+
+        \end{minipage}
 
     - .. raw:: html
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/foo2_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/foo2_module.rst
@@ -212,6 +212,10 @@ Parameters
         <div class="ansible-option-indent"></div><div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="parameter-subfoo/BaZ"></div>
 
+      .. raw:: latex
+
+        \hspace{0.02\textwidth}\begin{minipage}[t]{0.3\textwidth}
+
       .. _ansible_collections.ns.col2.foo2_module__parameter-subfoo/baz:
 
       .. rst-class:: ansible-option-title
@@ -230,6 +234,10 @@ Parameters
 
         </div>
 
+      .. raw:: latex
+
+        \end{minipage}
+
     - .. raw:: html
 
         <div class="ansible-option-indent-desc"></div><div class="ansible-option-cell">
@@ -245,6 +253,10 @@ Parameters
 
         <div class="ansible-option-indent"></div><div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="parameter-subfoo/foo"></div>
+
+      .. raw:: latex
+
+        \hspace{0.02\textwidth}\begin{minipage}[t]{0.3\textwidth}
 
       .. _ansible_collections.ns.col2.foo2_module__parameter-subfoo/foo:
 
@@ -263,6 +275,10 @@ Parameters
       .. raw:: html
 
         </div>
+
+      .. raw:: latex
+
+        \end{minipage}
 
     - .. raw:: html
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/foo3_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/foo3_module.rst
@@ -205,6 +205,10 @@ Parameters
         <div class="ansible-option-indent"></div><div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="parameter-subfoo/foo"></div>
 
+      .. raw:: latex
+
+        \hspace{0.02\textwidth}\begin{minipage}[t]{0.3\textwidth}
+
       .. _ansible_collections.ns.col2.foo3_module__parameter-subfoo/foo:
 
       .. rst-class:: ansible-option-title
@@ -222,6 +226,10 @@ Parameters
       .. raw:: html
 
         </div>
+
+      .. raw:: latex
+
+        \end{minipage}
 
     - .. raw:: html
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_module.rst
@@ -225,6 +225,10 @@ Parameters
         <div class="ansible-option-indent"></div><div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="parameter-subfoo/foo"></div>
 
+      .. raw:: latex
+
+        \hspace{0.02\textwidth}\begin{minipage}[t]{0.3\textwidth}
+
       .. _ansible_collections.ns2.col.foo_module__parameter-subfoo/foo:
 
       .. rst-class:: ansible-option-title
@@ -242,6 +246,10 @@ Parameters
       .. raw:: html
 
         </div>
+
+      .. raw:: latex
+
+        \end{minipage}
 
     - .. raw:: html
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/flatcol/foo_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/flatcol/foo_module.rst
@@ -221,6 +221,10 @@ Parameters
         <div class="ansibleOptionAnchor" id="parameter-subfoo/bam"></div>
         <div class="ansibleOptionAnchor" id="parameter-subbaz/bam"></div>
 
+      .. raw:: latex
+
+        \hspace{0.02\textwidth}\begin{minipage}[t]{0.3\textwidth}
+
       .. _ansible_collections.ns2.flatcol.foo_module__parameter-subbaz/bam:
       .. _ansible_collections.ns2.flatcol.foo_module__parameter-subbaz/foo:
       .. _ansible_collections.ns2.flatcol.foo_module__parameter-subfoo/bam:
@@ -245,6 +249,10 @@ Parameters
       .. raw:: html
 
         </div>
+
+      .. raw:: latex
+
+        \end{minipage}
 
     - .. raw:: html
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_module.rst
@@ -225,6 +225,10 @@ Parameters
         <div class="ansible-option-indent"></div><div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="parameter-subfoo/foo"></div>
 
+      .. raw:: latex
+
+        \hspace{0.02\textwidth}\begin{minipage}[t]{0.3\textwidth}
+
       .. _ansible_collections.ns2.col.foo_module__parameter-subfoo/foo:
 
       .. rst-class:: ansible-option-title
@@ -242,6 +246,10 @@ Parameters
       .. raw:: html
 
         </div>
+
+      .. raw:: latex
+
+        \end{minipage}
 
     - .. raw:: html
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/flatcol/foo_module.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/flatcol/foo_module.rst
@@ -221,6 +221,10 @@ Parameters
         <div class="ansibleOptionAnchor" id="parameter-subfoo/bam"></div>
         <div class="ansibleOptionAnchor" id="parameter-subbaz/bam"></div>
 
+      .. raw:: latex
+
+        \hspace{0.02\textwidth}\begin{minipage}[t]{0.3\textwidth}
+
       .. _ansible_collections.ns2.flatcol.foo_module__parameter-subbaz/bam:
       .. _ansible_collections.ns2.flatcol.foo_module__parameter-subbaz/foo:
       .. _ansible_collections.ns2.flatcol.foo_module__parameter-subfoo/bam:
@@ -245,6 +249,10 @@ Parameters
       .. raw:: html
 
         </div>
+
+      .. raw:: latex
+
+        \end{minipage}
 
     - .. raw:: html
 

--- a/tests/functional/baseline-squash-hierarchy/foo_module.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_module.rst
@@ -225,6 +225,10 @@ Parameters
         <div class="ansible-option-indent"></div><div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="parameter-subfoo/foo"></div>
 
+      .. raw:: latex
+
+        \hspace{0.02\textwidth}\begin{minipage}[t]{0.3\textwidth}
+
       .. _ansible_collections.ns2.col.foo_module__parameter-subfoo/foo:
 
       .. rst-class:: ansible-option-title
@@ -242,6 +246,10 @@ Parameters
       .. raw:: html
 
         </div>
+
+      .. raw:: latex
+
+        \end{minipage}
 
     - .. raw:: html
 


### PR DESCRIPTION
~~Currently includes #195 (modifies one of its changelog fragments). Will rebase once that is merged.~~

Uses `.. raw:: latex` to insert some hspace and a minipage when indentation of the left cell is needed. This isn't perfect, but a lot better than before (no indent at all).

Screenshot from the [community.dns.nameserver_record_info module return value docs](https://docs.ansible.com/ansible/latest/collections/community/dns/nameserver_record_info_module.html#return-values):
![screenshot](https://github.com/ansible-community/antsibull-docs/assets/5781356/53bfee28-f67f-4f83-95e3-7e61fb763d04)
