### PR TITLE
Update version and license information of Sphinx extension; make sure they are kept up to date

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ nox
 ## Creating a new release:
 
 1. Run `nox -e bump -- <version> <release_summary_message>`. This:
-   * Bumps the package version in `pyproject.toml`.
+   * Bumps the package version in `pyproject.toml` and `src/sphinx_antsibull_ext/__init__.py`.
    * Creates `changelogs/fragments/<version>.yml` with a `release_summary` section.
    * Runs `antsibull-changelog release` and adds the changed files to git.
    * Commits with message `Release <version>.` and runs `git tag -a -m 'antsibull-docs <version>' <version>`.

--- a/README.md
+++ b/README.md
@@ -115,9 +115,9 @@ nox
 ## Creating a new release:
 
 1. Run `nox -e bump -- <version> <release_summary_message>`. This:
-   * Bumps the package version in `pyproject.toml` and `src/antsibull_docs/__init__.py`.
+   * Bumps the package version in `src/antsibull_docs/__init__.py`.
    * Creates `changelogs/fragments/<version>.yml` with a `release_summary` section.
-   * Runs `antsibull-changelog release` and adds the changed files to git.
+   * Runs `antsibull-changelog release --version <version>` and adds the changed files to git.
    * Commits with message `Release <version>.` and runs `git tag -a -m 'antsibull-docs <version>' <version>`.
    * Runs `hatch build --clean`.
 2. Run `git push` to the appropriate remotes.

--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ nox
 ## Creating a new release:
 
 1. Run `nox -e bump -- <version> <release_summary_message>`. This:
-   * Bumps the package version in `pyproject.toml` and `src/sphinx_antsibull_ext/__init__.py`.
+   * Bumps the package version in `pyproject.toml`, `src/antsibull_docs/__init__.py`,
+     and `src/sphinx_antsibull_ext/__init__.py`.
    * Creates `changelogs/fragments/<version>.yml` with a `release_summary` section.
    * Runs `antsibull-changelog release` and adds the changed files to git.
    * Commits with message `Release <version>.` and runs `git tag -a -m 'antsibull-docs <version>' <version>`.

--- a/README.md
+++ b/README.md
@@ -115,8 +115,7 @@ nox
 ## Creating a new release:
 
 1. Run `nox -e bump -- <version> <release_summary_message>`. This:
-   * Bumps the package version in `pyproject.toml`, `src/antsibull_docs/__init__.py`,
-     and `src/sphinx_antsibull_ext/__init__.py`.
+   * Bumps the package version in `pyproject.toml` and `src/antsibull_docs/__init__.py`.
    * Creates `changelogs/fragments/<version>.yml` with a `release_summary` section.
    * Runs `antsibull-changelog release` and adds the changed files to git.
    * Commits with message `Release <version>.` and runs `git tag -a -m 'antsibull-docs <version>' <version>`.

