### PR TITLE
Allow collections to render changelog as part of their docsite

### DIFF
--- a/.github/workflows/antsibull-docs.yml
+++ b/.github/workflows/antsibull-docs.yml
@@ -36,6 +36,8 @@ jobs:
           - "stable-2"
         antsibull_docs_parser_ref:
           - main
+        antsibull_changelog_ref:
+          - main
         include:
           - options: '--use-current --use-html-blobs --no-breadcrumbs community.crypto community.docker --extra-conf antsibull_ext_color_scheme=none'
             python: '3.9'
@@ -61,6 +63,13 @@ jobs:
           repository: ansible-community/antsibull-docs-parser
           path: antsibull-docs-parser
           ref: ${{ matrix.antsibull_docs_parser_ref }}
+
+      - name: Check out dependent project antsibull-changelog
+        uses: actions/checkout@v4
+        with:
+          repository: ansible-community/antsibull-changelog
+          path: antsibull-changelog
+          ref: ${{ matrix.antsibull_changelog_ref }}
 
       - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v5
@@ -166,6 +175,12 @@ jobs:
           repository: ansible-community/antsibull-docs-parser
           path: antsibull-docs-parser
 
+      - name: Check out dependent project antsibull-changelog
+        uses: actions/checkout@v4
+        with:
+          repository: ansible-community/antsibull-changelog
+          path: antsibull-changelog
+
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
@@ -223,6 +238,12 @@ jobs:
         with:
           repository: ansible-community/antsibull-docs-parser
           path: antsibull-docs-parser
+
+      - name: Check out dependent project antsibull-changelog
+        uses: actions/checkout@v4
+        with:
+          repository: ansible-community/antsibull-changelog
+          path: antsibull-changelog
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5

--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -57,6 +57,11 @@ jobs:
         with:
           repository: ansible-community/antsibull-docs-parser
           path: antsibull-docs-parser
+      - name: Check out dependent project antsibull-changelog
+        uses: actions/checkout@v4
+        with:
+          repository: ansible-community/antsibull-changelog
+          path: antsibull-changelog
       - name: Install extra packages
         if: "matrix.packages != ''"
         run: |

--- a/changelogs/fragments/267-changelog.yml
+++ b/changelogs/fragments/267-changelog.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - "It is now possible to render the collection's changelog as part of the collection's docsite by using the ``changelog`` option in ``docs/docsite/config.yml`` (https://github.com/ansible-community/antsibull-docs/issues/31, https://github.com/ansible-community/antsibull-docs/pull/267)."
+  - "It is now possible to render the collection changelog as part of the collection docsite by using the ``changelog`` option in ``docs/docsite/config.yml`` (https://github.com/ansible-community/antsibull-docs/issues/31, https://github.com/ansible-community/antsibull-docs/pull/267)."

--- a/changelogs/fragments/267-changelog.yml
+++ b/changelogs/fragments/267-changelog.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "It is now possible to render the collection's changelog as part of the collection's docsite by using the ``changelog`` option in ``docs/docsite/config.yml`` (https://github.com/ansible-community/antsibull-docs/issues/31, https://github.com/ansible-community/antsibull-docs/pull/267)."

--- a/docs/collection-docs.md
+++ b/docs/collection-docs.md
@@ -124,6 +124,29 @@ The `sphinx-init` subcommand has quite a few configuration options:
 * `--intersphinx` can be used to add intersphinx config entries to allow to use RST references to more external documentation. Refer to the [intersphinx documentation](https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html) for more information.
 * `--project`, `--copyright`, `--title`, `--html-short-title`, `--extra-conf`, `--extra-html-context`, and `--extra-html-theme-options` can be used to add specific configuration entries to the Sphinx configuration `conf.py`.
 
