### PR TITLE
Restrict rstcheck to <6.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "docutils",
     "jinja2 >= 3.0",
     "packaging",
-    "rstcheck >= 3.0.0, < 7.0.0",
+    "rstcheck >= 3.0.0, < 6.2.0",
     "sphinx",
     # pydantic v2 is a major rewrite
     "pydantic >= 1.0.0, < 2.0.0",


### PR DESCRIPTION
`rstcheck-core` requires `pydantic>=2` since v1.1.0 while antsibull-docs requires `pydantic<2`.

`rstcheck` v6.2.0 requires `rstcheck-core>=1.1` (https://github.com/rstcheck/rstcheck/commit/6834d0d708e5f305c13930d3eedeaab41057adb2).