### PR TITLE
Improve support for other HTML-based builders

### DIFF
--- a/changelogs/fragments/201-builders.yml
+++ b/changelogs/fragments/201-builders.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Add basic support for other HTML based Sphinx builders such as ``epub`` and ``singlehtml`` (https://github.com/ansible-community/antsibull-docs/pull/201)."

--- a/src/sphinx_antsibull_ext/assets.py
+++ b/src/sphinx_antsibull_ext/assets.py
@@ -23,8 +23,38 @@ BUILDER_FILES = {
     },
 }
 
+# A map mapping builder names to the builder they inherit (indirectly) from.
+# Mainly necessary to link the myriad of HTML-derived builders to the main HTML
+# builder, to make sure that the stylesheet is copied in all these cases.
+_BUILDER_ALIASES = {
+    "applehelp": "html",
+    "devhelp": "html",
+    "dirhtml": "html",
+    "epub": "html",
+    "htmlhelp": "html",
+    "qthelp": "html",
+    "singlehtml": "html",
+    "websupport": "html",
+}
 
-def _copy_asset_files(app, exc):  # pylint: disable=unused-argument
+# A list of builders which needs the static files to be presented before the
+# build finishes. I only verified this for epub, since the others also provide
+# similar formats my guess is that they also need it.
+_BUILDER_COPY_ON_INITED = [
+    "applehelp",
+    "devhelp",
+    "epub",
+    "htmlhelp",
+    "qthelp",
+    "websupport",
+]
+
+for _builder_name, _alias in _BUILDER_ALIASES.items():
+    if _builder_name not in BUILDER_FILES and _alias in BUILDER_FILES:
+        BUILDER_FILES[_builder_name] = BUILDER_FILES[_alias]
+
+
+def _copy_asset_files(app):
     """
     Copy asset files.
     """
@@ -41,12 +71,38 @@ def _copy_asset_files(app, exc):  # pylint: disable=unused-argument
             f.write(data)
 
 
+def _copy_asset_files_inited(app):
+    # pylint: disable=line-too-long
+    """
+    Copy asset files on 'builder-inited' signal.
+
+    While the official documentation says that stylesheets should be copied
+    during the build-finished signal
+    (https://www.sphinx-doc.org/en/master/development/theming.html#add-your-own-static-files-to-the-build-assets)
+    this won't work for builders such as epub, since they assemble the epub
+    file *before* the build finishes. Since there is no other documented
+    signal when to copy over the files, I picked the 'builder-inited' signal.
+    """
+    # pylint: enable=line-too-long
+    if app.builder.name in _BUILDER_COPY_ON_INITED:
+        _copy_asset_files(app)
+
+
+def _copy_asset_files_finished(app, exc):  # pylint: disable=unused-argument
+    """
+    Copy asset files on 'build-finished' signal.
+    """
+    if app.builder.name not in _BUILDER_COPY_ON_INITED:
+        _copy_asset_files(app)
+
+
 def setup_assets(app):
     """
     Setup assets for a Sphinx app object.
     """
     # Copy assets
-    app.connect("build-finished", _copy_asset_files)
+    app.connect("builder-inited", _copy_asset_files_inited)
+    app.connect("build-finished", _copy_asset_files_finished)
 
     # Add CSS files
     for file in BUILDER_FILES.get("html", {}):


### PR DESCRIPTION
Currently includes ~~#195, #198,~~ #199 ~~, and #200~~. Will rebase once these are merged.

I tested `singlehtml` and `epub`; both work with this appendum. Previously they didn't got the stylesheet. For epub (and probably some more builders, I've added a list of guesses in the code), the stylesheet also needs to be copied earlier, otherwise it won't be included in the final epub file.