+## Configuring the docsite
+
+Generally, configuration is done with a `docs/docsite/config.yml` YAML file. The format and options are as follows:
+```yaml
+---
+# Whether the collection uses flatmapping to flatten subdirectories in
+# `plugins/*/`.
+flatmap: false
+
+# List of environment variables that are defined by `.. envvar::` directives
+# in the extra docsite RST files.
+envvar_directives: []
+
+# Changelog configuration (added in antsibull-docs 2.10.0)
+changelog:
+  # Whether to write the changelog (taken from changelogs/changelog.yaml, see the
+  # antsibull-changelog documentation for more information) and link to it from the
+  # collection's index page.
+  write_changelog: false
+```
+
+Most collections only want to use `envvar_directives` and `changelog`. The `flatmap` option was mainly needed for older versions of community.general and community.network and should only be used for legacy collections and not for new ones.
+
 ## Adding extra documentation
 
 It is possible to add extra documentation in RST format to the docsite. This can for example be used to provide scenario guides. On the [community.crypto docsite](https://ansible-collections.github.io/community.crypto/branch/main/), there are for example some how-tos in the "Scenario Guides" section.

--- a/docs/collection-docs.md
+++ b/docs/collection-docs.md
@@ -145,7 +145,7 @@ changelog:
   write_changelog: false
 ```
 
-Most collections only want to use `envvar_directives` and `changelog`. The `flatmap` option was mainly needed for older versions of community.general and community.network and should only be used for legacy collections and not for new ones.
+Most collections should use `envvar_directives` and `changelog` only. The `flatmap` option applies to older versions of community.general and community.network and should be used for legacy collections only, not for new ones.
 
 ## Adding extra documentation
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -42,7 +42,7 @@ def other_antsibull(
     if mode is None:
         mode = DEFAULT_MODE
     to_install: list[str | Path] = []
-    args = ("antsibull-core", "antsibull-docs-parser")
+    args = ("antsibull-changelog", "antsibull-core", "antsibull-docs-parser")
     for project in args:
         path = Path("../", project)
         path_exists = path.is_dir()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "ansible-pygments",
+    "antsibull-changelog >= 0.24.0",
     "antsibull-core >= 2.1.0, < 4.0.0",
     "antsibull-docs-parser >= 1.0.0, < 2.0.0",
     "asyncio-pool",
@@ -72,7 +73,6 @@ antsibull-docs = "antsibull_docs.cli.antsibull_docs:main"
 
 [project.optional-dependencies]
 codeqa = [
-    "antsibull-changelog",
     "flake8 >= 3.8.0",
     "pylint >= 2.17.2",
     "reuse",

--- a/src/antsibull_docs/cli/doc_commands/_build.py
+++ b/src/antsibull_docs/cli/doc_commands/_build.py
@@ -45,6 +45,7 @@ from ...schemas.app_context import (
     DEFAULT_COLLECTION_URL_TRANSFORM,
 )
 from ...utils.collection_name_transformer import CollectionNameTransformer
+from ...write_docs.changelog import output_changelogs
 from ...write_docs.collections import output_extra_docs, output_indexes
 from ...write_docs.hierarchy import (
     output_collection_index,
@@ -144,7 +145,8 @@ def generate_docs_for_all_collections(  # noqa: C901
                                      with ``collection_names``.
     :kwarg create_indexes: Whether to create the collection, namespace, and plugin indexes. By
                            default, they are created.
-    :kwarg create_collection_indexes: Whether to create the per-collection plugin index.
+    :kwarg create_collection_indexes: Whether to create the per-collection plugin index and other
+                                      global docs.
     :kwarg add_extra_docs: Whether to add extra docs.
     :kwarg add_redirect_stubs: Whether to create redirect stub files.
     :kwarg squash_hierarchy: If set to ``True``, no directory hierarchy will be used.
@@ -340,6 +342,17 @@ def generate_docs_for_all_collections(  # noqa: C901
                 breadcrumbs=breadcrumbs,
                 for_official_docsite=for_official_docsite,
                 referable_envvars=referable_envvars,
+            )
+        )
+        flog.notice("Finished writing indexes")
+
+        asyncio.run(
+            output_changelogs(
+                collection_to_plugin_info,
+                dest_dir,
+                collection_metadata=collection_metadata,
+                squash_hierarchy=squash_hierarchy,
+                output_format=output_format,
             )
         )
         flog.notice("Finished writing indexes")

--- a/src/antsibull_docs/cli/doc_commands/plugin.py
+++ b/src/antsibull_docs/cli/doc_commands/plugin.py
@@ -70,7 +70,7 @@ def generate_plugin_docs(
         )
     except CalledProcessError as exc:
         err_msg = []
-        formatted_exception = traceback.format_exception(None, exc, exc.__traceback__)
+        formatted_exception = traceback.format_exception(exc)
         err_msg.append(
             f"Exception while parsing documentation for {plugin_type} plugin:"
             f" {plugin_name}.  Will not document this plugin."

--- a/src/antsibull_docs/data/docsite/ansible-docsite/plugins_by_collection.rst.j2
+++ b/src/antsibull_docs/data/docsite/ansible-docsite/plugins_by_collection.rst.j2
@@ -110,8 +110,8 @@ Changelog
     :maxdepth: 1
 
     changelog
-{% endif %}
 
+{% endif %}
 {% for section in extra_docs_sections %}
 @{section.title}@
 @{ '-' * (section.title | column_width) }@
@@ -130,7 +130,6 @@ Changelog
 {%   endif %}
 
 {% endfor %}
-
 Plugin Index
 ------------
 

--- a/src/antsibull_docs/data/docsite/ansible-docsite/plugins_by_collection.rst.j2
+++ b/src/antsibull_docs/data/docsite/ansible-docsite/plugins_by_collection.rst.j2
@@ -102,6 +102,16 @@ Communication
 .. toctree::
     :maxdepth: 1
 
+{% if has_changelog %}
+Changelog
+---------
+
+.. toctree::
+    :maxdepth: 1
+
+    changelog
+{% endif %}
+
 {% for section in extra_docs_sections %}
 @{section.title}@
 @{ '-' * (section.title | column_width) }@

--- a/src/antsibull_docs/data/docsite/simplified-rst/plugins_by_collection.rst.j2
+++ b/src/antsibull_docs/data/docsite/simplified-rst/plugins_by_collection.rst.j2
@@ -80,6 +80,13 @@ Communication
 {%   endfor %}
 {% endif %}
 
+{% if has_changelog %}
+Changelog
+---------
+
+`@{ collection_name.title() }@ Release Notes <changelog.rst>`_
+{% endif %}
+
 {% for section in extra_docs_sections %}
 @{section.title}@
 @{ '-' * (section.title | column_width) }@

--- a/src/antsibull_docs/data/docsite/simplified-rst/plugins_by_collection.rst.j2
+++ b/src/antsibull_docs/data/docsite/simplified-rst/plugins_by_collection.rst.j2
@@ -85,8 +85,8 @@ Changelog
 ---------
 
 `@{ collection_name.title() }@ Release Notes <changelog.rst>`_
-{% endif %}
 
+{% endif %}
 {% for section in extra_docs_sections %}
 @{section.title}@
 @{ '-' * (section.title | column_width) }@
@@ -102,7 +102,6 @@ Changelog
 {%   endif %}
 
 {% endfor %}
-
 Plugin Index
 ------------
 

--- a/src/antsibull_docs/jinja2/__init__.py
+++ b/src/antsibull_docs/jinja2/__init__.py
@@ -10,29 +10,45 @@ from __future__ import annotations
 
 from enum import Enum
 
+from antsibull_changelog.config import TextFormat
+
 
 class OutputFormat(Enum):
     def __init__(
-        self, output_format: str, template_extension: str, output_extension: str
+        self,
+        output_format: str,
+        template_extension: str,
+        output_extension: str,
+        changelog_format: TextFormat,
     ):
         self._output_format = output_format
         self._template_extension = template_extension
         self._output_extension = output_extension
+        self._changelog_format = changelog_format
 
-    ANSIBLE_DOCSITE = ("ansible-docsite", ".rst.j2", ".rst")
-    SIMPLIFIED_RST = ("simplified-rst", ".rst.j2", ".rst")
+    ANSIBLE_DOCSITE = (
+        "ansible-docsite",
+        ".rst.j2",
+        ".rst",
+        TextFormat.RESTRUCTURED_TEXT,
+    )
+    SIMPLIFIED_RST = ("simplified-rst", ".rst.j2", ".rst", TextFormat.RESTRUCTURED_TEXT)
 
     @property
-    def output_format(self):
+    def output_format(self) -> str:
         return self._output_format
 
     @property
-    def template_extension(self):
+    def template_extension(self) -> str:
         return self._template_extension
 
     @property
-    def output_extension(self):
+    def output_extension(self) -> str:
         return self._output_extension
+
+    @property
+    def changelog_format(self) -> TextFormat:
+        return self._changelog_format
 
     @classmethod
     def parse(cls, output_format: str) -> OutputFormat:

--- a/src/antsibull_docs/schemas/collection_config.py
+++ b/src/antsibull_docs/schemas/collection_config.py
@@ -20,3 +20,6 @@ class CollectionConfig(p.BaseModel):
     # List of environment variables that are defined by `.. envvar::` directives
     # in the extra docsite RST files.
     envvar_directives: list[str] = []
+
+    # Whether to include the collection's changelog (added in version 2.10.0)
+    include_changelog: bool = False

--- a/src/antsibull_docs/schemas/collection_config.py
+++ b/src/antsibull_docs/schemas/collection_config.py
@@ -12,6 +12,11 @@
 from antsibull_docs._pydantic_compat import v1 as p
 
 
+class ChangelogConfig(p.BaseModel):
+    # Whether to write the changelog
+    write_changelog: bool = False
+
+
 class CollectionConfig(p.BaseModel):
     # Whether the collection uses flatmapping to flatten subdirectories in
     # `plugins/*/`.
@@ -21,5 +26,5 @@ class CollectionConfig(p.BaseModel):
     # in the extra docsite RST files.
     envvar_directives: list[str] = []
 
-    # Whether to include the collection's changelog (added in version 2.10.0)
-    include_changelog: bool = False
+    # Changelog configuration (added in version 2.10.0)
+    changelog: ChangelogConfig = ChangelogConfig()

--- a/src/antsibull_docs/write_docs/__init__.py
+++ b/src/antsibull_docs/write_docs/__init__.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import os
 from collections.abc import Mapping, Sequence
 
 from antsibull_core.logging import log
@@ -36,3 +37,36 @@ def _render_template(_template: Template, _name: str, **kwargs) -> str:
         )
     except Exception as exc:
         raise RuntimeError(f"Error while rendering {_name}") from exc
+
+
+def _get_collection_dir(
+    dest_dir: str,
+    namespace: str,
+    collection: str,
+    /,
+    squash_hierarchy: bool = False,
+    create_if_not_exists: bool = False,
+):
+    """
+    Compose collection directory.
+
+    :arg dest_dir: Destination directory for the plugin data.  For instance,
+        :file:`ansible-checkout/docs/docsite/rst/`.  The directory structure underneath this
+        directory will be created if needed.
+    :arg namespace: The collection's namespace.
+    :arg collection: The collection's name.
+    :kwarg squash_hierarchy: If set to ``True``, no directory hierarchy will be used.
+                             Undefined behavior if documentation for multiple collections are
+                             created.
+    :kwarg create_if_not_exists: If set to ``True``, the directory will be created if it does
+                                 not exist. The ``dest_dir`` is assumed to exist.
+    """
+    if squash_hierarchy:
+        return dest_dir
+
+    collection_dir = os.path.join(dest_dir, "collections", namespace, collection)
+    if create_if_not_exists:
+        # This is dangerous but the code that takes dest_dir from the user checks
+        # permissions on it to make it as safe as possible.
+        os.makedirs(collection_dir, mode=0o755, exist_ok=True)
+    return collection_dir

--- a/src/antsibull_docs/write_docs/changelog.py
+++ b/src/antsibull_docs/write_docs/changelog.py
@@ -110,7 +110,7 @@ async def output_changelogs(
     async with asyncio_pool.AioPool(size=lib_ctx.thread_max) as pool:
         for collection_name in collection_to_plugin_info:
             metadata = collection_metadata[collection_name]
-            if not metadata.docs_config.include_changelog:
+            if not metadata.docs_config.changelog.write_changelog:
                 continue
 
             namespace, collection = collection_name.split(".", 1)

--- a/src/antsibull_docs/write_docs/changelog.py
+++ b/src/antsibull_docs/write_docs/changelog.py
@@ -1,0 +1,137 @@
+# Author: Toshio Kuratomi <tkuratom@redhat.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2020, Ansible Project
+"""Output collection documentation."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import Mapping
+
+import asyncio_pool  # type: ignore[import]
+from antsibull_changelog.changes import load_changes
+from antsibull_changelog.config import ChangelogConfig, CollectionDetails, PathsConfig
+from antsibull_changelog.rendering.changelog import (
+    ChangelogGenerator,
+    create_document_renderer,
+)
+from antsibull_core import app_context
+from antsibull_core.logging import log
+from antsibull_core.utils.io import write_file
+
+from ..docs_parsing import AnsibleCollectionMetadata
+from ..jinja2 import OutputFormat
+from . import CollectionInfoT, _get_collection_dir
+
+mlog = log.fields(mod=__name__)
+
+
+async def write_changelog(
+    collection_name: str,
+    collection_dir: str,
+    collection_metadata: AnsibleCollectionMetadata,
+    output_format: OutputFormat,
+):
+    """
+    Write a changelog for each collection.
+
+    :arg collection_name: The collection's full name.
+    :arg collection_dir: The destination directory to output the changelog into.
+    :arg collection_metadata: Metadata for the collection.
+    :arg output_format: The output format to use.
+    """
+    flog = mlog.fields(func="write_changelog")
+    flog.debug("Enter")
+
+    paths = PathsConfig.force_collection(collection_metadata.path)
+
+    collection_details = CollectionDetails(paths)
+    collection_details.namespace, collection_details.name = collection_name.split(
+        ".", 1
+    )
+    collection_details.version = collection_metadata.version
+    collection_details.flatmap = collection_metadata.docs_config.flatmap
+
+    config = ChangelogConfig.default(paths, collection_details)
+    config.title = collection_name.title()
+    config.use_fqcn = True
+    config.mention_ancestor = True
+    config.flatmap = collection_metadata.docs_config.flatmap
+
+    changes = load_changes(config)
+
+    generator = ChangelogGenerator(config, changes)
+
+    renderer = create_document_renderer(output_format.changelog_format)
+    generator.generate(renderer)
+
+    changelog_contents = renderer.render()
+    for warning in renderer.get_warnings():
+        flog.warning(warning)
+
+    changelog_file = os.path.join(
+        collection_dir, f"changelog{output_format.output_extension}"
+    )
+    await write_file(changelog_file, changelog_contents)
+
+    flog.debug("Leave")
+
+
+async def output_changelogs(
+    collection_to_plugin_info: CollectionInfoT,
+    dest_dir: str,
+    collection_metadata: Mapping[str, AnsibleCollectionMetadata],
+    output_format: OutputFormat,
+    squash_hierarchy: bool = False,
+) -> None:
+    """
+    Generate collection changelogs if requested.
+
+    :arg collection_to_plugin_info: Mapping of collection_name to Mapping of plugin_type to
+        Mapping of plugin_name to short_description.
+    :arg dest_dir: The directory to place the documentation in.
+    :arg collection_metadata: Dictionary mapping collection names to collection metadata objects.
+    :kwarg squash_hierarchy: If set to ``True``, no directory hierarchy will be used.
+        Undefined behavior if documentation for multiple collections are created.
+    :kwarg output_format: The output format to use.
+    """
+    flog = mlog.fields(func="output_changelogs")
+    flog.debug("Enter")
+
+    if collection_metadata is None:
+        collection_metadata = {}
+
+    writers = []
+    lib_ctx = app_context.lib_ctx.get()
+
+    async with asyncio_pool.AioPool(size=lib_ctx.thread_max) as pool:
+        for collection_name in collection_to_plugin_info:
+            metadata = collection_metadata[collection_name]
+            if not metadata.docs_config.include_changelog:
+                continue
+
+            namespace, collection = collection_name.split(".", 1)
+            collection_dir = _get_collection_dir(
+                dest_dir,
+                namespace,
+                collection,
+                squash_hierarchy=squash_hierarchy,
+                create_if_not_exists=True,
+            )
+            writers.append(
+                await pool.spawn(
+                    write_changelog(
+                        collection_name,
+                        collection_dir,
+                        collection_metadata[collection_name],
+                        output_format,
+                    )
+                )
+            )
+
+        await asyncio.gather(*writers)
+
+    flog.debug("Leave")

--- a/src/antsibull_docs/write_docs/collections.py
+++ b/src/antsibull_docs/write_docs/collections.py
@@ -117,7 +117,7 @@ async def write_plugin_lists(
         collection_communication=link_data.communication,
         for_official_docsite=for_official_docsite,
         squash_hierarchy=squash_hierarchy,
-        has_changelog=collection_meta.docs_config.include_changelog,
+        has_changelog=collection_meta.docs_config.changelog.write_changelog,
     )
 
     index_file = os.path.join(dest_dir, f"index{output_format.output_extension}")

--- a/src/antsibull_docs/write_docs/collections.py
+++ b/src/antsibull_docs/write_docs/collections.py
@@ -117,6 +117,7 @@ async def write_plugin_lists(
         collection_communication=link_data.communication,
         for_official_docsite=for_official_docsite,
         squash_hierarchy=squash_hierarchy,
+        has_changelog=collection_meta.docs_config.include_changelog,
     )
 
     index_file = os.path.join(dest_dir, f"index{output_format.output_extension}")

--- a/src/antsibull_docs/write_docs/plugin_stubs.py
+++ b/src/antsibull_docs/write_docs/plugin_stubs.py
@@ -24,7 +24,7 @@ from ..docs_parsing import AnsibleCollectionMetadata
 from ..jinja2 import FilenameGenerator, OutputFormat
 from ..jinja2.environment import doc_environment, get_template_filename
 from ..utils.collection_name_transformer import CollectionNameTransformer
-from . import _render_template
+from . import _get_collection_dir, _render_template
 
 mlog = log.fields(mod=__name__)
 
@@ -104,15 +104,13 @@ async def write_stub_rst(
     if path_override is not None:
         plugin_file = path_override
     else:
-        if squash_hierarchy:
-            collection_dir = dest_dir
-        else:
-            collection_dir = os.path.join(
-                dest_dir, "collections", namespace, collection
-            )
-            # This is dangerous but the code that takes dest_dir from the user checks
-            # permissions on it to make it as safe as possible.
-            os.makedirs(collection_dir, mode=0o755, exist_ok=True)
+        collection_dir = _get_collection_dir(
+            dest_dir,
+            namespace,
+            collection,
+            squash_hierarchy=squash_hierarchy,
+            create_if_not_exists=True,
+        )
 
         plugin_file = os.path.join(
             collection_dir,

--- a/src/antsibull_docs/write_docs/plugins.py
+++ b/src/antsibull_docs/write_docs/plugins.py
@@ -24,7 +24,7 @@ from ..docs_parsing import AnsibleCollectionMetadata
 from ..jinja2 import FilenameGenerator, OutputFormat
 from ..jinja2.environment import doc_environment, get_template_filename
 from ..utils.collection_name_transformer import CollectionNameTransformer
-from . import CollectionInfoT, PluginErrorsT, _render_template
+from . import CollectionInfoT, PluginErrorsT, _get_collection_dir, _render_template
 
 mlog = log.fields(mod=__name__)
 
@@ -317,15 +317,13 @@ async def write_plugin_rst(
     if path_override is not None:
         plugin_file = path_override
     else:
-        if squash_hierarchy:
-            collection_dir = dest_dir
-        else:
-            collection_dir = os.path.join(
-                dest_dir, "collections", namespace, collection
-            )
-            # This is dangerous but the code that takes dest_dir from the user checks
-            # permissions on it to make it as safe as possible.
-            os.makedirs(collection_dir, mode=0o755, exist_ok=True)
+        collection_dir = _get_collection_dir(
+            dest_dir,
+            namespace,
+            collection,
+            squash_hierarchy=squash_hierarchy,
+            create_if_not_exists=True,
+        )
 
         plugin_file = os.path.join(
             collection_dir,

--- a/tests/functional/baseline-default/collections/ns/col1/changelog.rst
+++ b/tests/functional/baseline-default/collections/ns/col1/changelog.rst
@@ -1,0 +1,130 @@
+=====================
+Ns.Col1 Release Notes
+=====================
+
+.. contents:: Topics
+
+This changelog describes changes after version 1.0.2.
+
+v2.3.0-pre
+==========
+
+Release Summary
+---------------
+
+Just testing with pre-releases.
+
+v2.2.0
+======
+
+Release Summary
+---------------
+
+Testing long changelog fragments. Nothing else in this release. Ignore the fragment contents!
+
+Minor Changes
+-------------
+
+- And a final complex reStructuredText fragment.
+
+  The way to import a PowerShell or C# module util from a collection has changed in the Ansible 2.9 release. In Ansible
+  2.8 a util was imported with the following syntax:
+
+  .. code-block:: powershell
+
+      #AnsibleRequires -CSharpUtil AnsibleCollections.namespace_name.collection_name.util_filename
+      #AnsibleRequires -PowerShell AnsibleCollections.namespace_name.collection_name.util_filename
+
+  In Ansible 2.9 this was changed to:
+
+  .. code-block:: powershell
+
+      #AnsibleRequires -CSharpUtil ansible_collections.namespace_name.collection_name.plugins.module_utils.util_filename
+      #AnsibleRequires -PowerShell ansible_collections.namespace_name.collection_name.plugins.module_utils.util_filename
+
+  The change in the collection import name also requires any C# util namespaces to be updated with the newer name
+  format. This is more verbose but is designed to make sure we avoid plugin name conflicts across separate plugin types
+  and to standardise how imports work in PowerShell with how Python modules work.
+- This is an example of a longer reStructuredText fragment.
+
+  Ansible 2.9 handles "unsafe" data more robustly, ensuring that data marked "unsafe" is not templated. In previous versions, Ansible recursively marked all data returned by the direct use of ``lookup()`` as "unsafe", but only marked structured data returned by indirect lookups using ``with_X`` style loops as "unsafe" if the returned elements were strings. Ansible 2.9 treats these two approaches consistently.
+
+  As a result, if you use ``with_dict`` to return keys with templatable values, your templates may no longer work as expected in Ansible 2.9.
+
+  To allow the old behavior, switch from using ``with_X`` to using ``loop`` with a filter as described at :ref:`migrating_to_loop`.
+- This is an example of a more complex reStructuredText fragment.
+
+  Module and module_utils files can now use relative imports to include other module_utils files.
+  This is useful for shortening long import lines, especially in collections.
+
+  Example of using a relative import in collections:
+
+  .. code-block:: python
+
+    # File: ansible_collections/my_namespace/my_collection/plugins/modules/my_module.py
+    # Old way to use an absolute import to import module_utils from the collection:
+    from ansible_collections.my_namespace.my_collection.plugins.module_utils import my_util
+    # New way using a relative import:
+    from ..module_utils import my_util
+
+  Modules and module_utils shipped with Ansible can use relative imports as well but the savings
+  are smaller:
+
+  .. code-block:: python
+
+    # File: ansible/modules/system/ping.py
+    # Old way to use an absolute import to import module_utils from core:
+    from ansible.module_utils.basic import AnsibleModule
+    # New way using a relative import:
+    from ...module_utils.basic import AnsibleModule
+
+  Each single dot (``.``) represents one level of the tree (equivalent to ``../`` in filesystem relative links).
+
+  .. seealso:: `The Python Relative Import Docs <https://www.python.org/dev/peps/pep-0328/#guido-s-decision>`_ go into more detail of how to write relative imports.
+
+Bugfixes
+--------
+
+- Renamed ``master`` git branch to ``main``.
+
+v2.1.0
+======
+
+Release Summary
+---------------
+
+Bob was there, too!
+
+Bugfixes
+--------
+
+- bob lookup - forgot to check whether ``Bob`` was already there.
+
+New Plugins
+-----------
+
+Lookup
+~~~~~~
+
+- ns.col1.bob - Bob was there, too
+
+v2.0.0
+======
+
+Release Summary
+---------------
+
+We're happy to release 2.0.0 with a new plugin!
+
+Bugfixes
+--------
+
+- reverse lookup - fix bug in error message.
+
+New Plugins
+-----------
+
+Lookup
+~~~~~~
+
+- ns.col1.reverse - reverse magic

