### PR TITLE
Add new plugin_name to DocSchema

### DIFF
--- a/changelogs/fragments/242-plugin_name-schema.yml
+++ b/changelogs/fragments/242-plugin_name-schema.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Support new ``ansible-doc --json`` output field ``plugin_name`` (https://github.com/ansible-community/antsibull-docs/pull/242)."

--- a/src/antsibull_docs/_pydantic_compat.py
+++ b/src/antsibull_docs/_pydantic_compat.py
@@ -13,10 +13,10 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 import pydantic as p
-import pydantic.version
 from packaging.version import Version
+from pydantic.version import VERSION as PYDANTIC_VERSION
 
-pydantic_version = Version(p.version.VERSION)
+pydantic_version = Version(PYDANTIC_VERSION)
 HAS_PYDANTIC_V2 = pydantic_version.major == 2
 
 if TYPE_CHECKING or HAS_PYDANTIC_V2:
@@ -51,7 +51,7 @@ def Field(*args: Any, **kwargs: Any) -> Any:
                     value = transform(value)
                 kwargs[new_key] = value
                 del kwargs[key]
-    return pydantic.Field(*args, **kwargs)
+    return p.Field(*args, **kwargs)
 
 
 __all__ = ("pydantic_version", "HAS_PYDANTIC_V2", "Field", "v1")

--- a/src/antsibull_docs/schemas/docs/base.py
+++ b/src/antsibull_docs/schemas/docs/base.py
@@ -619,6 +619,7 @@ class DocSchema(BaseModel):
     collection: str = REQUIRED_COLLECTION_NAME_OR_EMPTY_STR_F
     description: list[str]
     name: str
+    plugin_name: str
     short_description: str
     aliases: list[str] = []
     author: list[str] = []

--- a/src/antsibull_docs/schemas/docs/base.py
+++ b/src/antsibull_docs/schemas/docs/base.py
@@ -619,7 +619,7 @@ class DocSchema(BaseModel):
     collection: str = REQUIRED_COLLECTION_NAME_OR_EMPTY_STR_F
     description: list[str]
     name: str
-    plugin_name: str
+    plugin_name: str = ""
     short_description: str
     aliases: list[str] = []
     author: list[str] = []

--- a/tests/functional/schema/good_data/one_become_results.json
+++ b/tests/functional/schema/good_data/one_become_results.json
@@ -81,6 +81,7 @@
                         "version_added_collection": ""
                     }
                 },
+                "plugin_name": "",
                 "requirements": [],
                 "seealso": [],
                 "short_description": "Switch to elevated permissions on a network device",

--- a/tests/functional/schema/good_data/one_cache_results.json
+++ b/tests/functional/schema/good_data/one_cache_results.json
@@ -123,6 +123,7 @@
                         "version_added_collection": ""
                     }
                 },
+                "plugin_name": "",
                 "requirements": [],
                 "seealso": [],
                 "short_description": "JSON formatted files.",

--- a/tests/functional/schema/good_data/one_callback_results.json
+++ b/tests/functional/schema/good_data/one_callback_results.json
@@ -15,6 +15,7 @@
                 "name": "aws_resource_actions",
                 "notes": [],
                 "options": {},
+                "plugin_name": "",
                 "requirements": [
                     "whitelisting in configuration - see examples section below for details."
                 ],

--- a/tests/functional/schema/good_data/one_cliconf_results.json
+++ b/tests/functional/schema/good_data/one_cliconf_results.json
@@ -52,6 +52,7 @@
                         "version_added_collection": ""
                     }
                 },
+                "plugin_name": "",
                 "requirements": [],
                 "seealso": [],
                 "short_description": "Use eos cliconf to run command on Arista EOS platform",

--- a/tests/functional/schema/good_data/one_connection_results.json
+++ b/tests/functional/schema/good_data/one_connection_results.json
@@ -490,6 +490,7 @@
                         "version_added_collection": ""
                     }
                 },
+                "plugin_name": "",
                 "requirements": [],
                 "seealso": [],
                 "short_description": "Use httpapi to run command on network appliances",

--- a/tests/functional/schema/good_data/one_filter_results.json
+++ b/tests/functional/schema/good_data/one_filter_results.json
@@ -104,6 +104,7 @@
                     "true_val",
                     "false_val"
                 ],
