### PR TITLE
Use certain fields from library context instead of app context that are deprecated in the app context and are removed from antsibull-core 3.0.0

### DIFF
--- a/changelogs/fragments/233-context.yml
+++ b/changelogs/fragments/233-context.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Use certain fields from library context instead of app context that are deprecated in the app context and are removed from antsibull-core 3.0.0 (https://github.com/ansible-community/antsibull-docs/pull/233)."

--- a/src/antsibull_docs/cli/doc_commands/collection.py
+++ b/src/antsibull_docs/cli/doc_commands/collection.py
@@ -117,6 +117,7 @@ def generate_docs() -> int:
     flog.debug("Begin processing docs")
 
     app_ctx = app_context.app_ctx.get()
+    lib_ctx = app_context.lib_ctx.get()
 
     squash_hierarchy: bool = app_ctx.extra["squash_hierarchy"]
     output_format = OutputFormat.parse(app_ctx.extra["output_format"])
@@ -136,8 +137,8 @@ def generate_docs() -> int:
                 app_ctx.extra["collections"],
                 collection_version,
                 tmp_dir,
-                galaxy_server=str(app_ctx.galaxy_url),
-                collection_cache=app_ctx.collection_cache,
+                galaxy_server=str(lib_ctx.galaxy_url),
+                collection_cache=lib_ctx.collection_cache,
             )
         )
         flog.fields(tarballs=collection_tarballs).debug("Download complete")

--- a/src/antsibull_docs/cli/doc_commands/collection_plugins.py
+++ b/src/antsibull_docs/cli/doc_commands/collection_plugins.py
@@ -68,6 +68,7 @@ def generate_docs() -> int:
     flog.debug("Begin processing docs")
 
     app_ctx = app_context.app_ctx.get()
+    lib_ctx = app_context.lib_ctx.get()
 
     output_format = OutputFormat.parse(app_ctx.extra["output_format"])
     fqcn_plugin_names: bool = app_ctx.extra["fqcn_plugin_names"]
@@ -89,8 +90,8 @@ def generate_docs() -> int:
                 list(app_ctx.extra["collection"]),
                 collection_version,
                 tmp_dir,
-                galaxy_server=str(app_ctx.galaxy_url),
-                collection_cache=app_ctx.collection_cache,
+                galaxy_server=str(lib_ctx.galaxy_url),
+                collection_cache=lib_ctx.collection_cache,
             )
         )
         flog.fields(tarballs=collection_tarballs).debug("Download complete")

--- a/src/antsibull_docs/cli/doc_commands/devel.py
+++ b/src/antsibull_docs/cli/doc_commands/devel.py
@@ -107,6 +107,8 @@ def generate_docs() -> int:
     flog.notice("Begin generating docs")
 
     app_ctx = app_context.app_ctx.get()
+    lib_ctx = app_context.lib_ctx.get()
+
     use_installed_ansible_core: bool = app_ctx.extra["use_installed_ansible_core"]
 
     # Parse the pieces file
@@ -121,9 +123,9 @@ def generate_docs() -> int:
             retrieve(
                 collections,
                 tmp_dir,
-                galaxy_server=str(app_ctx.galaxy_url),
+                galaxy_server=str(lib_ctx.galaxy_url),
                 ansible_core_source=app_ctx.extra["ansible_core_source"],
-                collection_cache=app_ctx.collection_cache,
+                collection_cache=lib_ctx.collection_cache,
                 use_installed_ansible_core=use_installed_ansible_core,
             )
         )

--- a/src/antsibull_docs/cli/doc_commands/stable.py
+++ b/src/antsibull_docs/cli/doc_commands/stable.py
@@ -106,6 +106,8 @@ def generate_docs() -> int:
     flog.notice("Begin generating docs")
 
     app_ctx = app_context.app_ctx.get()
+    lib_ctx = app_context.lib_ctx.get()
+
     use_installed_ansible_core: bool = app_ctx.extra["use_installed_ansible_core"]
 
     # Parse the deps file
@@ -123,9 +125,9 @@ def generate_docs() -> int:
                 ansible_core_version,
                 collections,
                 tmp_dir,
-                galaxy_server=str(app_ctx.galaxy_url),
+                galaxy_server=str(lib_ctx.galaxy_url),
                 ansible_core_source=app_ctx.extra["ansible_core_source"],
-                collection_cache=app_ctx.collection_cache,
+                collection_cache=lib_ctx.collection_cache,
                 use_installed_ansible_core=use_installed_ansible_core,
             )
         )


### PR DESCRIPTION
These fields have been moved from app to library context for antsibull-core 2.0.0 (or even before?). I apparently forgot to fix this earlier...

Ref: https://github.com/ansible-community/antsibull-core/pull/128