--- a/tests/functional/baseline-default/collections/ns/col1/index.rst
+++ b/tests/functional/baseline-default/collections/ns/col1/index.rst
@@ -40,7 +40,6 @@ Changelog
 
     changelog
 
-
 Plugin Index
 ------------
 

--- a/tests/functional/baseline-default/collections/ns/col1/index.rst
+++ b/tests/functional/baseline-default/collections/ns/col1/index.rst
@@ -33,6 +33,7 @@ A short description.
     :maxdepth: 1
 
 
+
 Plugin Index
 ------------
 

--- a/tests/functional/baseline-default/collections/ns/col1/index.rst
+++ b/tests/functional/baseline-default/collections/ns/col1/index.rst
@@ -32,6 +32,13 @@ A short description.
 .. toctree::
     :maxdepth: 1
 
+Changelog
+---------
+
+.. toctree::
+    :maxdepth: 1
+
+    changelog
 
 
 Plugin Index

--- a/tests/functional/baseline-default/collections/ns/col2/index.rst
+++ b/tests/functional/baseline-default/collections/ns/col2/index.rst
@@ -33,8 +33,6 @@ Description
 .. toctree::
     :maxdepth: 1
 
-
-
 Plugin Index
 ------------
 

--- a/tests/functional/baseline-default/collections/ns/col2/index.rst
+++ b/tests/functional/baseline-default/collections/ns/col2/index.rst
@@ -34,6 +34,7 @@ Description
     :maxdepth: 1
 
 