--- a/changelogs/fragments/202-sphinx-version.yml
+++ b/changelogs/fragments/202-sphinx-version.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - "Make sure that the antsibull Sphinx extension contains the correct version (same as antsibull-docs itself) and licensing information (GPL-3.0-or-later),
+     and that the version is kept up-to-date for new releases (https://github.com/ansible-community/antsibull-docs/pull/202)."

--- a/noxfile.py
+++ b/noxfile.py
@@ -196,7 +196,6 @@ def _repl_version_impl(
 
 
 def _repl_version(session: nox.Session, new_version: str) -> None:
-    _repl_version_impl("pyproject.toml", "version", new_version)
     _repl_version_impl(
         os.path.join("src", "antsibull_docs", "__init__.py"), "__version__", new_version
     )
@@ -269,18 +268,24 @@ def bump(session: nox.Session):
         )
         with open(fragment_file, "w") as fp:
             print(fragment, file=fp)
-        session.run("git", "add", "pyproject.toml", str(fragment_file), external=True)
+        session.run(
+            "git",
+            "add",
+            "src/antsibull_docs/__init__.py",
+            str(fragment_file),
+            external=True,
+        )
         session.run("git", "commit", "-m", f"Prepare {version}.", external=True)
-    session.run("antsibull-changelog", "release")
+    session.run("antsibull-changelog", "release", "--version", version)
     session.run(
         "git",
         "add",
         "CHANGELOG.rst",
         "changelogs/changelog.yaml",
         "changelogs/fragments/",
-        # pyproject.toml is not committed in the last step
+        # __init__.py is not committed in the last step
         # when the release_summary fragment is created manually
-        "pyproject.toml",
+        "src/antsibull_docs/__init__.py",
         external=True,
     )
     install(session, ".")  # Smoke test
@@ -307,7 +312,7 @@ def publish(session: nox.Session):
     session.run("hatch", "publish", *session.posargs)
     version = session.run("hatch", "version", silent=True).strip()
     _repl_version(session, f"{version}.post0")
-    session.run("git", "add", "pyproject.toml", external=True)
+    session.run("git", "add", "src/antsibull_docs/__init__.py", external=True)
     session.run("git", "commit", "-m", "Post-release version bump.", external=True)
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -198,6 +198,9 @@ def _repl_version_impl(
 def _repl_version(session: nox.Session, new_version: str) -> None:
     _repl_version_impl("pyproject.toml", "version", new_version)
     _repl_version_impl(
+        os.path.join("src", "antsibull_docs", "__init__.py"), "__version__", new_version
+    )
+    _repl_version_impl(
         os.path.join("src", "sphinx_antsibull_ext", "__init__.py"),
         "__version__",
         new_version,

--- a/noxfile.py
+++ b/noxfile.py
@@ -200,11 +200,6 @@ def _repl_version(session: nox.Session, new_version: str) -> None:
     _repl_version_impl(
         os.path.join("src", "antsibull_docs", "__init__.py"), "__version__", new_version
     )
-    _repl_version_impl(
-        os.path.join("src", "sphinx_antsibull_ext", "__init__.py"),
-        "__version__",
-        new_version,
-    )
 
 
 def check_no_modifications(session: nox.Session) -> None:

--- a/noxfile.py
+++ b/noxfile.py
@@ -233,7 +233,7 @@ def bump(session: nox.Session):
                 f"Either {fragment_file} must already exist, "
                 "or two positional arguments must be provided."
             )
-    install(session, "antsibull-changelog[toml]", "hatch")
+    install(session, "antsibull-changelog", "hatch")
     session.run("hatch", "version", version)
     if len(session.posargs) > 1:
         fragment = session.run(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "antsibull-docs"
-version = "2.3.1.post0"
+dynamic = ["version"]
 description = "Tools for building Ansible documentation"
 license = "GPL-3.0-or-later"
 license-files = {globs=["LICENSES/*.txt"]}
@@ -108,6 +108,9 @@ dev = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/antsibull_docs", "src/sphinx_antsibull_ext"]
+
+[tool.hatch.version]
+path = "src/antsibull_docs/__init__.py"
 
 [tool.black]
 exclude = '''

--- a/src/antsibull_docs/__init__.py
+++ b/src/antsibull_docs/__init__.py
@@ -2,3 +2,6 @@
 # https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 # SPDX-FileCopyrightText: 2020, Ansible Project
+"""The main antsibull-docs module. Contains versioning information."""
+
+__version__ = "2.3.1.post0"

--- a/src/sphinx_antsibull_ext/__init__.py
+++ b/src/sphinx_antsibull_ext/__init__.py
@@ -9,7 +9,8 @@ Antsibull minimal Sphinx extension which adds some features from the Ansible doc
 
 from __future__ import annotations
 
-__version__ = "2.3.1.post0"
+from antsibull_docs import __version__
+
 __license__ = "GPL-3.0-or-later"
 __author__ = "Felix Fontein"
 __author_email__ = "felix@fontein.de"

--- a/src/sphinx_antsibull_ext/__init__.py
+++ b/src/sphinx_antsibull_ext/__init__.py
@@ -9,8 +9,7 @@ Antsibull minimal Sphinx extension which adds some features from the Ansible doc
 
 from __future__ import annotations
 
-# TODO: update version automatically
-__version__ = "2.4.0"
+__version__ = "2.3.1.post0"
 __license__ = "GPL-3.0-or-later"
 __author__ = "Felix Fontein"
 __author_email__ = "felix@fontein.de"


### PR DESCRIPTION
Also store the version information in `src/antsibull_docs/__init__.py` so it can be used to embed it into the generated RST files, for example ("generated with antsibull-docs x.y.z"). I've been thinking of doing that for a longer time but wasn't able to get hold reliably of the version - using distutils or packaging doesn't work for local editable installs (or at least it didn't work when I tried it out a longer time ago, might have been related to poetry though).