### PR TITLE
Deprecate --use-html-blobs

### DIFF
--- a/changelogs/fragments/217-deprecate-use-html-blobs.yml
+++ b/changelogs/fragments/217-deprecate-use-html-blobs.yml
@@ -5,4 +5,4 @@ deprecated_features:
      values. If you think this feature needs to stay, please create an issue in the `antsibull-docs
      repository <https://github.com/ansible-community/antsibull-docs/issues/>`__ and provide
      good reasons for it
-     (https://github.com/ansible-community/antsibull-docs/pull/216)."
+     (https://github.com/ansible-community/antsibull-docs/pull/217)."

--- a/changelogs/fragments/217-deprecate-use-html-blobs.yml
+++ b/changelogs/fragments/217-deprecate-use-html-blobs.yml
@@ -1,0 +1,8 @@
+deprecated_features:
+  - "The ``--use-html-blobs`` feature that inserts HTML blobs for the options and return value
+     tables for the ``ansible-docsite`` output format is deprecated and will be removed soon.
+     The HTML tables cause several features to break, such as references to options and return
+     values. If you think this feature needs to stay, please create an issue in the `antsibull-docs
+     repository <https://github.com/ansible-community/antsibull-docs/issues/>`__ and provide
+     good reasons for it
+     (https://github.com/ansible-community/antsibull-docs/pull/216)."

--- a/src/antsibull_docs/cli/doc_commands/_build.py
+++ b/src/antsibull_docs/cli/doc_commands/_build.py
@@ -8,9 +8,9 @@
 from __future__ import annotations
 
 import asyncio
+import sys
 import textwrap
 import typing as t
-import sys
 from collections.abc import MutableMapping
 
 from antsibull_core.logging import log
@@ -100,7 +100,8 @@ def _validate_options(
 
     if use_html_blobs:
         print(
-            "WARNING: the use of --use-html-blobs is deprecated. This feature will be removed soon.",
+            "WARNING: the use of --use-html-blobs is deprecated."
+            " This feature will be removed soon.",
             file=sys.stderr,
         )
 

--- a/src/antsibull_docs/cli/doc_commands/_build.py
+++ b/src/antsibull_docs/cli/doc_commands/_build.py
@@ -90,10 +90,16 @@ def _remove_collections(
 def _validate_options(
     collection_names: list[str] | None,
     exclude_collection_names: list[str] | None,
+    use_html_blobs: bool,
 ) -> None:
     if collection_names is not None and exclude_collection_names is not None:
         raise ValueError(
             "Cannot specify both collection_names and exclude_collection_names"
+        )
+
+    if use_html_blobs:
+        print(
+            "WARNING: the use of --use-html-blobs is deprecated. This feature will be removed soon."
         )
 
 
@@ -153,7 +159,7 @@ def generate_docs_for_all_collections(  # noqa: C901
     flog = mlog.fields(func="generate_docs_for_all_collections")
     flog.notice("Begin")
 
-    _validate_options(collection_names, exclude_collection_names)
+    _validate_options(collection_names, exclude_collection_names, use_html_blobs)
 
     if collection_names is not None and "ansible.builtin" not in collection_names:
         exclude_collection_names = ["ansible.builtin"]

--- a/src/antsibull_docs/cli/doc_commands/_build.py
+++ b/src/antsibull_docs/cli/doc_commands/_build.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import textwrap
 import typing as t
+import sys
 from collections.abc import MutableMapping
 
 from antsibull_core.logging import log
@@ -99,7 +100,8 @@ def _validate_options(
 
     if use_html_blobs:
         print(
-            "WARNING: the use of --use-html-blobs is deprecated. This feature will be removed soon."
+            "WARNING: the use of --use-html-blobs is deprecated. This feature will be removed soon.",
+            file=sys.stderr,
         )
 
 

--- a/src/antsibull_docs/cli/doc_commands/plugin.py
+++ b/src/antsibull_docs/cli/doc_commands/plugin.py
@@ -14,7 +14,6 @@ import os
 import sys
 import traceback
 import typing as t
-import sys
 from collections.abc import MutableMapping
 
 from antsibull_core.logging import log
@@ -55,7 +54,8 @@ def generate_plugin_docs(
 
     if app_ctx.use_html_blobs:
         print(
-            "WARNING: the use of --use-html-blobs is deprecated. This feature will be removed soon.",
+            "WARNING: the use of --use-html-blobs is deprecated."
+            " This feature will be removed soon.",
             file=sys.stderr,
         )
 

--- a/src/antsibull_docs/cli/doc_commands/plugin.py
+++ b/src/antsibull_docs/cli/doc_commands/plugin.py
@@ -52,6 +52,11 @@ def generate_plugin_docs(
 
     app_ctx = app_context.app_ctx.get()
 
+    if app_ctx.use_html_blobs:
+        print(
+            "WARNING: the use of --use-html-blobs is deprecated. This feature will be removed soon."
+        )
+
     venv = FakeVenvRunner()
     venv_ansible_doc = venv.get_command("ansible-doc")
     venv_ansible_doc = venv_ansible_doc.bake("-vvv")

--- a/src/antsibull_docs/cli/doc_commands/plugin.py
+++ b/src/antsibull_docs/cli/doc_commands/plugin.py
@@ -14,6 +14,7 @@ import os
 import sys
 import traceback
 import typing as t
+import sys
 from collections.abc import MutableMapping
 
 from antsibull_core.logging import log
@@ -54,7 +55,8 @@ def generate_plugin_docs(
 
     if app_ctx.use_html_blobs:
         print(
-            "WARNING: the use of --use-html-blobs is deprecated. This feature will be removed soon."
+            "WARNING: the use of --use-html-blobs is deprecated. This feature will be removed soon.",
+            file=sys.stderr,
         )
 
     venv = FakeVenvRunner()

--- a/src/antsibull_docs/cli/doc_commands/sphinx_init.py
+++ b/src/antsibull_docs/cli/doc_commands/sphinx_init.py
@@ -135,7 +135,8 @@ def site_init() -> int:
 
     if use_html_blobs:
         print(
-            "WARNING: the use of --use-html-blobs is deprecated. This feature will be removed soon.",
+            "WARNING: the use of --use-html-blobs is deprecated."
+            " This feature will be removed soon.",
             file=sys.stderr,
         )
 

--- a/src/antsibull_docs/cli/doc_commands/sphinx_init.py
+++ b/src/antsibull_docs/cli/doc_commands/sphinx_init.py
@@ -132,6 +132,11 @@ def site_init() -> int:
     extra_html_theme_options = split_kv(app_ctx.extra["extra_html_theme_options"])
     output_format = app_ctx.extra["output_format"]
 
+    if use_html_blobs:
+        print(
+            "WARNING: the use of --use-html-blobs is deprecated. This feature will be removed soon."
+        )
+
     sphinx_theme = "sphinx_ansible_theme"
     sphinx_theme_package = "sphinx-ansible-theme >= 0.9.0"
     if app_ctx.extra["sphinx_theme"] != "sphinx-ansible-theme":

--- a/src/antsibull_docs/cli/doc_commands/sphinx_init.py
+++ b/src/antsibull_docs/cli/doc_commands/sphinx_init.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 import os.path
+import sys
 import typing as t
 
 from antsibull_core.logging import log
@@ -134,7 +135,8 @@ def site_init() -> int:
 
     if use_html_blobs:
         print(
-            "WARNING: the use of --use-html-blobs is deprecated. This feature will be removed soon."
+            "WARNING: the use of --use-html-blobs is deprecated. This feature will be removed soon.",
+            file=sys.stderr,
         )
 
     sphinx_theme = "sphinx_ansible_theme"


### PR DESCRIPTION
This feature is causing more and more problems, in particular now that it's so easy to reference options and return values (which simply won't work when this feature is enabled).

It is possible to make it work, but it's quite some amount of work, and I'm convinced that this isn't really needed.

(HTML tables are still a thing for the `simplified-rst` output format and won't go away there.)