+
 Plugin Index
 ------------
 

--- a/tests/functional/baseline-default/collections/ns2/col/changelog.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/changelog.rst
@@ -1,0 +1,4 @@
+
+The changelog of ns2.col could not be rendered::
+
+  list index out of range

--- a/tests/functional/baseline-default/collections/ns2/col/index.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/index.rst
@@ -82,7 +82,6 @@ Guides
 
     docsite/filter_guide
 
-
 Plugin Index
 ------------
 

--- a/tests/functional/baseline-default/collections/ns2/col/index.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/index.rst
@@ -66,6 +66,7 @@ Communication
 .. toctree::
     :maxdepth: 1
 
+
 Guides
 ------
 

--- a/tests/functional/baseline-default/collections/ns2/col/index.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/index.rst
@@ -66,6 +66,13 @@ Communication
 .. toctree::
     :maxdepth: 1
 
+Changelog
+---------
+
+.. toctree::
+    :maxdepth: 1
+
+    changelog
 
 Guides
 ------

--- a/tests/functional/baseline-default/collections/ns2/flatcol/index.rst
+++ b/tests/functional/baseline-default/collections/ns2/flatcol/index.rst
@@ -30,6 +30,7 @@ Description
     :maxdepth: 1
 
 
+
 Plugin Index
 ------------
 

--- a/tests/functional/baseline-default/collections/ns2/flatcol/index.rst
+++ b/tests/functional/baseline-default/collections/ns2/flatcol/index.rst
@@ -29,8 +29,6 @@ Description
 .. toctree::
     :maxdepth: 1
 
