### PR TITLE
Bump dependency on antsibull-core and use new options

### DIFF
--- a/changelogs/fragments/209-version.yml
+++ b/changelogs/fragments/209-version.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - "Antsibull-docs now depends on antsibull-core >= 2.1.0 (https://github.com/ansible-community/antsibull-docs/pull/209)."
+bugfixes:
+  - "When running ``antsibull-docs --version``, the correct version is now shown also for editable installs and other installs that do not allow ``importlib.metadata`` to show the correct version (https://github.com/ansible-community/antsibull-docs/pull/209)."
+  - "When running ``antsibull-docs --help``, the correct program name is now shown for the ``--version`` option (https://github.com/ansible-community/antsibull-docs/pull/209)."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "ansible-pygments",
-    "antsibull-core >= 2.0.0, < 3.0.0",
+    "antsibull-core >= 2.1.0, < 3.0.0",
     "antsibull-docs-parser >= 1.0.0, < 2.0.0",
     "asyncio-pool",
     "docutils",

--- a/src/antsibull_docs/cli/antsibull_docs.py
+++ b/src/antsibull_docs/cli/antsibull_docs.py
@@ -32,6 +32,8 @@ from antsibull_core.compat import BooleanOptionalAction  # noqa: E402
 from antsibull_core.config import ConfigError, load_config  # noqa: E402
 from antsibull_core.filesystem import UnableToCheck, writable_via_acls  # noqa: E402
 
+import antsibull_docs  # noqa: E402
+
 from ..constants import DOCUMENTABLE_PLUGINS  # noqa: E402
 from ..docs_parsing.fqcn import is_fqcn  # noqa: E402
 from ..schemas.app_context import DocsAppContext  # noqa: E402
@@ -327,6 +329,8 @@ def parse_args(program_name: str, args: list[str]) -> argparse.Namespace:
     parser = get_toplevel_parser(
         prog=program_name,
         package="antsibull_docs",
+        package_version=antsibull_docs.__version__,
+        program_name="antsibull-docs",
         description="Script to manage generated documentation for ansible",
     )
     subparsers = parser.add_subparsers(


### PR DESCRIPTION
Makes `antsibull-docs --help | grep version` and `antsibull-docs --version` work correctly, the latter also with long-lived editable installs.