+                "plugin_name": "",
                 "requirements": [],
                 "seealso": [],
                 "short_description": "Ternary operation filter",

--- a/tests/functional/schema/good_data/one_httpapi_results.json
+++ b/tests/functional/schema/good_data/one_httpapi_results.json
@@ -45,6 +45,7 @@
                         "version_added_collection": ""
                     }
                 },
+                "plugin_name": "",
                 "requirements": [],
                 "seealso": [],
                 "short_description": "HttpApi Plugin for devices supporting Restconf API",

--- a/tests/functional/schema/good_data/one_inventory_results.json
+++ b/tests/functional/schema/good_data/one_inventory_results.json
@@ -655,6 +655,7 @@
                         "version_added_collection": ""
                     }
                 },
+                "plugin_name": "",
                 "requirements": [
                     "boto3",
                     "botocore"

--- a/tests/functional/schema/good_data/one_lookup_results.json
+++ b/tests/functional/schema/good_data/one_lookup_results.json
@@ -266,6 +266,7 @@
                     }
                 },
                 "positional": [],
+                "plugin_name": "",
                 "requirements": [
                     "python-consul python library U(https://python-consul.readthedocs.io/en/latest/#installation)"
                 ],

--- a/tests/functional/schema/good_data/one_module_results.json
+++ b/tests/functional/schema/good_data/one_module_results.json
@@ -238,6 +238,7 @@
                         "version_added_collection": ""
                     }
                 },
+                "plugin_name": "",
                 "requirements": [],
                 "seealso": [
                     {

--- a/tests/functional/schema/good_data/one_netconf_results.json
+++ b/tests/functional/schema/good_data/one_netconf_results.json
@@ -38,6 +38,7 @@
                         "version_added_collection": ""
                     }
                 },
+                "plugin_name": "",
                 "requirements": [],
                 "seealso": [],
                 "short_description": "Use iosxr netconf plugin to run netconf commands on Cisco IOSXR platform",

--- a/tests/functional/schema/good_data/one_shell_results.json
+++ b/tests/functional/schema/good_data/one_shell_results.json
@@ -216,6 +216,7 @@
                         "version_added_collection": ""
                     }
                 },
+                "plugin_name": "",
                 "requirements": [],
                 "seealso": [],
                 "short_description": "POSIX shell (/bin/sh)",

--- a/tests/functional/schema/good_data/one_strategy_results.json
+++ b/tests/functional/schema/good_data/one_strategy_results.json
@@ -18,6 +18,7 @@
                 "name": "free",
                 "notes": [],
                 "options": {},
+                "plugin_name": "",
                 "requirements": [],
                 "seealso": [],
                 "short_description": "Executes tasks without waiting for all hosts",

--- a/tests/functional/schema/good_data/one_test_results.json
+++ b/tests/functional/schema/good_data/one_test_results.json
@@ -40,6 +40,7 @@
                     }
                 },
                 "positional": [],
+                "plugin_name": "",
                 "requirements": [],
                 "seealso": [],
                 "short_description": "check if task required changes",

--- a/tests/functional/schema/good_data/one_vars_results.json
+++ b/tests/functional/schema/good_data/one_vars_results.json
@@ -103,6 +103,7 @@
                         "version_added_collection": "foo.bar"
                     }
                 },
+                "plugin_name": "",
                 "requirements": [
                     "whitelist in configuration"
                 ],

--- a/tests/functional/schema/good_data/ssh_connection_results.json
+++ b/tests/functional/schema/good_data/ssh_connection_results.json
@@ -1200,6 +1200,7 @@
                         "version_added_collection": "ansible.builtin"
                     }
                 },
+                "plugin_name": "",
                 "requirements": [],
                 "seealso": [],
                 "short_description": "connect via ssh client binary",


### PR DESCRIPTION
In https://github.com/ansible/ansible/commit/bec27fb4c0a40c5f8bbcf26a475704227d65ee73 we added a new `plugin_name` field to the `ansible-doc` output. This PR adds this new field to the `DocSchema` class

See https://github.com/ansible/ansible-documentation/issues/1079