-
-
 Plugin Index
 ------------
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns/col1/changelog.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns/col1/changelog.rst
@@ -1,0 +1,130 @@
+=====================
+Ns.Col1 Release Notes
+=====================
+
+.. contents:: Topics
+
+This changelog describes changes after version 1.0.2.
+
+v2.3.0-pre
+==========
+
+Release Summary
+---------------
+
+Just testing with pre-releases.
+
+v2.2.0
+======
+
+Release Summary
+---------------
+
+Testing long changelog fragments. Nothing else in this release. Ignore the fragment contents!
+
+Minor Changes
+-------------
+
+- And a final complex reStructuredText fragment.
+
+  The way to import a PowerShell or C# module util from a collection has changed in the Ansible 2.9 release. In Ansible
+  2.8 a util was imported with the following syntax:
+
+  .. code-block:: powershell
+
+      #AnsibleRequires -CSharpUtil AnsibleCollections.namespace_name.collection_name.util_filename
+      #AnsibleRequires -PowerShell AnsibleCollections.namespace_name.collection_name.util_filename
+
+  In Ansible 2.9 this was changed to:
+
+  .. code-block:: powershell
+
+      #AnsibleRequires -CSharpUtil ansible_collections.namespace_name.collection_name.plugins.module_utils.util_filename
+      #AnsibleRequires -PowerShell ansible_collections.namespace_name.collection_name.plugins.module_utils.util_filename
+
+  The change in the collection import name also requires any C# util namespaces to be updated with the newer name
+  format. This is more verbose but is designed to make sure we avoid plugin name conflicts across separate plugin types
+  and to standardise how imports work in PowerShell with how Python modules work.
+- This is an example of a longer reStructuredText fragment.
+
+  Ansible 2.9 handles "unsafe" data more robustly, ensuring that data marked "unsafe" is not templated. In previous versions, Ansible recursively marked all data returned by the direct use of ``lookup()`` as "unsafe", but only marked structured data returned by indirect lookups using ``with_X`` style loops as "unsafe" if the returned elements were strings. Ansible 2.9 treats these two approaches consistently.
+
+  As a result, if you use ``with_dict`` to return keys with templatable values, your templates may no longer work as expected in Ansible 2.9.
+
+  To allow the old behavior, switch from using ``with_X`` to using ``loop`` with a filter as described at :ref:`migrating_to_loop`.
+- This is an example of a more complex reStructuredText fragment.
+
+  Module and module_utils files can now use relative imports to include other module_utils files.
+  This is useful for shortening long import lines, especially in collections.
+
+  Example of using a relative import in collections:
+
+  .. code-block:: python
+
+    # File: ansible_collections/my_namespace/my_collection/plugins/modules/my_module.py
+    # Old way to use an absolute import to import module_utils from the collection:
+    from ansible_collections.my_namespace.my_collection.plugins.module_utils import my_util
+    # New way using a relative import:
+    from ..module_utils import my_util
+
+  Modules and module_utils shipped with Ansible can use relative imports as well but the savings
+  are smaller:
+
+  .. code-block:: python
+
+    # File: ansible/modules/system/ping.py
+    # Old way to use an absolute import to import module_utils from core:
+    from ansible.module_utils.basic import AnsibleModule
+    # New way using a relative import:
+    from ...module_utils.basic import AnsibleModule
+
+  Each single dot (``.``) represents one level of the tree (equivalent to ``../`` in filesystem relative links).
+
+  .. seealso:: `The Python Relative Import Docs <https://www.python.org/dev/peps/pep-0328/#guido-s-decision>`_ go into more detail of how to write relative imports.
+
+Bugfixes
+--------
+
+- Renamed ``master`` git branch to ``main``.
+
+v2.1.0
+======
+
+Release Summary
+---------------
+
+Bob was there, too!
+
+Bugfixes
+--------
+
+- bob lookup - forgot to check whether ``Bob`` was already there.
+
+New Plugins
+-----------
+
+Lookup
+~~~~~~
+
+- ns.col1.bob - Bob was there, too
+
+v2.0.0
+======
+
+Release Summary
+---------------
+
+We're happy to release 2.0.0 with a new plugin!
+
+Bugfixes
+--------
+
+- reverse lookup - fix bug in error message.
+
+New Plugins
+-----------
+
+Lookup
+~~~~~~
+
+- ns.col1.reverse - reverse magic

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns/col1/index.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns/col1/index.rst
@@ -34,6 +34,7 @@ A short description.
     :maxdepth: 1
 
 
+
 Plugin Index
 ------------
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns/col1/index.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns/col1/index.rst
@@ -41,7 +41,6 @@ Changelog
 
     changelog
 
-
 Plugin Index
 ------------
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns/col1/index.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns/col1/index.rst
@@ -33,6 +33,13 @@ A short description.
 .. toctree::
     :maxdepth: 1
 
+Changelog
+---------
+
+.. toctree::
+    :maxdepth: 1
+
+    changelog
 
 
 Plugin Index

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/index.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/index.rst
@@ -35,6 +35,7 @@ Description
     :maxdepth: 1
 
 
+
 Plugin Index
 ------------
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/index.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/index.rst
@@ -34,8 +34,6 @@ Description
 .. toctree::
     :maxdepth: 1
 
-
-
 Plugin Index
 ------------
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/changelog.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/changelog.rst
@@ -1,0 +1,4 @@
+
+The changelog of ns2.col could not be rendered::
+
+  list index out of range

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/index.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/index.rst
@@ -67,6 +67,7 @@ Communication
 .. toctree::
     :maxdepth: 1
 
+
 Guides
 ------
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/index.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/index.rst
@@ -67,6 +67,13 @@ Communication
 .. toctree::
     :maxdepth: 1
 
+Changelog
+---------
+
+.. toctree::
+    :maxdepth: 1
+
+    changelog
 
 Guides
 ------

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/index.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/index.rst
@@ -83,7 +83,6 @@ Guides
 
     docsite/filter_guide
 
-
 Plugin Index
 ------------
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/flatcol/index.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/flatcol/index.rst
@@ -30,8 +30,6 @@ Description
 .. toctree::
     :maxdepth: 1
 
-
-
 Plugin Index
 ------------
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/flatcol/index.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/flatcol/index.rst
@@ -31,6 +31,7 @@ Description
     :maxdepth: 1
 
 
+
 Plugin Index
 ------------
 

--- a/tests/functional/baseline-no-indexes/collections/ns/col1/changelog.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns/col1/changelog.rst
@@ -1,0 +1,130 @@
+=====================
+Ns.Col1 Release Notes
+=====================
+
+.. contents:: Topics
+
+This changelog describes changes after version 1.0.2.
+
+v2.3.0-pre
+==========
+
+Release Summary
+---------------
+
+Just testing with pre-releases.
+
+v2.2.0
+======
+
+Release Summary
+---------------
+
+Testing long changelog fragments. Nothing else in this release. Ignore the fragment contents!
+
+Minor Changes
+-------------
+
+- And a final complex reStructuredText fragment.
+
+  The way to import a PowerShell or C# module util from a collection has changed in the Ansible 2.9 release. In Ansible
+  2.8 a util was imported with the following syntax:
+
+  .. code-block:: powershell
+
+      #AnsibleRequires -CSharpUtil AnsibleCollections.namespace_name.collection_name.util_filename
+      #AnsibleRequires -PowerShell AnsibleCollections.namespace_name.collection_name.util_filename
+
+  In Ansible 2.9 this was changed to:
+
+  .. code-block:: powershell
+
+      #AnsibleRequires -CSharpUtil ansible_collections.namespace_name.collection_name.plugins.module_utils.util_filename
+      #AnsibleRequires -PowerShell ansible_collections.namespace_name.collection_name.plugins.module_utils.util_filename
+
+  The change in the collection import name also requires any C# util namespaces to be updated with the newer name
+  format. This is more verbose but is designed to make sure we avoid plugin name conflicts across separate plugin types
+  and to standardise how imports work in PowerShell with how Python modules work.
+- This is an example of a longer reStructuredText fragment.
+
+  Ansible 2.9 handles "unsafe" data more robustly, ensuring that data marked "unsafe" is not templated. In previous versions, Ansible recursively marked all data returned by the direct use of ``lookup()`` as "unsafe", but only marked structured data returned by indirect lookups using ``with_X`` style loops as "unsafe" if the returned elements were strings. Ansible 2.9 treats these two approaches consistently.
+
+  As a result, if you use ``with_dict`` to return keys with templatable values, your templates may no longer work as expected in Ansible 2.9.
+
+  To allow the old behavior, switch from using ``with_X`` to using ``loop`` with a filter as described at :ref:`migrating_to_loop`.
+- This is an example of a more complex reStructuredText fragment.
+
+  Module and module_utils files can now use relative imports to include other module_utils files.
+  This is useful for shortening long import lines, especially in collections.
+
+  Example of using a relative import in collections:
+
+  .. code-block:: python
+
+    # File: ansible_collections/my_namespace/my_collection/plugins/modules/my_module.py
+    # Old way to use an absolute import to import module_utils from the collection:
+    from ansible_collections.my_namespace.my_collection.plugins.module_utils import my_util
+    # New way using a relative import:
+    from ..module_utils import my_util
+
+  Modules and module_utils shipped with Ansible can use relative imports as well but the savings
+  are smaller:
+
+  .. code-block:: python
+
+    # File: ansible/modules/system/ping.py
+    # Old way to use an absolute import to import module_utils from core:
+    from ansible.module_utils.basic import AnsibleModule
+    # New way using a relative import:
+    from ...module_utils.basic import AnsibleModule
+
+  Each single dot (``.``) represents one level of the tree (equivalent to ``../`` in filesystem relative links).
+
+  .. seealso:: `The Python Relative Import Docs <https://www.python.org/dev/peps/pep-0328/#guido-s-decision>`_ go into more detail of how to write relative imports.
+
+Bugfixes
+--------
+
+- Renamed ``master`` git branch to ``main``.
+
+v2.1.0
+======
+
+Release Summary
+---------------
+
+Bob was there, too!
+
+Bugfixes
+--------
+
+- bob lookup - forgot to check whether ``Bob`` was already there.
+
+New Plugins
+-----------
+
+Lookup
+~~~~~~
+
+- ns.col1.bob - Bob was there, too
+
+v2.0.0
+======
+
+Release Summary
+---------------
+
+We're happy to release 2.0.0 with a new plugin!
+
+Bugfixes
+--------
+
+- reverse lookup - fix bug in error message.
+
+New Plugins
+-----------
+
+Lookup
+~~~~~~
+
+- ns.col1.reverse - reverse magic

