### PR TITLE
Improve error output when calls to ansible-doc or ansible --version fail

### DIFF
--- a/changelogs/fragments/223-ansible-doc-errors.yml
+++ b/changelogs/fragments/223-ansible-doc-errors.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Improve error messages when calls to ``ansible-doc`` fail (https://github.com/ansible-community/antsibull-docs/pull/223)."

--- a/src/antsibull_docs/docs_parsing/ansible_doc.py
+++ b/src/antsibull_docs/docs_parsing/ansible_doc.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import json
 import os
 import re
+import shlex
+import textwrap
 import typing as t
 from collections.abc import Mapping
 
@@ -87,10 +89,18 @@ async def _call_ansible_galaxy_collection_list(
     venv: VenvRunner | FakeVenvRunner,
     env: dict[str, str],
 ) -> Mapping[str, t.Any]:
-    p = await venv.async_log_run(
-        ["ansible-galaxy", "collection", "list", "--format", "json"],
-        env=env,
-    )
+    try:
+        p = await venv.async_log_run(
+            ["ansible-galaxy", "collection", "list", "--format", "json"],
+            env=env,
+        )
+    except CalledProcessError as exc:
+        if exc.returncode and exc.returncode > 0:
+            raise RuntimeError(
+                f"The command\n| {shlex.join(exc.cmd)}\nreturned exit status {exc.returncode}"
+                f" with error output:\n{textwrap.indent(exc.stderr, '| ')}"
+            ) from exc
+        raise
     return json.loads(_filter_non_json_lines(p.stdout)[0])
 
 
@@ -156,5 +166,6 @@ async def get_ansible_core_version(
         return PypiVer(metadata.version)
     except CalledProcessError as exc:
         raise ValueError(
-            f"Cannot retrieve ansible-core version from `ansible --version`: {exc}"
+            f"Cannot retrieve ansible-core version from `ansible --version`: {exc};"
+            f" error output:\n{textwrap.indent(exc.stderr, '| ')}"
         ) from exc


### PR DESCRIPTION
Before:
```
subprocess.CalledProcessError: Command '['ansible-doc', '-vvv', '--metadata-dump', '--no-fail-on-errors', 'ansible.builtin', 'community.sops', 'foo.bar']' returned non-zero exit status 1.
```

After:
```
RuntimeError: The command
| ansible-doc -vvv --metadata-dump --no-fail-on-errors ansible.builtin community.sops foo.bar
returned exit status 1 with error output:
| [WARNING]: You are running the development version of Ansible. You should only
| run Ansible from "devel" if you are modifying the Ansible engine, or trying out
| features under development. This is a rapidly changing source of code and can
| become unstable at any point.
| ERROR! Cannot use supplied collection foo.bar: unable to locate collection foo.bar. unable to locate collection foo.bar
```

This would have helped me to quickly identify two nightly CI failures indirectly caused by ansible-core 2.16.0 having been released. (The `lint-collection-docs` subcommand was used when the collection's dependencies haven't been installed, and antsibull-docs was trying to find the docs for the dependencies as well. After figuring out that this caused the `ansible-doc` call to suddenly fail, it was easy to fix it by making sure that all dependent collections are installed.)