### PR TITLE
Fix bugs in choices

### DIFF
--- a/changelogs/fragments/276-choices.yml
+++ b/changelogs/fragments/276-choices.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "Fix handling of ``choices`` that are dictionaries for ``type=list`` (https://github.com/ansible-community/antsibull-docs/pull/276)."
+  - "Fix handling of ``default`` for ``type=list`` if ``choices`` is present (https://github.com/ansible-community/antsibull-docs/pull/276)."

--- a/src/antsibull_docs/data/docsite/ansible-docsite/macros/parameters.rst.j2
+++ b/src/antsibull_docs/data/docsite/ansible-docsite/macros/parameters.rst.j2
@@ -103,7 +103,7 @@
 @{     choices_rst(value['choices'], value['default'], role_entrypoint=role_entrypoint) }@
 {%   endif %}
 {# Show default value, when multiple choice or no choices #}
-{%   if value['default'] is not none and value['default'] not in value['choices'] %}
+{%   if value['default'] is list or (value['default'] is not none and value['default'] not in value['choices']) %}
 
       .. rst-class:: ansible-option-line
 
@@ -235,7 +235,7 @@
 @{     choices_html(value['choices'], value['default'], role_entrypoint=role_entrypoint) }@
 {%   endif %}
 {#   Show default value, when multiple choice or no choices #}
-{%   if value['default'] is not none and value['default'] not in value['choices'] %}
+{%   if value['default'] is list or (value['default'] is not none and value['default'] not in value['choices']) %}
       <p class="ansible-option-line"><strong class="ansible-option-default-bold">Default:</strong> <code class="ansible-value literal notranslate ansible-option-default">@{ value['default'] | antsibull_to_json | escape | indent(6, blank=true) }@</code></p>
 {%   endif %}
 {#   Configuration #}

--- a/src/antsibull_docs/data/docsite/simplified-rst/macros/parameters.rst.j2
+++ b/src/antsibull_docs/data/docsite/simplified-rst/macros/parameters.rst.j2
@@ -67,7 +67,7 @@
 @{     choices_html(value['choices'], value['default'], role_entrypoint=role_entrypoint) }@
 {%   endif %}
 {#   Show default value, when multiple choice or no choices #}
-{%   if value['default'] is not none and value['default'] not in value['choices'] %}
+{%   if value['default'] is list or (value['default'] is not none and value['default'] not in value['choices']) %}
       <p style="margin-top: 8px;"><b style="color: blue;">Default:</b> <code style="color: blue;">@{ value['default'] | antsibull_to_json | escape | indent(6, blank=true) }@</code></p>
 {%   endif %}
 {#   Configuration #}

--- a/src/antsibull_docs/schemas/docs/base.py
+++ b/src/antsibull_docs/schemas/docs/base.py
@@ -319,19 +319,22 @@ def normalize_value(  # noqa: C901
     value = values[field]
     type_name = normalize_option_type_names(values["type"])
     type_checker = TYPE_CHECKERS.get(type_name)
-    if type_checker is None:
-        return
 
     elements_name = normalize_option_type_names(values.get("elements"))
     elements_checker = TYPE_CHECKERS.get(elements_name)
 
     descs = None
-    if not is_list_of_values:
-        value = [value]
-    elif accept_dict and isinstance(value, dict):
+    if accept_dict and isinstance(value, dict):
         descs = list(value.values())
         value = list(value)
+        type_name = elements_name
+        type_checker = elements_checker
+    elif not is_list_of_values:
+        value = [value]
     elif not isinstance(value, list):
+        return
+
+    if type_checker is None:
         return
 
     for i, v in enumerate(value):
@@ -349,10 +352,10 @@ def normalize_value(  # noqa: C901
                     raise ValueError(f'Invalid value {vv!r} for "{field}[{i}]": {exc}')
         value[i] = v
 
-    if not is_list_of_values:
-        value = value[0]
-    elif descs is not None:
+    if descs is not None:
         value = dict(zip(value, descs))
+    elif not is_list_of_values:
+        value = value[0]
 
     values[field] = value
 
@@ -477,7 +480,7 @@ class OptionsSchema(BaseModel):
     version_added: str = "historical"
     version_added_collection: str = COLLECTION_NAME_F
 
-    @p.validator("aliases", "description", "choices", pre=True)
+    @p.validator("aliases", "description", pre=True)
     # pylint:disable=no-self-argument
     def list_from_scalars(cls, obj):
         return list_from_scalars(obj)

--- a/tests/functional/ansible-doc-cache-all-others.json
+++ b/tests/functional/ansible-doc-cache-all-others.json
@@ -23081,6 +23081,37 @@
        "required": true,
        "type": "str"
       },
+      "manager": {
+       "choices": {
+        "apk": "Alpine Linux package manager",
+        "apt": "For DEB based distros, C(python-apt) package must be installed on targeted hosts",
+        "auto": "Depending on O(strategy), will match the first or all package managers provided, in order",
+        "dnf": "Alias to rpm",
+        "dnf5": "Alias to rpm",
+        "openbsd_pkg": "Alias to pkg_info",
+        "pacman": "Archlinux package manager/builder",
+        "pkg": "libpkg front end (FreeBSD)",
+        "pkg5": "Alias to pkg",
+        "pkg_info": "OpenBSD package manager",
+        "pkgng": "Alias to pkg",
+        "portage": "Handles ebuild packages, it requires the C(qlist) utility, which is part of 'app-portage/portage-utils'",
+        "rpm": "For RPM based distros, requires RPM Python bindings, not installed by default on Suse (python3-rpm)",
+        "yum": "Alias to rpm",
+        "zypper": "Alias to rpm"
+       },
+       "default": [
+        "auto"
+       ],
+       "description": [
+        "The package manager(s) used by the system so we can query the package information. This is a list and can support multiple package managers per system, since version 2.8.",
+        "The 'portage' and 'pkg' options were added in version 2.8.",
+        "The 'apk' option was added in version 2.11.",
+        "The 'pkg_info' option was added in version 2.13.",
+        "Aliases were added in 2.18, to support using C(auto={{ansible_facts['pkg_mgr']}})"
+       ],
+       "elements": "str",
+       "type": "list"
+      },
       "subfoo": {
        "description": "Some recursive foo.",
        "suboptions": {

--- a/tests/functional/ansible-doc-cache-all.json
+++ b/tests/functional/ansible-doc-cache-all.json
@@ -22998,6 +22998,37 @@
        "required": true,
        "type": "str"
       },
+      "manager": {
+       "choices": {
+        "apk": "Alpine Linux package manager",
+        "apt": "For DEB based distros, C(python-apt) package must be installed on targeted hosts",
+        "auto": "Depending on O(strategy), will match the first or all package managers provided, in order",
+        "dnf": "Alias to rpm",
+        "dnf5": "Alias to rpm",
+        "openbsd_pkg": "Alias to pkg_info",
+        "pacman": "Archlinux package manager/builder",
+        "pkg": "libpkg front end (FreeBSD)",
+        "pkg5": "Alias to pkg",
+        "pkg_info": "OpenBSD package manager",
+        "pkgng": "Alias to pkg",
+        "portage": "Handles ebuild packages, it requires the C(qlist) utility, which is part of 'app-portage/portage-utils'",
+        "rpm": "For RPM based distros, requires RPM Python bindings, not installed by default on Suse (python3-rpm)",
+        "yum": "Alias to rpm",
+        "zypper": "Alias to rpm"
+       },
+       "default": [
+        "auto"
+       ],
+       "description": [
+        "The package manager(s) used by the system so we can query the package information. This is a list and can support multiple package managers per system, since version 2.8.",
+        "The 'portage' and 'pkg' options were added in version 2.8.",
+        "The 'apk' option was added in version 2.11.",
+        "The 'pkg_info' option was added in version 2.13.",
+        "Aliases were added in 2.18, to support using C(auto={{ansible_facts['pkg_mgr']}})"
+       ],
+       "elements": "str",
+       "type": "list"
+      },
       "subfoo": {
        "description": "Some recursive foo.",
        "suboptions": {

--- a/tests/functional/ansible-doc-cache-ansible.builtin-ns.col2-ns2.col.json
+++ b/tests/functional/ansible-doc-cache-ansible.builtin-ns.col2-ns2.col.json
@@ -22998,6 +22998,37 @@
        "required": true,
        "type": "str"
       },
+      "manager": {
+       "choices": {
+        "apk": "Alpine Linux package manager",
+        "apt": "For DEB based distros, C(python-apt) package must be installed on targeted hosts",
+        "auto": "Depending on O(strategy), will match the first or all package managers provided, in order",
+        "dnf": "Alias to rpm",
+        "dnf5": "Alias to rpm",
+        "openbsd_pkg": "Alias to pkg_info",
+        "pacman": "Archlinux package manager/builder",
+        "pkg": "libpkg front end (FreeBSD)",
+        "pkg5": "Alias to pkg",
+        "pkg_info": "OpenBSD package manager",
+        "pkgng": "Alias to pkg",
+        "portage": "Handles ebuild packages, it requires the C(qlist) utility, which is part of 'app-portage/portage-utils'",
+        "rpm": "For RPM based distros, requires RPM Python bindings, not installed by default on Suse (python3-rpm)",
+        "yum": "Alias to rpm",
+        "zypper": "Alias to rpm"
+       },
+       "default": [
+        "auto"
+       ],
+       "description": [
+        "The package manager(s) used by the system so we can query the package information. This is a list and can support multiple package managers per system, since version 2.8.",
+        "The 'portage' and 'pkg' options were added in version 2.8.",
+        "The 'apk' option was added in version 2.11.",
+        "The 'pkg_info' option was added in version 2.13.",
+        "Aliases were added in 2.18, to support using C(auto={{ansible_facts['pkg_mgr']}})"
+       ],
+       "elements": "str",
+       "type": "list"
+      },
       "subfoo": {
        "description": "Some recursive foo.",
        "suboptions": {

--- a/tests/functional/ansible-doc-cache-ansible.builtin-ns2.col.json
+++ b/tests/functional/ansible-doc-cache-ansible.builtin-ns2.col.json
@@ -22619,6 +22619,37 @@
        "required": true,
        "type": "str"
       },
+      "manager": {
+       "choices": {
+        "apk": "Alpine Linux package manager",
+        "apt": "For DEB based distros, C(python-apt) package must be installed on targeted hosts",
+        "auto": "Depending on O(strategy), will match the first or all package managers provided, in order",
+        "dnf": "Alias to rpm",
+        "dnf5": "Alias to rpm",
+        "openbsd_pkg": "Alias to pkg_info",
+        "pacman": "Archlinux package manager/builder",
+        "pkg": "libpkg front end (FreeBSD)",
+        "pkg5": "Alias to pkg",
+        "pkg_info": "OpenBSD package manager",
+        "pkgng": "Alias to pkg",
+        "portage": "Handles ebuild packages, it requires the C(qlist) utility, which is part of 'app-portage/portage-utils'",
+        "rpm": "For RPM based distros, requires RPM Python bindings, not installed by default on Suse (python3-rpm)",
+        "yum": "Alias to rpm",
+        "zypper": "Alias to rpm"
+       },
+       "default": [
+        "auto"
+       ],
+       "description": [
+        "The package manager(s) used by the system so we can query the package information. This is a list and can support multiple package managers per system, since version 2.8.",
+        "The 'portage' and 'pkg' options were added in version 2.8.",
+        "The 'apk' option was added in version 2.11.",
+        "The 'pkg_info' option was added in version 2.13.",
+        "Aliases were added in 2.18, to support using C(auto={{ansible_facts['pkg_mgr']}})"
+       ],
+       "elements": "str",
+       "type": "list"
+      },
       "subfoo": {
        "description": "Some recursive foo.",
        "suboptions": {

--- a/tests/functional/ansible-doc-cache-ns.col1-ns.col2-ns2.col-ns2.flatcol.json
+++ b/tests/functional/ansible-doc-cache-ns.col1-ns.col2-ns2.col-ns2.flatcol.json
@@ -1553,6 +1553,37 @@
        "required": true,
        "type": "str"
       },
+      "manager": {
+       "choices": {
+        "apk": "Alpine Linux package manager",
+        "apt": "For DEB based distros, C(python-apt) package must be installed on targeted hosts",
+        "auto": "Depending on O(strategy), will match the first or all package managers provided, in order",
+        "dnf": "Alias to rpm",
+        "dnf5": "Alias to rpm",
+        "openbsd_pkg": "Alias to pkg_info",
+        "pacman": "Archlinux package manager/builder",
+        "pkg": "libpkg front end (FreeBSD)",
+        "pkg5": "Alias to pkg",
+        "pkg_info": "OpenBSD package manager",
+        "pkgng": "Alias to pkg",
+        "portage": "Handles ebuild packages, it requires the C(qlist) utility, which is part of 'app-portage/portage-utils'",
+        "rpm": "For RPM based distros, requires RPM Python bindings, not installed by default on Suse (python3-rpm)",
+        "yum": "Alias to rpm",
+        "zypper": "Alias to rpm"
+       },
+       "default": [
+        "auto"
+       ],
+       "description": [
+        "The package manager(s) used by the system so we can query the package information. This is a list and can support multiple package managers per system, since version 2.8.",
+        "The 'portage' and 'pkg' options were added in version 2.8.",
+        "The 'apk' option was added in version 2.11.",
+        "The 'pkg_info' option was added in version 2.13.",
+        "Aliases were added in 2.18, to support using C(auto={{ansible_facts['pkg_mgr']}})"
+       ],
+       "elements": "str",
+       "type": "list"
+      },
       "subfoo": {
        "description": "Some recursive foo.",
        "suboptions": {

--- a/tests/functional/ansible-doc-cache-ns.col1-ns2.col-ns2.flatcol.json
+++ b/tests/functional/ansible-doc-cache-ns.col1-ns2.col-ns2.flatcol.json
@@ -1174,6 +1174,37 @@
        "required": true,
        "type": "str"
       },
+      "manager": {
+       "choices": {
+        "apk": "Alpine Linux package manager",
+        "apt": "For DEB based distros, C(python-apt) package must be installed on targeted hosts",
+        "auto": "Depending on O(strategy), will match the first or all package managers provided, in order",
+        "dnf": "Alias to rpm",
+        "dnf5": "Alias to rpm",
+        "openbsd_pkg": "Alias to pkg_info",
+        "pacman": "Archlinux package manager/builder",
+        "pkg": "libpkg front end (FreeBSD)",
+        "pkg5": "Alias to pkg",
+        "pkg_info": "OpenBSD package manager",
+        "pkgng": "Alias to pkg",
+        "portage": "Handles ebuild packages, it requires the C(qlist) utility, which is part of 'app-portage/portage-utils'",
+        "rpm": "For RPM based distros, requires RPM Python bindings, not installed by default on Suse (python3-rpm)",
+        "yum": "Alias to rpm",
+        "zypper": "Alias to rpm"
+       },
+       "default": [
+        "auto"
+       ],
+       "description": [
+        "The package manager(s) used by the system so we can query the package information. This is a list and can support multiple package managers per system, since version 2.8.",
+        "The 'portage' and 'pkg' options were added in version 2.8.",
+        "The 'apk' option was added in version 2.11.",
+        "The 'pkg_info' option was added in version 2.13.",
+        "Aliases were added in 2.18, to support using C(auto={{ansible_facts['pkg_mgr']}})"
+       ],
+       "elements": "str",
+       "type": "list"
+      },
       "subfoo": {
        "description": "Some recursive foo.",
        "suboptions": {

--- a/tests/functional/ansible-doc-cache-ns2.col.json
+++ b/tests/functional/ansible-doc-cache-ns2.col.json
@@ -1174,6 +1174,37 @@
        "required": true,
        "type": "str"
       },
+      "manager": {
+       "choices": {
+        "apk": "Alpine Linux package manager",
+        "apt": "For DEB based distros, C(python-apt) package must be installed on targeted hosts",
+        "auto": "Depending on O(strategy), will match the first or all package managers provided, in order",
+        "dnf": "Alias to rpm",
+        "dnf5": "Alias to rpm",
+        "openbsd_pkg": "Alias to pkg_info",
+        "pacman": "Archlinux package manager/builder",
+        "pkg": "libpkg front end (FreeBSD)",
+        "pkg5": "Alias to pkg",
+        "pkg_info": "OpenBSD package manager",
+        "pkgng": "Alias to pkg",
+        "portage": "Handles ebuild packages, it requires the C(qlist) utility, which is part of 'app-portage/portage-utils'",
+        "rpm": "For RPM based distros, requires RPM Python bindings, not installed by default on Suse (python3-rpm)",
+        "yum": "Alias to rpm",
+        "zypper": "Alias to rpm"
+       },
+       "default": [
+        "auto"
+       ],
+       "description": [
+        "The package manager(s) used by the system so we can query the package information. This is a list and can support multiple package managers per system, since version 2.8.",
+        "The 'portage' and 'pkg' options were added in version 2.8.",
+        "The 'apk' option was added in version 2.11.",
+        "The 'pkg_info' option was added in version 2.13.",
+        "Aliases were added in 2.18, to support using C(auto={{ansible_facts['pkg_mgr']}})"
+       ],
+       "elements": "str",
+       "type": "list"
+      },
       "subfoo": {
        "description": "Some recursive foo.",
        "suboptions": {

--- a/tests/functional/baseline-default/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_module.rst
@@ -172,6 +172,103 @@ Parameters
   * - .. raw:: html
 
         <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-manager"></div>
+
+      .. _ansible_collections.ns2.col.foo_module__parameter-manager:
+
+      .. rst-class:: ansible-option-title
+
+      **manager**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-manager" title="Permalink to this option"></a>
+
+      .. ansible-option-type-line::
+
+        :ansible-option-type:`list` / :ansible-option-elements:`elements=string`
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      The package manager(s) used by the system so we can query the package information. This is a list and can support multiple package managers per system, since version 2.8.
+
+      The 'portage' and 'pkg' options were added in version 2.8.
+
+      The 'apk' option was added in version 2.11.
+
+      The 'pkg\_info' option was added in version 2.13.
+
+      Aliases were added in 2.18, to support using \ :literal:`auto={{ansible\_facts['pkg\_mgr']}}`\ 
+
+
+      .. rst-class:: ansible-option-line
+
+      :ansible-option-choices:`Choices:`
+
+      - :ansible-option-choices-entry:`"apk"`\ :
+        Alpine Linux package manager
+
+      - :ansible-option-choices-entry:`"apt"`\ :
+        For DEB based distros, \ :literal:`python-apt`\  package must be installed on targeted hosts
+
+      - :ansible-option-choices-entry-default:`"auto"` :ansible-option-choices-default-mark:`(default)`\ :
+        Depending on \ :ansopt:`strategy`\ , will match the first or all package managers provided, in order
+
+      - :ansible-option-choices-entry:`"dnf"`\ :
+        Alias to rpm
+
+      - :ansible-option-choices-entry:`"dnf5"`\ :
+        Alias to rpm
+
+      - :ansible-option-choices-entry:`"openbsd\_pkg"`\ :
+        Alias to pkg\_info
+
+      - :ansible-option-choices-entry:`"pacman"`\ :
+        Archlinux package manager/builder
+
+      - :ansible-option-choices-entry:`"pkg"`\ :
+        libpkg front end (FreeBSD)
+
+      - :ansible-option-choices-entry:`"pkg5"`\ :
+        Alias to pkg
+
+      - :ansible-option-choices-entry:`"pkg\_info"`\ :
+        OpenBSD package manager
+
+      - :ansible-option-choices-entry:`"pkgng"`\ :
+        Alias to pkg
+
+      - :ansible-option-choices-entry:`"portage"`\ :
+        Handles ebuild packages, it requires the \ :literal:`qlist`\  utility, which is part of 'app-portage/portage-utils'
+
+      - :ansible-option-choices-entry:`"rpm"`\ :
+        For RPM based distros, requires RPM Python bindings, not installed by default on Suse (python3-rpm)
+
+      - :ansible-option-choices-entry:`"yum"`\ :
+        Alias to rpm
+
+      - :ansible-option-choices-entry:`"zypper"`\ :
+        Alias to rpm
+
+
+
+      .. rst-class:: ansible-option-line
+
+      :ansible-option-default-bold:`Default:` :ansible-option-default:`["auto"]`
+
+      .. raw:: html
+
+        </div>
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="parameter-subfoo"></div>
 
       .. _ansible_collections.ns2.col.foo_module__parameter-subfoo:

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_module.rst
@@ -172,6 +172,103 @@ Parameters
   * - .. raw:: html
 
         <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-manager"></div>
+
+      .. _ansible_collections.ns2.col.foo_module__parameter-manager:
+
+      .. rst-class:: ansible-option-title
+
+      **manager**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-manager" title="Permalink to this option"></a>
+
+      .. ansible-option-type-line::
+
+        :ansible-option-type:`list` / :ansible-option-elements:`elements=string`
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      The package manager(s) used by the system so we can query the package information. This is a list and can support multiple package managers per system, since version 2.8.
+
+      The 'portage' and 'pkg' options were added in version 2.8.
+
+      The 'apk' option was added in version 2.11.
+
+      The 'pkg\_info' option was added in version 2.13.
+
+      Aliases were added in 2.18, to support using \ :literal:`auto={{ansible\_facts['pkg\_mgr']}}`\ 
+
+
+      .. rst-class:: ansible-option-line
+
+      :ansible-option-choices:`Choices:`
+
+      - :ansible-option-choices-entry:`"apk"`\ :
+        Alpine Linux package manager
+
+      - :ansible-option-choices-entry:`"apt"`\ :
+        For DEB based distros, \ :literal:`python-apt`\  package must be installed on targeted hosts
+
+      - :ansible-option-choices-entry-default:`"auto"` :ansible-option-choices-default-mark:`(default)`\ :
+        Depending on \ :ansopt:`strategy`\ , will match the first or all package managers provided, in order
+
+      - :ansible-option-choices-entry:`"dnf"`\ :
+        Alias to rpm
+
+      - :ansible-option-choices-entry:`"dnf5"`\ :
+        Alias to rpm
+
+      - :ansible-option-choices-entry:`"openbsd\_pkg"`\ :
+        Alias to pkg\_info
+
+      - :ansible-option-choices-entry:`"pacman"`\ :
+        Archlinux package manager/builder
+
+      - :ansible-option-choices-entry:`"pkg"`\ :
+        libpkg front end (FreeBSD)
+
+      - :ansible-option-choices-entry:`"pkg5"`\ :
+        Alias to pkg
+
+      - :ansible-option-choices-entry:`"pkg\_info"`\ :
+        OpenBSD package manager
+
+      - :ansible-option-choices-entry:`"pkgng"`\ :
+        Alias to pkg
+
+      - :ansible-option-choices-entry:`"portage"`\ :
+        Handles ebuild packages, it requires the \ :literal:`qlist`\  utility, which is part of 'app-portage/portage-utils'
+
+      - :ansible-option-choices-entry:`"rpm"`\ :
+        For RPM based distros, requires RPM Python bindings, not installed by default on Suse (python3-rpm)
+
+      - :ansible-option-choices-entry:`"yum"`\ :
+        Alias to rpm
+
+      - :ansible-option-choices-entry:`"zypper"`\ :
+        Alias to rpm
+
+
+
+      .. rst-class:: ansible-option-line
+
+      :ansible-option-default-bold:`Default:` :ansible-option-default:`["auto"]`
+
+      .. raw:: html
+
+        </div>
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="parameter-subfoo"></div>
 
       .. _ansible_collections.ns2.col.foo_module__parameter-subfoo:

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_module.rst
@@ -172,6 +172,103 @@ Parameters
   * - .. raw:: html
 
         <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-manager"></div>
+
+      .. _ansible_collections.ns2.col.foo_module__parameter-manager:
+
+      .. rst-class:: ansible-option-title
+
+      **manager**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-manager" title="Permalink to this option"></a>
+
+      .. ansible-option-type-line::
+
+        :ansible-option-type:`list` / :ansible-option-elements:`elements=string`
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      The package manager(s) used by the system so we can query the package information. This is a list and can support multiple package managers per system, since version 2.8.
+
+      The 'portage' and 'pkg' options were added in version 2.8.
+
+      The 'apk' option was added in version 2.11.
+
+      The 'pkg\_info' option was added in version 2.13.
+
+      Aliases were added in 2.18, to support using \ :literal:`auto={{ansible\_facts['pkg\_mgr']}}`\ 
+
+
+      .. rst-class:: ansible-option-line
+
+      :ansible-option-choices:`Choices:`
+
+      - :ansible-option-choices-entry:`"apk"`\ :
+        Alpine Linux package manager
+
+      - :ansible-option-choices-entry:`"apt"`\ :
+        For DEB based distros, \ :literal:`python-apt`\  package must be installed on targeted hosts
+
+      - :ansible-option-choices-entry-default:`"auto"` :ansible-option-choices-default-mark:`(default)`\ :
+        Depending on \ :ansopt:`strategy`\ , will match the first or all package managers provided, in order
+
+      - :ansible-option-choices-entry:`"dnf"`\ :
+        Alias to rpm
+
+      - :ansible-option-choices-entry:`"dnf5"`\ :
+        Alias to rpm
+
+      - :ansible-option-choices-entry:`"openbsd\_pkg"`\ :
+        Alias to pkg\_info
+
+      - :ansible-option-choices-entry:`"pacman"`\ :
+        Archlinux package manager/builder
+
+      - :ansible-option-choices-entry:`"pkg"`\ :
+        libpkg front end (FreeBSD)
+
+      - :ansible-option-choices-entry:`"pkg5"`\ :
+        Alias to pkg
+
+      - :ansible-option-choices-entry:`"pkg\_info"`\ :
+        OpenBSD package manager
+
+      - :ansible-option-choices-entry:`"pkgng"`\ :
+        Alias to pkg
+
+      - :ansible-option-choices-entry:`"portage"`\ :
+        Handles ebuild packages, it requires the \ :literal:`qlist`\  utility, which is part of 'app-portage/portage-utils'
+
+      - :ansible-option-choices-entry:`"rpm"`\ :
+        For RPM based distros, requires RPM Python bindings, not installed by default on Suse (python3-rpm)
+
+      - :ansible-option-choices-entry:`"yum"`\ :
+        Alias to rpm
+
+      - :ansible-option-choices-entry:`"zypper"`\ :
+        Alias to rpm
+
+
+
+      .. rst-class:: ansible-option-line
+
+      :ansible-option-default-bold:`Default:` :ansible-option-default:`["auto"]`
+
+      .. raw:: html
+
+        </div>
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="parameter-subfoo"></div>
 
       .. _ansible_collections.ns2.col.foo_module__parameter-subfoo:

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_module.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_module.rst
@@ -92,6 +92,89 @@ Parameters
   </tr>
   <tr>
     <td colspan="2" valign="top">
+      <div class="ansibleOptionAnchor" id="parameter-manager"></div>
+      <p style="display: inline;"><strong>manager</strong></p>
+      <a class="ansibleOptionLink" href="#parameter-manager" title="Permalink to this option"></a>
+      <p style="font-size: small; margin-bottom: 0;">
+        <span style="color: purple;">list</span>
+        / <span style="color: purple;">elements=string</span>
+      </p>
+    </td>
+    <td valign="top">
+      <p>The package manager(s) used by the system so we can query the package information. This is a list and can support multiple package managers per system, since version 2.8.</p>
+      <p>The &#x27;portage&#x27; and &#x27;pkg&#x27; options were added in version 2.8.</p>
+      <p>The &#x27;apk&#x27; option was added in version 2.11.</p>
+      <p>The &#x27;pkg_info&#x27; option was added in version 2.13.</p>
+      <p>Aliases were added in 2.18, to support using <code class='docutils literal notranslate'>auto={{ansible_facts[&#x27;pkg_mgr&#x27;]}}</code></p>
+      <p style="margin-top: 8px;"><b">Choices:</b></p>
+      <ul>
+        <li>
+          <p><code>&#34;apk&#34;</code>:
+          Alpine Linux package manager</p>
+        </li>
+        <li>
+          <p><code>&#34;apt&#34;</code>:
+          For DEB based distros, <code class='docutils literal notranslate'>python-apt</code> package must be installed on targeted hosts</p>
+        </li>
+        <li>
+          <p><code style="color: blue;"><b>&#34;auto&#34;</b></code> <span style="color: blue;">(default)</span>:
+          Depending on <code class="ansible-option literal notranslate"><strong>strategy</strong></code>, will match the first or all package managers provided, in order</p>
+        </li>
+        <li>
+          <p><code>&#34;dnf&#34;</code>:
+          Alias to rpm</p>
+        </li>
+        <li>
+          <p><code>&#34;dnf5&#34;</code>:
+          Alias to rpm</p>
+        </li>
+        <li>
+          <p><code>&#34;openbsd_pkg&#34;</code>:
+          Alias to pkg_info</p>
+        </li>
+        <li>
+          <p><code>&#34;pacman&#34;</code>:
+          Archlinux package manager/builder</p>
+        </li>
+        <li>
+          <p><code>&#34;pkg&#34;</code>:
+          libpkg front end (FreeBSD)</p>
+        </li>
+        <li>
+          <p><code>&#34;pkg5&#34;</code>:
+          Alias to pkg</p>
+        </li>
+        <li>
+          <p><code>&#34;pkg_info&#34;</code>:
+          OpenBSD package manager</p>
+        </li>
+        <li>
+          <p><code>&#34;pkgng&#34;</code>:
+          Alias to pkg</p>
+        </li>
+        <li>
+          <p><code>&#34;portage&#34;</code>:
+          Handles ebuild packages, it requires the <code class='docutils literal notranslate'>qlist</code> utility, which is part of &#x27;app-portage/portage-utils&#x27;</p>
+        </li>
+        <li>
+          <p><code>&#34;rpm&#34;</code>:
+          For RPM based distros, requires RPM Python bindings, not installed by default on Suse (python3-rpm)</p>
+        </li>
+        <li>
+          <p><code>&#34;yum&#34;</code>:
+          Alias to rpm</p>
+        </li>
+        <li>
+          <p><code>&#34;zypper&#34;</code>:
+          Alias to rpm</p>
+        </li>
+      </ul>
+
+      <p style="margin-top: 8px;"><b style="color: blue;">Default:</b> <code style="color: blue;">[&#34;auto&#34;]</code></p>
+    </td>
+  </tr>
+  <tr>
+    <td colspan="2" valign="top">
       <div class="ansibleOptionAnchor" id="parameter-subfoo"></div>
       <p style="display: inline;"><strong>subfoo</strong></p>
       <a class="ansibleOptionLink" href="#parameter-subfoo" title="Permalink to this option"></a>

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_module.rst
@@ -92,6 +92,89 @@ Parameters
   </tr>
   <tr>
     <td colspan="2" valign="top">
+      <div class="ansibleOptionAnchor" id="parameter-manager"></div>
+      <p style="display: inline;"><strong>manager</strong></p>
+      <a class="ansibleOptionLink" href="#parameter-manager" title="Permalink to this option"></a>
+      <p style="font-size: small; margin-bottom: 0;">
+        <span style="color: purple;">list</span>
+        / <span style="color: purple;">elements=string</span>
+      </p>
+    </td>
+    <td valign="top">
+      <p>The package manager(s) used by the system so we can query the package information. This is a list and can support multiple package managers per system, since version 2.8.</p>
+      <p>The &#x27;portage&#x27; and &#x27;pkg&#x27; options were added in version 2.8.</p>
+      <p>The &#x27;apk&#x27; option was added in version 2.11.</p>
+      <p>The &#x27;pkg_info&#x27; option was added in version 2.13.</p>
+      <p>Aliases were added in 2.18, to support using <code class='docutils literal notranslate'>auto={{ansible_facts[&#x27;pkg_mgr&#x27;]}}</code></p>
+      <p style="margin-top: 8px;"><b">Choices:</b></p>
+      <ul>
+        <li>
+          <p><code>&#34;apk&#34;</code>:
+          Alpine Linux package manager</p>
+        </li>
+        <li>
+          <p><code>&#34;apt&#34;</code>:
+          For DEB based distros, <code class='docutils literal notranslate'>python-apt</code> package must be installed on targeted hosts</p>
+        </li>
+        <li>
+          <p><code style="color: blue;"><b>&#34;auto&#34;</b></code> <span style="color: blue;">(default)</span>:
+          Depending on <code class="ansible-option literal notranslate"><strong>strategy</strong></code>, will match the first or all package managers provided, in order</p>
+        </li>
+        <li>
+          <p><code>&#34;dnf&#34;</code>:
+          Alias to rpm</p>
+        </li>
+        <li>
+          <p><code>&#34;dnf5&#34;</code>:
+          Alias to rpm</p>
+        </li>
+        <li>
+          <p><code>&#34;openbsd_pkg&#34;</code>:
+          Alias to pkg_info</p>
+        </li>
+        <li>
+          <p><code>&#34;pacman&#34;</code>:
+          Archlinux package manager/builder</p>
+        </li>
+        <li>
+          <p><code>&#34;pkg&#34;</code>:
+          libpkg front end (FreeBSD)</p>
+        </li>
+        <li>
+          <p><code>&#34;pkg5&#34;</code>:
+          Alias to pkg</p>
+        </li>
+        <li>
+          <p><code>&#34;pkg_info&#34;</code>:
+          OpenBSD package manager</p>
+        </li>
+        <li>
+          <p><code>&#34;pkgng&#34;</code>:
+          Alias to pkg</p>
+        </li>
+        <li>
+          <p><code>&#34;portage&#34;</code>:
+          Handles ebuild packages, it requires the <code class='docutils literal notranslate'>qlist</code> utility, which is part of &#x27;app-portage/portage-utils&#x27;</p>
+        </li>
+        <li>
+          <p><code>&#34;rpm&#34;</code>:
+          For RPM based distros, requires RPM Python bindings, not installed by default on Suse (python3-rpm)</p>
+        </li>
+        <li>
+          <p><code>&#34;yum&#34;</code>:
+          Alias to rpm</p>
+        </li>
+        <li>
+          <p><code>&#34;zypper&#34;</code>:
+          Alias to rpm</p>
+        </li>
+      </ul>
+
+      <p style="margin-top: 8px;"><b style="color: blue;">Default:</b> <code style="color: blue;">[&#34;auto&#34;]</code></p>
+    </td>
+  </tr>
+  <tr>
+    <td colspan="2" valign="top">
       <div class="ansibleOptionAnchor" id="parameter-subfoo"></div>
       <p style="display: inline;"><strong>subfoo</strong></p>
       <a class="ansibleOptionLink" href="#parameter-subfoo" title="Permalink to this option"></a>

--- a/tests/functional/baseline-squash-hierarchy/foo_module.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_module.rst
@@ -172,6 +172,103 @@ Parameters
   * - .. raw:: html
 
         <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-manager"></div>
+
+      .. _ansible_collections.ns2.col.foo_module__parameter-manager:
+
+      .. rst-class:: ansible-option-title
+
+      **manager**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-manager" title="Permalink to this option"></a>
+
+      .. ansible-option-type-line::
+
+        :ansible-option-type:`list` / :ansible-option-elements:`elements=string`
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      The package manager(s) used by the system so we can query the package information. This is a list and can support multiple package managers per system, since version 2.8.
+
+      The 'portage' and 'pkg' options were added in version 2.8.
+
+      The 'apk' option was added in version 2.11.
+
+      The 'pkg\_info' option was added in version 2.13.
+
+      Aliases were added in 2.18, to support using \ :literal:`auto={{ansible\_facts['pkg\_mgr']}}`\ 
+
+
+      .. rst-class:: ansible-option-line
+
+      :ansible-option-choices:`Choices:`
+
+      - :ansible-option-choices-entry:`"apk"`\ :
+        Alpine Linux package manager
+
+      - :ansible-option-choices-entry:`"apt"`\ :
+        For DEB based distros, \ :literal:`python-apt`\  package must be installed on targeted hosts
+
+      - :ansible-option-choices-entry-default:`"auto"` :ansible-option-choices-default-mark:`(default)`\ :
+        Depending on \ :ansopt:`strategy`\ , will match the first or all package managers provided, in order
+
+      - :ansible-option-choices-entry:`"dnf"`\ :
+        Alias to rpm
+
+      - :ansible-option-choices-entry:`"dnf5"`\ :
+        Alias to rpm
+
+      - :ansible-option-choices-entry:`"openbsd\_pkg"`\ :
+        Alias to pkg\_info
+
+      - :ansible-option-choices-entry:`"pacman"`\ :
+        Archlinux package manager/builder
+
+      - :ansible-option-choices-entry:`"pkg"`\ :
+        libpkg front end (FreeBSD)
+
+      - :ansible-option-choices-entry:`"pkg5"`\ :
+        Alias to pkg
+
+      - :ansible-option-choices-entry:`"pkg\_info"`\ :
+        OpenBSD package manager
+
+      - :ansible-option-choices-entry:`"pkgng"`\ :
+        Alias to pkg
+
+      - :ansible-option-choices-entry:`"portage"`\ :
+        Handles ebuild packages, it requires the \ :literal:`qlist`\  utility, which is part of 'app-portage/portage-utils'
+
+      - :ansible-option-choices-entry:`"rpm"`\ :
+        For RPM based distros, requires RPM Python bindings, not installed by default on Suse (python3-rpm)
+
+      - :ansible-option-choices-entry:`"yum"`\ :
+        Alias to rpm
+
+      - :ansible-option-choices-entry:`"zypper"`\ :
+        Alias to rpm
+
+
+
+      .. rst-class:: ansible-option-line
+
+      :ansible-option-default-bold:`Default:` :ansible-option-default:`["auto"]`
+
+      .. raw:: html
+
+        </div>
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
         <div class="ansibleOptionAnchor" id="parameter-subfoo"></div>
 
       .. _ansible_collections.ns2.col.foo_module__parameter-subfoo:

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_module.rst
@@ -126,6 +126,89 @@ Parameters
   </tr>
   <tr class="row-even">
     <td><div class="ansible-option-cell">
+      <div class="ansibleOptionAnchor" id="parameter-manager"></div>
+      <p class="ansible-option-title"><strong>manager</strong></p>
+      <a class="ansibleOptionLink" href="#parameter-manager" title="Permalink to this option"></a>
+      <p class="ansible-option-type-line">
+        <span class="ansible-option-type">list</span>
+        / <span class="ansible-option-elements">elements=string</span>
+      </p>
+    </div></td>
+    <td><div class="ansible-option-cell">
+      <p>The package manager(s) used by the system so we can query the package information. This is a list and can support multiple package managers per system, since version 2.8.</p>
+      <p>The &#x27;portage&#x27; and &#x27;pkg&#x27; options were added in version 2.8.</p>
+      <p>The &#x27;apk&#x27; option was added in version 2.11.</p>
+      <p>The &#x27;pkg_info&#x27; option was added in version 2.13.</p>
+      <p>Aliases were added in 2.18, to support using <code class='docutils literal notranslate'>auto={{ansible_facts[&#x27;pkg_mgr&#x27;]}}</code></p>
+      <p class="ansible-option-line"><strong class="ansible-option-choices">Choices:</strong></p>
+      <ul class="simple">
+        <li>
+          <p><code class="ansible-value literal notranslate ansible-option-choices-entry">&#34;apk&#34;</code>:
+          Alpine Linux package manager</p>
+        </li>
+        <li>
+          <p><code class="ansible-value literal notranslate ansible-option-choices-entry">&#34;apt&#34;</code>:
+          For DEB based distros, <code class='docutils literal notranslate'>python-apt</code> package must be installed on targeted hosts</p>
+        </li>
+        <li>
+          <p><code class="ansible-value literal notranslate ansible-option-default-bold"><strong>&#34;auto&#34;</strong></code> <span class="ansible-option-choices-default-mark">(default)</span>:
+          Depending on <code class="ansible-option literal notranslate"><strong>strategy</strong></code>, will match the first or all package managers provided, in order</p>
+        </li>
+        <li>
+          <p><code class="ansible-value literal notranslate ansible-option-choices-entry">&#34;dnf&#34;</code>:
+          Alias to rpm</p>
+        </li>
+        <li>
+          <p><code class="ansible-value literal notranslate ansible-option-choices-entry">&#34;dnf5&#34;</code>:
+          Alias to rpm</p>
+        </li>
+        <li>
+          <p><code class="ansible-value literal notranslate ansible-option-choices-entry">&#34;openbsd_pkg&#34;</code>:
+          Alias to pkg_info</p>
+        </li>
+        <li>
+          <p><code class="ansible-value literal notranslate ansible-option-choices-entry">&#34;pacman&#34;</code>:
+          Archlinux package manager/builder</p>
+        </li>
+        <li>
+          <p><code class="ansible-value literal notranslate ansible-option-choices-entry">&#34;pkg&#34;</code>:
+          libpkg front end (FreeBSD)</p>
+        </li>
+        <li>
+          <p><code class="ansible-value literal notranslate ansible-option-choices-entry">&#34;pkg5&#34;</code>:
+          Alias to pkg</p>
+        </li>
+        <li>
+          <p><code class="ansible-value literal notranslate ansible-option-choices-entry">&#34;pkg_info&#34;</code>:
+          OpenBSD package manager</p>
+        </li>
+        <li>
+          <p><code class="ansible-value literal notranslate ansible-option-choices-entry">&#34;pkgng&#34;</code>:
+          Alias to pkg</p>
+        </li>
+        <li>
+          <p><code class="ansible-value literal notranslate ansible-option-choices-entry">&#34;portage&#34;</code>:
+          Handles ebuild packages, it requires the <code class='docutils literal notranslate'>qlist</code> utility, which is part of &#x27;app-portage/portage-utils&#x27;</p>
+        </li>
+        <li>
+          <p><code class="ansible-value literal notranslate ansible-option-choices-entry">&#34;rpm&#34;</code>:
+          For RPM based distros, requires RPM Python bindings, not installed by default on Suse (python3-rpm)</p>
+        </li>
+        <li>
+          <p><code class="ansible-value literal notranslate ansible-option-choices-entry">&#34;yum&#34;</code>:
+          Alias to rpm</p>
+        </li>
+        <li>
+          <p><code class="ansible-value literal notranslate ansible-option-choices-entry">&#34;zypper&#34;</code>:
+          Alias to rpm</p>
+        </li>
+      </ul>
+
+      <p class="ansible-option-line"><strong class="ansible-option-default-bold">Default:</strong> <code class="ansible-value literal notranslate ansible-option-default">[&#34;auto&#34;]</code></p>
+    </div></td>
+  </tr>
+  <tr class="row-odd">
+    <td><div class="ansible-option-cell">
       <div class="ansibleOptionAnchor" id="parameter-subfoo"></div>
       <p class="ansible-option-title"><strong>subfoo</strong></p>
       <a class="ansibleOptionLink" href="#parameter-subfoo" title="Permalink to this option"></a>
@@ -138,7 +221,7 @@ Parameters
       <p>Some recursive foo.</p>
     </div></td>
   </tr>
-  <tr class="row-odd">
+  <tr class="row-even">
     <td><div class="ansible-option-indent"></div><div class="ansible-option-cell">
       <div class="ansibleOptionAnchor" id="parameter-subfoo/foo"></div>
       <p class="ansible-option-title"><strong>foo</strong></p>

--- a/tests/functional/collections/ansible_collections/ns2/col/plugins/modules/foo.py
+++ b/tests/functional/collections/ansible_collections/ns2/col/plugins/modules/foo.py
@@ -47,6 +47,34 @@ options:
                 type: str
                 required: true
 
+    manager:
+        description:
+          - The package manager(s) used by the system so we can query the package information.
+            This is a list and can support multiple package managers per system, since version 2.8.
+          - The 'portage' and 'pkg' options were added in version 2.8.
+          - The 'apk' option was added in version 2.11.
+          - The 'pkg_info' option was added in version 2.13.
+          - Aliases were added in 2.18, to support using C(auto={{ansible_facts['pkg_mgr']}})
+        default: ['auto']
+        choices:
+            auto: Depending on O(strategy), will match the first or all package managers provided, in order
+            rpm: For RPM based distros, requires RPM Python bindings, not installed by default on Suse (python3-rpm)
+            yum: Alias to rpm
+            dnf: Alias to rpm
+            dnf5: Alias to rpm
+            zypper: Alias to rpm
+            apt: For DEB based distros, C(python-apt) package must be installed on targeted hosts
+            portage: Handles ebuild packages, it requires the C(qlist) utility, which is part of 'app-portage/portage-utils'
+            pkg: libpkg front end (FreeBSD)
+            pkg5: Alias to pkg
+            pkgng: Alias to pkg
+            pacman: Archlinux package manager/builder
+            apk: Alpine Linux package manager
+            pkg_info: OpenBSD package manager
+            openbsd_pkg: Alias to pkg_info
+        type: list
+        elements: str
+
 requirements:
     - Foo on remote.
 


### PR DESCRIPTION
Fixes https://github.com/ansible/ansible/issues/83204.

https://github.com/ansible/ansible/pull/83149/files#diff-fc025deb71887b0e6b0b3280f4dac62412a7e253db3417036dc9ce8d9a9f8e52R24 triggered three bugs in antsibull-docs:
1. If `choices` is a dictionary for `type=list`, it was treated as a single entry in the choices list for validation purposes (resulting in a validation error).
2. If `choices` is a dictionary for `type=list`, the normalized result was recombined incorrectly, resulting in a list with a single entry.
3. If `default` is present for `type=list` with `choices`, rendering fails with `TypeError: unhashable type: 'list'`. (This only happens after 1. is fixed.)