--- a/tests/functional/baseline-no-indexes/collections/ns/col1/index.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns/col1/index.rst
@@ -40,7 +40,6 @@ Changelog
 
     changelog
 
-
 Plugin Index
 ------------
 

--- a/tests/functional/baseline-no-indexes/collections/ns/col1/index.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns/col1/index.rst
@@ -33,6 +33,7 @@ A short description.
     :maxdepth: 1
 
 
+
 Plugin Index
 ------------
 

--- a/tests/functional/baseline-no-indexes/collections/ns/col1/index.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns/col1/index.rst
@@ -32,6 +32,13 @@ A short description.
 .. toctree::
     :maxdepth: 1
 
+Changelog
+---------
+
+.. toctree::
+    :maxdepth: 1
+
+    changelog
 
 
 Plugin Index

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/changelog.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/changelog.rst
@@ -1,0 +1,4 @@
+
+The changelog of ns2.col could not be rendered::
+
+  list index out of range

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/index.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/index.rst
@@ -82,7 +82,6 @@ Guides
 
     docsite/filter_guide
 
-
 Plugin Index
 ------------
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/index.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/index.rst
@@ -66,6 +66,7 @@ Communication
 .. toctree::
     :maxdepth: 1
 
+
 Guides
 ------
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/index.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/index.rst
@@ -66,6 +66,13 @@ Communication
 .. toctree::
     :maxdepth: 1
 
+Changelog
+---------
+
+.. toctree::
+    :maxdepth: 1
+
+    changelog
 
 Guides
 ------

--- a/tests/functional/baseline-no-indexes/collections/ns2/flatcol/index.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/flatcol/index.rst
@@ -30,6 +30,7 @@ Description
     :maxdepth: 1
 
 
+
 Plugin Index
 ------------
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/flatcol/index.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/flatcol/index.rst
@@ -29,8 +29,6 @@ Description
 .. toctree::
     :maxdepth: 1
 
-
-
 Plugin Index
 ------------
 

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/changelog.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/changelog.rst
@@ -1,0 +1,4 @@
+
+The changelog of ns2.col could not be rendered::
+
+  list index out of range

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/index.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/index.rst
@@ -46,6 +46,7 @@ Communication
 - Mailing list: `Ansible Project List <https://groups.google.com/g/ansible-project>`__.
   (`Subscribe <mailto:ansible-project+subscribe@googlegroups.com?subject=subscribe>`__)
 
+
 Guides
 ------
 

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/index.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/index.rst
@@ -56,7 +56,6 @@ Guides
 
 * `<docsite/filter_guide.rst>`_
 
-
 Plugin Index
 ------------
 

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/index.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/index.rst
@@ -46,6 +46,10 @@ Communication
 - Mailing list: `Ansible Project List <https://groups.google.com/g/ansible-project>`__.
   (`Subscribe <mailto:ansible-project+subscribe@googlegroups.com?subject=subscribe>`__)
 
+Changelog
+---------
+
+`Ns2.Col Release Notes <changelog.rst>`_
 
 Guides
 ------

--- a/tests/functional/baseline-simplified-rst/collections/ns/col1/changelog.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns/col1/changelog.rst
@@ -1,0 +1,130 @@
+=====================
+Ns.Col1 Release Notes
+=====================
+
+.. contents:: Topics
+
+This changelog describes changes after version 1.0.2.
+
+v2.3.0-pre
+==========
+
+Release Summary
+---------------
+
+Just testing with pre-releases.
+
+v2.2.0
+======
+
+Release Summary
+---------------
+
+Testing long changelog fragments. Nothing else in this release. Ignore the fragment contents!
+
+Minor Changes
+-------------
+
+- And a final complex reStructuredText fragment.
+
+  The way to import a PowerShell or C# module util from a collection has changed in the Ansible 2.9 release. In Ansible
+  2.8 a util was imported with the following syntax:
+
+  .. code-block:: powershell
+
+      #AnsibleRequires -CSharpUtil AnsibleCollections.namespace_name.collection_name.util_filename
+      #AnsibleRequires -PowerShell AnsibleCollections.namespace_name.collection_name.util_filename
+
+  In Ansible 2.9 this was changed to:
+
+  .. code-block:: powershell
+
+      #AnsibleRequires -CSharpUtil ansible_collections.namespace_name.collection_name.plugins.module_utils.util_filename
+      #AnsibleRequires -PowerShell ansible_collections.namespace_name.collection_name.plugins.module_utils.util_filename
+
+  The change in the collection import name also requires any C# util namespaces to be updated with the newer name
+  format. This is more verbose but is designed to make sure we avoid plugin name conflicts across separate plugin types
+  and to standardise how imports work in PowerShell with how Python modules work.
+- This is an example of a longer reStructuredText fragment.
+
+  Ansible 2.9 handles "unsafe" data more robustly, ensuring that data marked "unsafe" is not templated. In previous versions, Ansible recursively marked all data returned by the direct use of ``lookup()`` as "unsafe", but only marked structured data returned by indirect lookups using ``with_X`` style loops as "unsafe" if the returned elements were strings. Ansible 2.9 treats these two approaches consistently.
+
+  As a result, if you use ``with_dict`` to return keys with templatable values, your templates may no longer work as expected in Ansible 2.9.
+
+  To allow the old behavior, switch from using ``with_X`` to using ``loop`` with a filter as described at :ref:`migrating_to_loop`.
+- This is an example of a more complex reStructuredText fragment.
+
+  Module and module_utils files can now use relative imports to include other module_utils files.
+  This is useful for shortening long import lines, especially in collections.
+
+  Example of using a relative import in collections:
+
+  .. code-block:: python
+
+    # File: ansible_collections/my_namespace/my_collection/plugins/modules/my_module.py
+    # Old way to use an absolute import to import module_utils from the collection:
+    from ansible_collections.my_namespace.my_collection.plugins.module_utils import my_util
+    # New way using a relative import:
+    from ..module_utils import my_util
+
+  Modules and module_utils shipped with Ansible can use relative imports as well but the savings
+  are smaller:
+
+  .. code-block:: python
+
+    # File: ansible/modules/system/ping.py
+    # Old way to use an absolute import to import module_utils from core:
+    from ansible.module_utils.basic import AnsibleModule
+    # New way using a relative import:
+    from ...module_utils.basic import AnsibleModule
+
+  Each single dot (``.``) represents one level of the tree (equivalent to ``../`` in filesystem relative links).
+
+  .. seealso:: `The Python Relative Import Docs <https://www.python.org/dev/peps/pep-0328/#guido-s-decision>`_ go into more detail of how to write relative imports.
+
+Bugfixes
+--------
+
+- Renamed ``master`` git branch to ``main``.
+
+v2.1.0
+======
+
+Release Summary
+---------------
+
+Bob was there, too!
+
+Bugfixes
+--------
+
+- bob lookup - forgot to check whether ``Bob`` was already there.
+
+New Plugins
+-----------
+
+Lookup
+~~~~~~
+
+- ns.col1.bob - Bob was there, too
+
+v2.0.0
+======
+
+Release Summary
+---------------
+
+We're happy to release 2.0.0 with a new plugin!
+
+Bugfixes
+--------
+
+- reverse lookup - fix bug in error message.
+
+New Plugins
+-----------
+
+Lookup
+~~~~~~
+
+- ns.col1.reverse - reverse magic

