### PR TITLE
Explicitly set up Galaxy context instead of relying on deprecated functionality

### DIFF
--- a/changelogs/fragments/234-galaxy-context.yml
+++ b/changelogs/fragments/234-galaxy-context.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Explicitly set up Galaxy context instead of relying on deprecated functionality (https://github.com/ansible-community/antsibull-docs/pull/234)."

--- a/src/antsibull_docs/cli/doc_commands/collection.py
+++ b/src/antsibull_docs/cli/doc_commands/collection.py
@@ -16,7 +16,7 @@ import tempfile
 import aiohttp
 import asyncio_pool  # type: ignore[import]
 from antsibull_core.collections import install_together
-from antsibull_core.galaxy import CollectionDownloader
+from antsibull_core.galaxy import CollectionDownloader, GalaxyContext
 from antsibull_core.logging import log
 from antsibull_core.venv import FakeVenvRunner
 
@@ -77,11 +77,12 @@ async def retrieve(
 
     lib_ctx = app_context.lib_ctx.get()
     async with aiohttp.ClientSession() as aio_session:
+        context = await GalaxyContext.create(aio_session, galaxy_server=galaxy_server)
         async with asyncio_pool.AioPool(size=lib_ctx.thread_max) as pool:
             downloader = CollectionDownloader(
                 aio_session,
                 collection_dir,
-                galaxy_server=galaxy_server,
+                context=context,
                 collection_cache=collection_cache,
             )
             for collection in collections:

--- a/src/antsibull_docs/cli/doc_commands/devel.py
+++ b/src/antsibull_docs/cli/doc_commands/devel.py
@@ -17,7 +17,7 @@ import asyncio_pool  # type: ignore[import]
 from antsibull_core.ansible_core import get_ansible_core
 from antsibull_core.collections import install_together
 from antsibull_core.dependency_files import parse_pieces_file
-from antsibull_core.galaxy import CollectionDownloader, DownloadResults
+from antsibull_core.galaxy import CollectionDownloader, DownloadResults, GalaxyContext
 from antsibull_core.logging import log
 from antsibull_core.venv import FakeVenvRunner, VenvRunner
 
@@ -59,6 +59,7 @@ async def retrieve(
 
     lib_ctx = app_context.lib_ctx.get()
     async with aiohttp.ClientSession() as aio_session:
+        context = await GalaxyContext.create(aio_session, galaxy_server=galaxy_server)
         async with asyncio_pool.AioPool(size=lib_ctx.thread_max) as pool:
             if not use_installed_ansible_core:
                 requestors["_ansible_core"] = await pool.spawn(
@@ -73,7 +74,7 @@ async def retrieve(
             downloader = CollectionDownloader(
                 aio_session,
                 collection_dir,
-                galaxy_server=galaxy_server,
+                context=context,
                 collection_cache=collection_cache,
             )
             for collection in collections:

--- a/src/antsibull_docs/cli/doc_commands/stable.py
+++ b/src/antsibull_docs/cli/doc_commands/stable.py
@@ -18,7 +18,7 @@ import asyncio_pool  # type: ignore[import]
 from antsibull_core.ansible_core import get_ansible_core
 from antsibull_core.collections import install_together
 from antsibull_core.dependency_files import DepsFile
-from antsibull_core.galaxy import CollectionDownloader
+from antsibull_core.galaxy import CollectionDownloader, GalaxyContext
 from antsibull_core.logging import log
 from antsibull_core.venv import FakeVenvRunner, VenvRunner
 
@@ -62,6 +62,7 @@ async def retrieve(
 
     lib_ctx = app_context.lib_ctx.get()
     async with aiohttp.ClientSession() as aio_session:
+        context = await GalaxyContext.create(aio_session, galaxy_server=galaxy_server)
         async with asyncio_pool.AioPool(size=lib_ctx.thread_max) as pool:
             if not use_installed_ansible_core:
                 requestors["_ansible_core"] = await pool.spawn(
@@ -76,7 +77,7 @@ async def retrieve(
             downloader = CollectionDownloader(
                 aio_session,
                 collection_dir,
-                galaxy_server=galaxy_server,
+                context=context,
                 collection_cache=collection_cache,
             )
             for collection, version in collections.items():


### PR DESCRIPTION
Found this while working on https://github.com/ansible-community/antsibull-core/issues/121.