--- a/tests/functional/baseline-simplified-rst/collections/ns/col1/index.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns/col1/index.rst
@@ -24,6 +24,10 @@ A short description.
 
 
 
+Changelog
+---------
+
+`Ns.Col1 Release Notes <changelog.rst>`_
 
 
 Plugin Index

--- a/tests/functional/baseline-simplified-rst/collections/ns/col1/index.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns/col1/index.rst
@@ -25,6 +25,7 @@ A short description.
 
 
 
+
 Plugin Index
 ------------
 

--- a/tests/functional/baseline-simplified-rst/collections/ns/col1/index.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns/col1/index.rst
@@ -29,7 +29,6 @@ Changelog
 
 `Ns.Col1 Release Notes <changelog.rst>`_
 
-
 Plugin Index
 ------------
 

--- a/tests/functional/baseline-simplified-rst/collections/ns/col2/index.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns/col2/index.rst
@@ -25,8 +25,6 @@ Description
 
 
 
-
-
 Plugin Index
 ------------
 

--- a/tests/functional/baseline-simplified-rst/collections/ns/col2/index.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns/col2/index.rst
@@ -26,6 +26,7 @@ Description
 
 
 
+
 Plugin Index
 ------------
 

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/changelog.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/changelog.rst
@@ -1,0 +1,4 @@
+
+The changelog of ns2.col could not be rendered::
+
+  list index out of range

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/index.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/index.rst
@@ -46,6 +46,7 @@ Communication
 - Mailing list: `Ansible Project List <https://groups.google.com/g/ansible-project>`__.
   (`Subscribe <mailto:ansible-project+subscribe@googlegroups.com?subject=subscribe>`__)
 
+
 Guides
 ------
 

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/index.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/index.rst
@@ -56,7 +56,6 @@ Guides
 
 * `<docsite/filter_guide.rst>`_
 
-
 Plugin Index
 ------------
 

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/index.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/index.rst
@@ -46,6 +46,10 @@ Communication
 - Mailing list: `Ansible Project List <https://groups.google.com/g/ansible-project>`__.
   (`Subscribe <mailto:ansible-project+subscribe@googlegroups.com?subject=subscribe>`__)
 
+Changelog
+---------
+
+`Ns2.Col Release Notes <changelog.rst>`_
 
 Guides
 ------

--- a/tests/functional/baseline-simplified-rst/collections/ns2/flatcol/index.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/flatcol/index.rst
@@ -21,8 +21,6 @@ Description
 
 
 
-
-
 Plugin Index
 ------------
 

--- a/tests/functional/baseline-simplified-rst/collections/ns2/flatcol/index.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/flatcol/index.rst
@@ -22,6 +22,7 @@ Description
 
 
 
+
 Plugin Index
 ------------
 

--- a/tests/functional/baseline-squash-hierarchy/changelog.rst
+++ b/tests/functional/baseline-squash-hierarchy/changelog.rst
@@ -1,0 +1,4 @@
+
+The changelog of ns2.col could not be rendered::
+
+  list index out of range

--- a/tests/functional/baseline-squash-hierarchy/index.rst
+++ b/tests/functional/baseline-squash-hierarchy/index.rst
@@ -82,7 +82,6 @@ Guides
 
     docsite/filter_guide
 
-
 Plugin Index
 ------------
 

--- a/tests/functional/baseline-squash-hierarchy/index.rst
+++ b/tests/functional/baseline-squash-hierarchy/index.rst
@@ -66,6 +66,7 @@ Communication
 .. toctree::
     :maxdepth: 1
 
+
 Guides
 ------
 

--- a/tests/functional/baseline-squash-hierarchy/index.rst
+++ b/tests/functional/baseline-squash-hierarchy/index.rst
@@ -66,6 +66,13 @@ Communication
 .. toctree::
     :maxdepth: 1
 
+Changelog
+---------
+
+.. toctree::
+    :maxdepth: 1
+
+    changelog
 
 Guides
 ------

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/changelog.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/changelog.rst
@@ -1,0 +1,4 @@
+
+The changelog of ns2.col could not be rendered::
+
+  list index out of range

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/index.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/index.rst
@@ -82,7 +82,6 @@ Guides
 
     docsite/filter_guide
 
-
 Plugin Index
 ------------
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/index.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/index.rst
@@ -66,6 +66,7 @@ Communication
 .. toctree::
     :maxdepth: 1
 
+
 Guides
 ------
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/index.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/index.rst
@@ -66,6 +66,13 @@ Communication
 .. toctree::
     :maxdepth: 1
 
+Changelog
+---------
+
+.. toctree::
+    :maxdepth: 1
+
+    changelog
 
 Guides
 ------

--- a/tests/functional/collections/ansible_collections/ns/col1/changelogs/changelog.yaml
+++ b/tests/functional/collections/ansible_collections/ns/col1/changelogs/changelog.yaml
@@ -1,0 +1,109 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+ancestor: 1.0.2
+releases:
+  2.0.0:
+    changes:
+      bugfixes:
+      - reverse lookup - fix bug in error message.
+      release_summary: We're happy to release 2.0.0 with a new plugin!
+    fragments:
+    - 2.0.0.rst
+    - fix-doc.yml
+    release_date: '2020-04-30'
+  2.0.0-1:
+    plugins:
+      lookup:
+      - description: reverse magic
+        name: reverse
+        namespace: null
+    release_date: '2020-04-29'
+  2.1.0:
+    changes:
+      release_summary: Bob was there, too!
+    fragments:
+    - v2.1.0.rst
+    release_date: '2020-05-01'
+  2.1.0-beta:
+    plugins:
+      lookup:
+      - description: Bob was there, too
+        name: bob
+        namespace: null
+    release_date: '2020-04-30'
+  2.1.0-beta-2:
+    changes:
+      bugfixes:
+      - bob lookup - forgot to check whether ``Bob`` was already there.
+    fragments:
+    - bob-exists.yml
+    release_date: '2020-05-01'
+  2.2.0:
+    changes:
+      bugfixes:
+      - Renamed ``master`` git branch to ``main``.
+      minor_changes:
+      - "And a final complex reStructuredText fragment.\n\nThe way to import a PowerShell
+        or C# module util from a collection has changed in the Ansible 2.9 release.
+        In Ansible\n2.8 a util was imported with the following syntax:\n\n.. code-block::
+        powershell\n\n    #AnsibleRequires -CSharpUtil AnsibleCollections.namespace_name.collection_name.util_filename\n
+        \   #AnsibleRequires -PowerShell AnsibleCollections.namespace_name.collection_name.util_filename\n\nIn
+        Ansible 2.9 this was changed to:\n\n.. code-block:: powershell\n\n    #AnsibleRequires
+        -CSharpUtil ansible_collections.namespace_name.collection_name.plugins.module_utils.util_filename\n
+        \   #AnsibleRequires -PowerShell ansible_collections.namespace_name.collection_name.plugins.module_utils.util_filename\n\nThe
+        change in the collection import name also requires any C# util namespaces
+        to be updated with the newer name\nformat. This is more verbose but is designed
+        to make sure we avoid plugin name conflicts across separate plugin types\nand
+        to standardise how imports work in PowerShell with how Python modules work.\n"
+      - 'This is an example of a longer reStructuredText fragment.
+
+
+        Ansible 2.9 handles "unsafe" data more robustly, ensuring that data marked
+        "unsafe" is not templated. In previous versions, Ansible recursively marked
+        all data returned by the direct use of ``lookup()`` as "unsafe", but only
+        marked structured data returned by indirect lookups using ``with_X`` style
+        loops as "unsafe" if the returned elements were strings. Ansible 2.9 treats
+        these two approaches consistently.
+
+
+        As a result, if you use ``with_dict`` to return keys with templatable values,
+        your templates may no longer work as expected in Ansible 2.9.
+
+
+        To allow the old behavior, switch from using ``with_X`` to using ``loop``
+        with a filter as described at :ref:`migrating_to_loop`.
+
+        '
+      - "This is an example of a more complex reStructuredText fragment.\n\nModule
+        and module_utils files can now use relative imports to include other module_utils
+        files.\nThis is useful for shortening long import lines, especially in collections.\n\nExample
+        of using a relative import in collections:\n\n.. code-block:: python\n\n  #
+        File: ansible_collections/my_namespace/my_collection/plugins/modules/my_module.py\n
+        \ # Old way to use an absolute import to import module_utils from the collection:\n
+        \ from ansible_collections.my_namespace.my_collection.plugins.module_utils
+        import my_util\n  # New way using a relative import:\n  from ..module_utils
+        import my_util\n\nModules and module_utils shipped with Ansible can use relative
+        imports as well but the savings\nare smaller:\n\n.. code-block:: python\n\n
+        \ # File: ansible/modules/system/ping.py\n  # Old way to use an absolute import
+        to import module_utils from core:\n  from ansible.module_utils.basic import
+        AnsibleModule\n  # New way using a relative import:\n  from ...module_utils.basic
+        import AnsibleModule\n\nEach single dot (``.``) represents one level of the
+        tree (equivalent to ``../`` in filesystem relative links).\n\n.. seealso::
+        `The Python Relative Import Docs <https://www.python.org/dev/peps/pep-0328/#guido-s-decision>`_
+        go into more detail of how to write relative imports.\n"
+      release_summary: Testing long changelog fragments. Nothing else in this release.
+        Ignore the fragment contents!
+    fragments:
+    - 2.2.0.yml
+    - master-main.yml
+    - something-long.yml
+    release_date: '2020-05-27'
+  2.3.0-pre:
+    changes:
+      release_summary: Just testing with pre-releases.
+    fragments:
+    - 2.3.0-pre.yml
+    release_date: '2020-06-27'

--- a/tests/functional/collections/ansible_collections/ns/col1/docs/docsite/config.yml
+++ b/tests/functional/collections/ansible_collections/ns/col1/docs/docsite/config.yml
@@ -1,0 +1,7 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+changelog:
+  write_changelog: true

--- a/tests/functional/collections/ansible_collections/ns/col2/changelogs/changelog.yaml
+++ b/tests/functional/collections/ansible_collections/ns/col2/changelogs/changelog.yaml
@@ -1,0 +1,109 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+ancestor: 1.0.2
+releases:
+  2.0.0:
+    changes:
+      bugfixes:
+      - reverse lookup - fix bug in error message.
+      release_summary: We're happy to release 2.0.0 with a new plugin!
+    fragments:
+    - 2.0.0.rst
+    - fix-doc.yml
+    release_date: '2020-04-30'
+  2.0.0-1:
+    plugins:
+      lookup:
+      - description: reverse magic
+        name: reverse
+        namespace: null
+    release_date: '2020-04-29'
+  2.1.0:
+    changes:
+      release_summary: Bob was there, too!
+    fragments:
+    - v2.1.0.rst
+    release_date: '2020-05-01'
+  2.1.0-beta:
+    plugins:
+      lookup:
+      - description: Bob was there, too
+        name: bob
+        namespace: null
+    release_date: '2020-04-30'
+  2.1.0-beta-2:
+    changes:
+      bugfixes:
+      - bob lookup - forgot to check whether ``Bob`` was already there.
+    fragments:
+    - bob-exists.yml
+    release_date: '2020-05-01'
+  2.2.0:
+    changes:
+      bugfixes:
+      - Renamed ``master`` git branch to ``main``.
+      minor_changes:
+      - "And a final complex reStructuredText fragment.\n\nThe way to import a PowerShell
+        or C# module util from a collection has changed in the Ansible 2.9 release.
+        In Ansible\n2.8 a util was imported with the following syntax:\n\n.. code-block::
+        powershell\n\n    #AnsibleRequires -CSharpUtil AnsibleCollections.namespace_name.collection_name.util_filename\n
+        \   #AnsibleRequires -PowerShell AnsibleCollections.namespace_name.collection_name.util_filename\n\nIn
+        Ansible 2.9 this was changed to:\n\n.. code-block:: powershell\n\n    #AnsibleRequires
+        -CSharpUtil ansible_collections.namespace_name.collection_name.plugins.module_utils.util_filename\n
+        \   #AnsibleRequires -PowerShell ansible_collections.namespace_name.collection_name.plugins.module_utils.util_filename\n\nThe
+        change in the collection import name also requires any C# util namespaces
+        to be updated with the newer name\nformat. This is more verbose but is designed
+        to make sure we avoid plugin name conflicts across separate plugin types\nand
+        to standardise how imports work in PowerShell with how Python modules work.\n"
+      - 'This is an example of a longer reStructuredText fragment.
+
+
+        Ansible 2.9 handles "unsafe" data more robustly, ensuring that data marked
+        "unsafe" is not templated. In previous versions, Ansible recursively marked
+        all data returned by the direct use of ``lookup()`` as "unsafe", but only
+        marked structured data returned by indirect lookups using ``with_X`` style
+        loops as "unsafe" if the returned elements were strings. Ansible 2.9 treats
+        these two approaches consistently.
+
+
+        As a result, if you use ``with_dict`` to return keys with templatable values,
+        your templates may no longer work as expected in Ansible 2.9.
+
+
+        To allow the old behavior, switch from using ``with_X`` to using ``loop``
+        with a filter as described at :ref:`migrating_to_loop`.
+
+        '
+      - "This is an example of a more complex reStructuredText fragment.\n\nModule
+        and module_utils files can now use relative imports to include other module_utils
+        files.\nThis is useful for shortening long import lines, especially in collections.\n\nExample
+        of using a relative import in collections:\n\n.. code-block:: python\n\n  #
+        File: ansible_collections/my_namespace/my_collection/plugins/modules/my_module.py\n
+        \ # Old way to use an absolute import to import module_utils from the collection:\n
+        \ from ansible_collections.my_namespace.my_collection.plugins.module_utils
+        import my_util\n  # New way using a relative import:\n  from ..module_utils
+        import my_util\n\nModules and module_utils shipped with Ansible can use relative
+        imports as well but the savings\nare smaller:\n\n.. code-block:: python\n\n
+        \ # File: ansible/modules/system/ping.py\n  # Old way to use an absolute import
+        to import module_utils from core:\n  from ansible.module_utils.basic import
+        AnsibleModule\n  # New way using a relative import:\n  from ...module_utils.basic
+        import AnsibleModule\n\nEach single dot (``.``) represents one level of the
+        tree (equivalent to ``../`` in filesystem relative links).\n\n.. seealso::
+        `The Python Relative Import Docs <https://www.python.org/dev/peps/pep-0328/#guido-s-decision>`_
+        go into more detail of how to write relative imports.\n"
+      release_summary: Testing long changelog fragments. Nothing else in this release.
+        Ignore the fragment contents!
+    fragments:
+    - 2.2.0.yml
+    - master-main.yml
+    - something-long.yml
+    release_date: '2020-05-27'
+  2.3.0-pre:
+    changes:
+      release_summary: Just testing with pre-releases.
+    fragments:
+    - 2.3.0-pre.yml
+    release_date: '2020-06-27'

--- a/tests/functional/collections/ansible_collections/ns2/col/changelogs/changelog.yaml
+++ b/tests/functional/collections/ansible_collections/ns2/col/changelogs/changelog.yaml
@@ -3,9 +3,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-envvar_directives:
-  - FOOBAR1
-  - FOOBAR2
-
-changelog:
-  write_changelog: true
+releases:
+  - 1
+  - 2


### PR DESCRIPTION
Fixes #31.

To do:
- [x] Add documentation.
- [x] Add proper error handling.
- [x] Make configuration more future-proof.
- [x] Discuss at DaWG meeting where to place changelog on collection index page.
- [x] Add tests.
