### PR TITLE
Improve error handling/rendering

### DIFF
--- a/changelogs/fragments/289-fixes.yml
+++ b/changelogs/fragments/289-fixes.yml
@@ -1,3 +1,4 @@
 bugfixes:
   - "Render errors as code blocks of language ``text`` instead of using the default lexer (https://github.com/ansible-community/antsibull-docs/pull/289)."
   - "Improve rendering of empty or broken changelogs (https://github.com/ansible-community/antsibull-docs/pull/289)."
+  - "Remove leading spaces in paragraphs to avoid unintended RST blockquotes (https://github.com/ansible-community/antsibull-docs/pull/289)."

--- a/changelogs/fragments/289-fixes.yml
+++ b/changelogs/fragments/289-fixes.yml
@@ -1,2 +1,3 @@
 bugfixes:
   - "Render errors as code blocks of language ``text`` instead of using the default lexer (https://github.com/ansible-community/antsibull-docs/pull/289)."
+  - "Improve rendering of empty or broken changelogs (https://github.com/ansible-community/antsibull-docs/pull/289)."

--- a/changelogs/fragments/289-fixes.yml
+++ b/changelogs/fragments/289-fixes.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Render errors as code blocks of language ``text`` instead of using the default lexer (https://github.com/ansible-community/antsibull-docs/pull/289)."

--- a/src/antsibull_docs/data/docsite/ansible-docsite/list_of_env_variables.rst.j2
+++ b/src/antsibull_docs/data/docsite/ansible-docsite/list_of_env_variables.rst.j2
@@ -22,7 +22,7 @@ Environment variables used by the ansible-core configuration are documented in :
 .. envvar:: @{ env_var.name }@
 
 {%   for paragraph in env_var.description or [] %}
-    @{ paragraph | replace('\n', '\n    ') | rst_ify(plugin_fqcn='', plugin_type='') | indent(4) }@
+    @{ paragraph | replace('\n', '\n    ') | rst_ify(plugin_fqcn='', plugin_type='') | rst_indent(4) }@
 
 {%   endfor %}
     *Used by:*

--- a/src/antsibull_docs/data/docsite/ansible-docsite/macros/attributes.rst.j2
+++ b/src/antsibull_docs/data/docsite/ansible-docsite/macros/attributes.rst.j2
@@ -77,7 +77,7 @@
 {%   endif %}
 
 {%   for desc in data['details'] %}
-      @{ desc | rst_ify(role_entrypoint=role_entrypoint) | indent(6) }@
+      @{ desc | rst_ify(role_entrypoint=role_entrypoint) | rst_indent(6) }@
 
 {%   endfor %}
 
@@ -91,7 +91,7 @@
         <div class="ansible-option-cell">
 
 {% for desc in data['description'] %}
-      @{ desc | rst_ify(role_entrypoint=role_entrypoint) | indent(6) }@
+      @{ desc | rst_ify(role_entrypoint=role_entrypoint) | rst_indent(6) }@
 
 {%   endfor %}
 

--- a/src/antsibull_docs/data/docsite/ansible-docsite/macros/choiceslist.rst.j2
+++ b/src/antsibull_docs/data/docsite/ansible-docsite/macros/choiceslist.rst.j2
@@ -13,7 +13,7 @@
       - :ansible-option-choices-entry:`@{ choice | antsibull_to_json | rst_escape(escape_ending_whitespace=true) }@`\ :
 {%       endif %}
 {%       for par in desc %}
-        @{ par | rst_ify(role_entrypoint=role_entrypoint) | indent(8) }@
+        @{ par | rst_ify(role_entrypoint=role_entrypoint) | rst_indent(8) }@
 
 {%       endfor %}
 {%     endfor %}
@@ -39,9 +39,9 @@
 {%       else %}
           <p><code class="ansible-value literal notranslate ansible-option-choices-entry">@{ choice | antsibull_to_json | escape }@</code>:
 {%       endif %}
-          @{ desc | first | default('') | html_ify(role_entrypoint=role_entrypoint) | indent(10, blank=true) }@</p>
+          @{ desc | first | default('') | html_ify(role_entrypoint=role_entrypoint) | rst_indent(10, blank=true) }@</p>
 {%       for line in desc[1:] %}
-          <p>@{ line | html_ify(role_entrypoint=role_entrypoint) | indent(10, blank=true) }@</p>
+          <p>@{ line | html_ify(role_entrypoint=role_entrypoint) | rst_indent(10, blank=true) }@</p>
 {%       endfor %}
         </li>
 {%     endfor %}

--- a/src/antsibull_docs/data/docsite/ansible-docsite/macros/deprecates.rst.j2
+++ b/src/antsibull_docs/data/docsite/ansible-docsite/macros/deprecates.rst.j2
@@ -20,9 +20,9 @@ Removed in: a future release
 {%     endif %}
 
 
-@{ ('Why: ' ~ data['why'] | rst_ify(role_entrypoint=role_entrypoint)) | indent(indent, first=true) }@
+@{ ('Why: ' ~ data['why'] | rst_ify(role_entrypoint=role_entrypoint)) | rst_indent(indent, first=true) }@
 
-@{ ('Alternative: ' ~ data['alternative'] | rst_ify(role_entrypoint=role_entrypoint)) | indent(indent, first=true) }@
+@{ ('Alternative: ' ~ data['alternative'] | rst_ify(role_entrypoint=role_entrypoint)) | rst_indent(indent, first=true) }@
 
 {%   endif %}
 {% endmacro %}
@@ -42,7 +42,7 @@ Removed in: a future release
  of @{ data['removed_from_collection'] | html_ify(role_entrypoint=role_entrypoint) }@
 {%-    endif -%}
   </p>
-  <p>@{ 'Why: ' ~ data['why'] | html_ify(role_entrypoint=role_entrypoint) | indent(2, blank=true) }@</p>
-  <p>@{ 'Alternative: ' ~ data['alternative'] | html_ify(role_entrypoint=role_entrypoint) | indent(2, blank=true) }@</p>
+  <p>@{ 'Why: ' ~ data['why'] | html_ify(role_entrypoint=role_entrypoint) | rst_indent(2, blank=true) }@</p>
+  <p>@{ 'Alternative: ' ~ data['alternative'] | html_ify(role_entrypoint=role_entrypoint) | rst_indent(2, blank=true) }@</p>
 {%   endif %}
 {% endmacro %}

--- a/src/antsibull_docs/data/docsite/ansible-docsite/macros/parameters.rst.j2
+++ b/src/antsibull_docs/data/docsite/ansible-docsite/macros/parameters.rst.j2
@@ -86,7 +86,7 @@
         {% for i in range(1, loop.depth) %}<div class="ansible-option-indent-desc"></div>{% endfor %}<div class="ansible-option-cell">
 
 {%   for desc in value['description'] %}
-      @{ desc | replace('\n', '\n    ') | rst_ify(role_entrypoint=role_entrypoint) | indent(6) }@
+      @{ desc | replace('\n', '\n    ') | rst_ify(role_entrypoint=role_entrypoint) | rst_indent(6) }@
 
 {%   endfor %}
 {#   default / choices #}
@@ -107,7 +107,7 @@
 
       .. rst-class:: ansible-option-line
 
-      :ansible-option-default-bold:`Default:` :ansible-option-default:`@{ value['default'] | antsibull_to_json | rst_escape(escape_ending_whitespace=true) | indent(6, blank=true) }@`
+      :ansible-option-default-bold:`Default:` :ansible-option-default:`@{ value['default'] | antsibull_to_json | rst_escape(escape_ending_whitespace=true) | rst_indent(6, blank=true) }@`
 {%   endif %}
 {#   Configuration #}
 {%   if plugin_type != 'module' and plugin_type != 'role' and (value['ini'] or value['env'] or value['vars'] or value['cli']) %}
@@ -126,7 +126,7 @@
 {%        if value['default'] is none %}
           @{ ini['key'] }@ = VALUE
 {%        else %}
-          @{ ini['key'] }@ = @{ value['default'] | antsibull_to_ini_value | indent(10, blank=true) }@
+          @{ ini['key'] }@ = @{ value['default'] | antsibull_to_ini_value | rst_indent(10, blank=true) }@
 {%        endif %}
 
 {%         if ini['version_added'] is still_relevant(collection=ini['version_added_collection'] or collection) %}
@@ -223,7 +223,7 @@
 {#   description #}
     <td>{% for i in range(1, loop.depth) %}<div class="ansible-option-indent-desc"></div>{% endfor %}<div class="ansible-option-cell">
 {%   for desc in value['description'] %}
-      <p>@{ desc | html_ify(role_entrypoint=role_entrypoint) | indent(6, blank=true) }@</p>
+      <p>@{ desc | html_ify(role_entrypoint=role_entrypoint) | rst_indent(6, blank=true) }@</p>
 {%   endfor %}
 {#   default / choices #}
 {%   if value['type'] == 'bool' %}
@@ -236,7 +236,7 @@
 {%   endif %}
 {#   Show default value, when multiple choice or no choices #}
 {%   if value['default'] is list or (value['default'] is not none and value['default'] not in value['choices']) %}
-      <p class="ansible-option-line"><strong class="ansible-option-default-bold">Default:</strong> <code class="ansible-value literal notranslate ansible-option-default">@{ value['default'] | antsibull_to_json | escape | indent(6, blank=true) }@</code></p>
+      <p class="ansible-option-line"><strong class="ansible-option-default-bold">Default:</strong> <code class="ansible-value literal notranslate ansible-option-default">@{ value['default'] | antsibull_to_json | escape | rst_indent(6, blank=true) }@</code></p>
 {%   endif %}
 {#   Configuration #}
 {%   if plugin_type != 'module' and plugin_type != 'role' and (value['ini'] or value['env'] or value['vars'] or value['cli']) %}

--- a/src/antsibull_docs/data/docsite/ansible-docsite/macros/returnvalues.rst.j2
+++ b/src/antsibull_docs/data/docsite/ansible-docsite/macros/returnvalues.rst.j2
@@ -74,14 +74,14 @@
         {% for i in range(1, loop.depth) %}<div class="ansible-option-indent-desc"></div>{% endfor %}<div class="ansible-option-cell">
 
 {%   for desc in value['description'] %}
-      @{ desc | rst_ify(role_entrypoint=role_entrypoint) | indent(6) }@
+      @{ desc | rst_ify(role_entrypoint=role_entrypoint) | rst_indent(6) }@
 
 {%   endfor %}
 {%   if value['returned'] %}
 
       .. rst-class:: ansible-option-line
 
-      :ansible-option-returned-bold:`Returned:` @{ value['returned'] | rst_ify(role_entrypoint=role_entrypoint) | indent(6) }@
+      :ansible-option-returned-bold:`Returned:` @{ value['returned'] | rst_ify(role_entrypoint=role_entrypoint) | rst_indent(6) }@
 {%   endif %}
 {#   Show possible choices and highlight details #}
 {%   if value['choices'] %}
@@ -97,7 +97,7 @@
       .. rst-class:: ansible-option-line
       .. rst-class:: ansible-option-sample
 
-      :ansible-option-sample-bold:`Sample:` :ansible-rv-sample-value:`@{ value['sample'] | antsibull_to_json | rst_escape(escape_ending_whitespace=true) | indent(6, blank=true) }@`
+      :ansible-option-sample-bold:`Sample:` :ansible-rv-sample-value:`@{ value['sample'] | antsibull_to_json | rst_escape(escape_ending_whitespace=true) | rst_indent(6, blank=true) }@`
 {%   endif %}
 
 
@@ -147,10 +147,10 @@
 {#   description #}
     <td>{% for i in range(1, loop.depth) %}<div class="ansible-option-indent-desc"></div>{% endfor %}<div class="ansible-option-cell">
 {%   for desc in value['description'] %}
-      <p>@{ desc | html_ify(role_entrypoint=role_entrypoint) | indent(6, blank=true) }@</p>
+      <p>@{ desc | html_ify(role_entrypoint=role_entrypoint) | rst_indent(6, blank=true) }@</p>
 {%   endfor %}
 {%   if value['returned'] %}
-      <p class="ansible-option-line"><strong class="ansible-option-returned-bold">Returned:</strong> @{ value['returned'] | html_ify(role_entrypoint=role_entrypoint) | indent(6, blank=true) }@</p>
+      <p class="ansible-option-line"><strong class="ansible-option-returned-bold">Returned:</strong> @{ value['returned'] | html_ify(role_entrypoint=role_entrypoint) | rst_indent(6, blank=true) }@</p>
 {%   endif %}
 {#   Show possible choices and highlight details #}
 {%   if value['choices'] %}
@@ -158,7 +158,7 @@
 @{     choices_html(value['choices'], has_no_default=True, role_entrypoint=role_entrypoint) }@
 {%   endif %}
 {%   if value['sample'] is not none %}
-      <p class="ansible-option-line ansible-option-sample"><strong class="ansible-option-sample-bold">Sample:</strong> <code class="ansible-value literal notranslate ansible-option-sample">@{ value['sample'] | antsibull_to_json | escape | indent(6, blank=true) }@</code></p>
+      <p class="ansible-option-line ansible-option-sample"><strong class="ansible-option-sample-bold">Sample:</strong> <code class="ansible-value literal notranslate ansible-option-sample">@{ value['sample'] | antsibull_to_json | escape | rst_indent(6, blank=true) }@</code></p>
 {%   endif %}
     </div></td>
   </tr>

--- a/src/antsibull_docs/data/docsite/ansible-docsite/plugin-error.rst.j2
+++ b/src/antsibull_docs/data/docsite/ansible-docsite/plugin-error.rst.j2
@@ -33,7 +33,7 @@ The documentation for the @{ plugin_type }@ plugin, @{ plugin_name }@,  was malf
 The errors were:
 
 {% for error in nonfatal_errors %}
-* ::
+* .. code-block:: text
 
 @{   error | indent(width=8, first=True) }@
 

--- a/src/antsibull_docs/data/docsite/ansible-docsite/plugin.rst.j2
+++ b/src/antsibull_docs/data/docsite/ansible-docsite/plugin.rst.j2
@@ -450,7 +450,7 @@ There were some errors parsing the documentation for this plugin.  Please file a
 The errors were:
 
 {%   for error in nonfatal_errors %}
-* ::
+* .. code-block:: text
 
 @{     error | indent(width=8, first=True) }@
 

--- a/src/antsibull_docs/data/docsite/ansible-docsite/plugin.rst.j2
+++ b/src/antsibull_docs/data/docsite/ansible-docsite/plugin.rst.j2
@@ -109,8 +109,8 @@ DEPRECATED
 {% if doc['deprecated']['removed_from_collection'] and doc['deprecated']['removed_from_collection'] != collection %}
              of @{ doc['deprecated']['removed_from_collection'] | rst_ify }@
 {% endif %}
-:Why: @{ doc['deprecated']['why'] | rst_ify | indent(6) }@
-:Alternative: @{ doc['deprecated']['alternative'] | rst_ify | indent(14) }@
+:Why: @{ doc['deprecated']['why'] | rst_ify | rst_indent(6) }@
+:Alternative: @{ doc['deprecated']['alternative'] | rst_ify | rst_indent(14) }@
 {% endif %}
 
 {% if plugin_type == 'callback' %}
@@ -133,7 +133,7 @@ Synopsis
 .. Description
 
 {%   for desc in doc['description'] -%}
-- @{ desc | rst_ify | indent(width=2) }@
+- @{ desc | rst_ify | rst_indent(width=2) }@
 {%   endfor %}
 
 {% if doc['has_action'] %}
@@ -161,7 +161,7 @@ The below requirements are needed on the local controller node that executes thi
 {%   endif %}
 
 {%   for req in doc['requirements'] %}
-- @{ req | rst_ify | indent(width=2) }@
+- @{ req | rst_ify | rst_indent(width=2) }@
 {%   endfor %}
 
 {% endif %}
@@ -289,7 +289,7 @@ Notes
 {%   endif %}
 {%   if doc['notes'] %}
 {%     for note in doc['notes'] %}
-   - @{ note | rst_ify | indent(width=5) }@
+   - @{ note | rst_ify | rst_indent(width=5) }@
 {%     endfor %}
 {%   endif %}
 {% endif %}
@@ -305,22 +305,22 @@ See Also
 {% for item in doc['seealso'] %}
 {%   if item.module is defined and item.description %}
    @{ reference_plugin_rst(item['module'], 'module') }@
-       @{ item['description'] | rst_ify | indent(7) }@
+       @{ item['description'] | rst_ify | rst_indent(7) }@
 {%   elif item.module is defined %}
    @{ reference_plugin_rst(item['module'], 'module') }@
        The official documentation on the **@{ item['module'] }@** module.
 {%   elif item.plugin is defined and item.plugin_type is defined and item.description %}
    @{ reference_plugin_rst(item['plugin'], item['plugin_type']) }@ @{ item['plugin_type'] }@ plugin
-       @{ item['description'] | rst_ify | indent(7) }@
+       @{ item['description'] | rst_ify | rst_indent(7) }@
 {%   elif item.plugin is defined and item.plugin_type is defined %}
    @{ reference_plugin_rst(item['plugin'], item['plugin_type']) }@ @{ item['plugin_type'] }@ plugin
        The official documentation on the **@{ item['plugin'] }@** @{ item['plugin_type'] }@ plugin.
 {%   elif item.name is defined and item.link is defined and item.description %}
    `@{ item['name'] }@ <@{ item['link'] }@>`_
-       @{ item['description'] | rst_ify | indent(7) }@
+       @{ item['description'] | rst_ify | rst_indent(7) }@
 {%   elif item.ref is defined and item.description %}
    :ref:`@{ item['ref'] }@`
-       @{ item['description'] | rst_ify | indent(7) }@
+       @{ item['description'] | rst_ify | rst_indent(7) }@
 {%   endif %}
 {% endfor %}
 {% endif %}

--- a/src/antsibull_docs/data/docsite/ansible-docsite/plugins_by_collection.rst.j2
+++ b/src/antsibull_docs/data/docsite/ansible-docsite/plugins_by_collection.rst.j2
@@ -15,7 +15,7 @@
 
 {% macro list_plugins(plugin_type) %}
 {%   for name, desc in plugin_maps[plugin_type].items() | sort %}
-* :ansplugin:`@{ name }@ @{ plugin_type }@ <@{ collection_name }@.@{ name }@#@{ plugin_type }@>` -- @{ desc | rst_ify(plugin_fqcn=collection_name ~ '.' ~ name, plugin_type=plugin_type) | indent(width=2) }@
+* :ansplugin:`@{ name }@ @{ plugin_type }@ <@{ collection_name }@.@{ name }@#@{ plugin_type }@>` -- @{ desc | rst_ify(plugin_fqcn=collection_name ~ '.' ~ name, plugin_type=plugin_type) | rst_indent(width=2) }@
 {%   endfor %}
 {%   if breadcrumbs %}
 
@@ -54,7 +54,7 @@ Description
 **Author@{ 's' if (collection_authors | length) > 1 else '' }@:**
 
 {%     for author in collection_authors %}
-* @{ author | indent(2) }@
+* @{ author | rst_indent(2) }@
 {%     endfor %}
 {%   endif %}
 

--- a/src/antsibull_docs/data/docsite/ansible-docsite/role.rst.j2
+++ b/src/antsibull_docs/data/docsite/ansible-docsite/role.rst.j2
@@ -228,7 +228,7 @@ There were some errors parsing the documentation for this role.  Please file a b
 The errors were:
 
 {% for error in nonfatal_errors %}
-* ::
+* .. code-block:: text
 
 @{ error | indent(width=8, first=True) }@
 

--- a/src/antsibull_docs/data/docsite/ansible-docsite/role.rst.j2
+++ b/src/antsibull_docs/data/docsite/ansible-docsite/role.rst.j2
@@ -96,8 +96,8 @@ DEPRECATED
 {%     else %}
 :Removed in: a future release
 {%     endif %}
-:Why: @{ ep_doc['deprecated']['why'] | rst_ify(role_entrypoint=entry_point) | indent(6) }@
-:Alternative: @{ ep_doc['deprecated']['alternative'] | rst_ify(role_entrypoint=entry_point) | indent(14) }@
+:Why: @{ ep_doc['deprecated']['why'] | rst_ify(role_entrypoint=entry_point) | rst_indent(6) }@
+:Alternative: @{ ep_doc['deprecated']['alternative'] | rst_ify(role_entrypoint=entry_point) | rst_indent(14) }@
 {%   endif %}
 
 Synopsis
@@ -106,7 +106,7 @@ Synopsis
 .. Description
 
 {%   for desc in ep_doc['description'] -%}
-- @{ desc | rst_ify(role_entrypoint=entry_point) | indent(width=2) }@
+- @{ desc | rst_ify(role_entrypoint=entry_point) | rst_indent(width=2) }@
 {%   endfor %}
 
 .. Requirements
@@ -117,7 +117,7 @@ Requirements
 The below requirements are needed on the remote host and/or the local controller node.
 
 {%     for req in ep_doc['requirements'] %}
-- @{ req | rst_ify(role_entrypoint=entry_point) | indent(width=2) }@
+- @{ req | rst_ify(role_entrypoint=entry_point) | rst_indent(width=2) }@
 {%     endfor %}
 
 {%   endif %}
@@ -154,7 +154,7 @@ Notes
 
 .. note::
 {%     for note in ep_doc['notes'] %}
-   - @{ note | rst_ify(role_entrypoint=entry_point) | indent(width=5) }@
+   - @{ note | rst_ify(role_entrypoint=entry_point) | rst_indent(width=5) }@
 {%     endfor %}
 {%   endif %}
 
@@ -169,22 +169,22 @@ See Also
 {%     for item in ep_doc['seealso'] %}
 {%       if item.module is defined and item.description %}
    @{ reference_plugin_rst(item['module'], 'module') }@
-       @{ item['description'] | rst_ify(role_entrypoint=entry_point) | indent(7) }@
+       @{ item['description'] | rst_ify(role_entrypoint=entry_point) | rst_indent(7) }@
 {%       elif item.module is defined %}
    @{ reference_plugin_rst(item['module'], 'module') }@
        The official documentation on the **@{ item['module'] }@** module.
 {%       elif item.plugin is defined and item.plugin_type is defined and item.description %}
    @{ reference_plugin_rst(item['plugin'], item['plugin_type']) }@ @{ item['plugin_type'] }@ plugin
-       @{ item['description'] | rst_ify(role_entrypoint=entry_point) | indent(7) }@
+       @{ item['description'] | rst_ify(role_entrypoint=entry_point) | rst_indent(7) }@
 {%       elif item.plugin is defined and item.plugin_type is defined %}
    @{ reference_plugin_rst(item['plugin'], item['plugin_type']) }@ @{ item['plugin_type'] }@ plugin
        The official documentation on the **@{ item['plugin'] }@** @{ item['plugin_type'] }@ plugin.
 {%       elif item.name is defined and item.link is defined and item.description %}
    `@{ item['name'] }@ <@{ item['link'] }@>`_
-       @{ item['description'] | rst_ify(role_entrypoint=entry_point) | indent(7) }@
+       @{ item['description'] | rst_ify(role_entrypoint=entry_point) | rst_indent(7) }@
 {%       elif item.ref is defined and item.description %}
    :ref:`@{ item['ref'] }@`
-       @{ item['description'] | rst_ify(role_entrypoint=entry_point) | indent(7) }@
+       @{ item['description'] | rst_ify(role_entrypoint=entry_point) | rst_indent(7) }@
 {%       endif %}
 {%     endfor %}
 {%   endif %}

--- a/src/antsibull_docs/data/docsite/simplified-rst/macros/attributes.rst.j2
+++ b/src/antsibull_docs/data/docsite/simplified-rst/macros/attributes.rst.j2
@@ -44,14 +44,14 @@
 {%   endif %}
 
 {%   for desc in data['details'] %}
-      @{ desc | rst_ify(role_entrypoint=role_entrypoint) | indent(6) }@
+      @{ desc | rst_ify(role_entrypoint=role_entrypoint) | rst_indent(6) }@
 
 {%   endfor %}
 
 {#   description #}
     - 
 {% for desc in data['description'] %}
-      @{ desc | rst_ify(role_entrypoint=role_entrypoint) | indent(6) }@
+      @{ desc | rst_ify(role_entrypoint=role_entrypoint) | rst_indent(6) }@
 
 {%   endfor %}
 

--- a/src/antsibull_docs/data/docsite/simplified-rst/macros/choiceslist.rst.j2
+++ b/src/antsibull_docs/data/docsite/simplified-rst/macros/choiceslist.rst.j2
@@ -14,9 +14,9 @@
 {%       else %}
           <p><code>@{ choice | antsibull_to_json | escape }@</code>:
 {%       endif %}
-          @{ desc | first | default('') | html_ify(role_entrypoint=role_entrypoint) | indent(10, blank=true) }@</p>
+          @{ desc | first | default('') | html_ify(role_entrypoint=role_entrypoint) | rst_indent(10, blank=true) }@</p>
 {%       for line in desc[1:] %}
-          <p>@{ line | html_ify(role_entrypoint=role_entrypoint) | indent(10, blank=true) }@</p>
+          <p>@{ line | html_ify(role_entrypoint=role_entrypoint) | rst_indent(10, blank=true) }@</p>
 {%       endfor %}
         </li>
 {%     endfor %}

--- a/src/antsibull_docs/data/docsite/simplified-rst/macros/deprecates.rst.j2
+++ b/src/antsibull_docs/data/docsite/simplified-rst/macros/deprecates.rst.j2
@@ -18,7 +18,7 @@ Removed in: a future release
  of @{ data['removed_from_collection'] | html_ify(role_entrypoint=role_entrypoint) }@
 {%-    endif -%}
   </p>
-  <p>@{ 'Why: ' ~ data['why'] | html_ify(role_entrypoint=role_entrypoint) | indent(2, blank=true) }@</p>
-  <p>@{ 'Alternative: ' ~ data['alternative'] | html_ify(role_entrypoint=role_entrypoint) | indent(2, blank=true) }@</p>
+  <p>@{ 'Why: ' ~ data['why'] | html_ify(role_entrypoint=role_entrypoint) | rst_indent(2, blank=true) }@</p>
+  <p>@{ 'Alternative: ' ~ data['alternative'] | html_ify(role_entrypoint=role_entrypoint) | rst_indent(2, blank=true) }@</p>
 {%   endif %}
 {% endmacro %}

--- a/src/antsibull_docs/data/docsite/simplified-rst/macros/parameters.rst.j2
+++ b/src/antsibull_docs/data/docsite/simplified-rst/macros/parameters.rst.j2
@@ -55,7 +55,7 @@
 {#   description #}
     <td valign="top">
 {%   for desc in value['description'] %}
-      <p>@{ desc | html_ify(role_entrypoint=role_entrypoint) | indent(6, blank=true) }@</p>
+      <p>@{ desc | html_ify(role_entrypoint=role_entrypoint) | rst_indent(6, blank=true) }@</p>
 {%   endfor %}
 {#   default / choices #}
 {%   if value['type'] == 'bool' %}
@@ -68,7 +68,7 @@
 {%   endif %}
 {#   Show default value, when multiple choice or no choices #}
 {%   if value['default'] is list or (value['default'] is not none and value['default'] not in value['choices']) %}
-      <p style="margin-top: 8px;"><b style="color: blue;">Default:</b> <code style="color: blue;">@{ value['default'] | antsibull_to_json | escape | indent(6, blank=true) }@</code></p>
+      <p style="margin-top: 8px;"><b style="color: blue;">Default:</b> <code style="color: blue;">@{ value['default'] | antsibull_to_json | escape | rst_indent(6, blank=true) }@</code></p>
 {%   endif %}
 {#   Configuration #}
 {%   if plugin_type != 'module' and plugin_type != 'role' and (value['ini'] or value['env'] or value['vars'] or value['cli']) %}

--- a/src/antsibull_docs/data/docsite/simplified-rst/macros/returnvalues.rst.j2
+++ b/src/antsibull_docs/data/docsite/simplified-rst/macros/returnvalues.rst.j2
@@ -45,10 +45,10 @@
 {#   description #}
     <td valign="top">
 {%   for desc in value['description'] %}
-      <p>@{ desc | html_ify(role_entrypoint=role_entrypoint) | indent(6, blank=true) }@</p>
+      <p>@{ desc | html_ify(role_entrypoint=role_entrypoint) | rst_indent(6, blank=true) }@</p>
 {%   endfor %}
 {%   if value['returned'] %}
-      <p style="margin-top: 8px;"><b>Returned:</b> @{ value['returned'] | html_ify(role_entrypoint=role_entrypoint) | indent(6, blank=true) }@</p>
+      <p style="margin-top: 8px;"><b>Returned:</b> @{ value['returned'] | html_ify(role_entrypoint=role_entrypoint) | rst_indent(6, blank=true) }@</p>
 {%   endif %}
 {#   Show possible choices and highlight details #}
 {%   if value['choices'] %}
@@ -56,7 +56,7 @@
 @{     choices_html(value['choices'], has_no_default=True, role_entrypoint=role_entrypoint) }@
 {%   endif %}
 {%   if value['sample'] is not none %}
-      <p style="margin-top: 8px; color: blue; word-wrap: break-word; word-break: break-all;"><b style="color: black;">Sample:</b> <code>@{ value['sample'] | antsibull_to_json | escape | indent(6, blank=true) }@</code></p>
+      <p style="margin-top: 8px; color: blue; word-wrap: break-word; word-break: break-all;"><b style="color: black;">Sample:</b> <code>@{ value['sample'] | antsibull_to_json | escape | rst_indent(6, blank=true) }@</code></p>
 {%   endif %}
     </td>
   </tr>

--- a/src/antsibull_docs/data/docsite/simplified-rst/plugin.rst.j2
+++ b/src/antsibull_docs/data/docsite/simplified-rst/plugin.rst.j2
@@ -75,8 +75,8 @@ DEPRECATED
 {% if doc['deprecated']['removed_from_collection'] and doc['deprecated']['removed_from_collection'] != collection %}
              of @{ doc['deprecated']['removed_from_collection'] | rst_ify }@
 {% endif %}
-:Why: @{ doc['deprecated']['why'] | rst_ify | indent(6) }@
-:Alternative: @{ doc['deprecated']['alternative'] | rst_ify | indent(14) }@
+:Why: @{ doc['deprecated']['why'] | rst_ify | rst_indent(6) }@
+:Alternative: @{ doc['deprecated']['alternative'] | rst_ify | rst_indent(14) }@
 {% endif %}
 
 {% if plugin_type == 'callback' %}
@@ -96,7 +96,7 @@ Synopsis
 --------
 
 {%   for desc in doc['description'] -%}
-- @{ desc | rst_ify | indent(width=2) }@
+- @{ desc | rst_ify | rst_indent(width=2) }@
 {%   endfor %}
 
 {% if doc['has_action'] %}
@@ -119,7 +119,7 @@ The below requirements are needed on the local controller node that executes thi
 {%   endif %}
 
 {%   for req in doc['requirements'] %}
-- @{ req | rst_ify | indent(width=2) }@
+- @{ req | rst_ify | rst_indent(width=2) }@
 {%   endfor %}
 
 {% endif %}
@@ -218,7 +218,7 @@ Notes
 {%   endif %}
 {%   if doc['notes'] %}
 {%     for note in doc['notes'] %}
-- @{ note | rst_ify | indent(width=2) }@
+- @{ note | rst_ify | rst_indent(width=2) }@
 {%     endfor %}
 {%   endif %}
 {% endif %}
@@ -231,7 +231,7 @@ See Also
 {%   if item.module is defined and item.description %}
 * @{ reference_plugin_rst(item['module'], 'module') }@
 
-  @{ item['description'] | rst_ify | indent(2) }@
+  @{ item['description'] | rst_ify | rst_indent(2) }@
 {%   elif item.module is defined %}
 * @{ reference_plugin_rst(item['module'], 'module') }@
 
@@ -239,7 +239,7 @@ See Also
 {%   elif item.plugin is defined and item.plugin_type is defined and item.description %}
 * @{ reference_plugin_rst(item['plugin'], item['plugin_type']) }@ @{ item['plugin_type'] }@ plugin
 
-  @{ item['description'] | rst_ify | indent(2) }@
+  @{ item['description'] | rst_ify | rst_indent(2) }@
 {%   elif item.plugin is defined and item.plugin_type is defined %}
 * @{ reference_plugin_rst(item['plugin'], item['plugin_type']) }@ @{ item['plugin_type'] }@ plugin
 
@@ -247,11 +247,11 @@ See Also
 {%   elif item.name is defined and item.link is defined and item.description %}
 * `@{ item['name'] }@ <@{ item['link'] }@>`_
 
-  @{ item['description'] | rst_ify | indent(2) }@
+  @{ item['description'] | rst_ify | rst_indent(2) }@
 {%   elif item.ref is defined and item.description %}
 * :ref:`@{ item['ref'] }@`
 
-  @{ item['description'] | rst_ify | indent(2) }@
+  @{ item['description'] | rst_ify | rst_indent(2) }@
 {%   endif %}
 {% endfor %}
 {% endif %}

--- a/src/antsibull_docs/data/docsite/simplified-rst/plugins_by_collection.rst.j2
+++ b/src/antsibull_docs/data/docsite/simplified-rst/plugins_by_collection.rst.j2
@@ -10,7 +10,7 @@
 
 {% macro list_plugins(plugin_type) %}
 {%   for name, desc in plugin_maps[plugin_type].items() | sort %}
-* `@{ name }@ @{ plugin_type }@ <@{ get_plugin_filename(collection_name ~ '.' ~ name, plugin_type) }@>`_ -- @{ desc | rst_ify(plugin_fqcn=collection_name ~ '.' ~ name, plugin_type=plugin_type) | indent(width=2) }@
+* `@{ name }@ @{ plugin_type }@ <@{ get_plugin_filename(collection_name ~ '.' ~ name, plugin_type) }@>`_ -- @{ desc | rst_ify(plugin_fqcn=collection_name ~ '.' ~ name, plugin_type=plugin_type) | rst_indent(width=2) }@
 {%   endfor %}
 {% endmacro %}
 
@@ -37,7 +37,7 @@ Description
 **Author@{ 's' if (collection_authors | length) > 1 else '' }@:**
 
 {%     for author in collection_authors %}
-* @{ author | indent(2) }@
+* @{ author | rst_indent(2) }@
 {%     endfor %}
 {%   endif %}
 

--- a/src/antsibull_docs/data/docsite/simplified-rst/role.rst.j2
+++ b/src/antsibull_docs/data/docsite/simplified-rst/role.rst.j2
@@ -66,15 +66,15 @@ DEPRECATED
 {%     else %}
 :Removed in: a future release
 {%     endif %}
-:Why: @{ ep_doc['deprecated']['why'] | rst_ify(role_entrypoint=entry_point) | indent(6) }@
-:Alternative: @{ ep_doc['deprecated']['alternative'] | rst_ify(role_entrypoint=entry_point) | indent(14) }@
+:Why: @{ ep_doc['deprecated']['why'] | rst_ify(role_entrypoint=entry_point) | rst_indent(6) }@
+:Alternative: @{ ep_doc['deprecated']['alternative'] | rst_ify(role_entrypoint=entry_point) | rst_indent(14) }@
 {%   endif %}
 
 Synopsis
 ^^^^^^^^
 
 {%   for desc in ep_doc['description'] -%}
-- @{ desc | rst_ify(role_entrypoint=entry_point) | indent(width=2) }@
+- @{ desc | rst_ify(role_entrypoint=entry_point) | rst_indent(width=2) }@
 {%   endfor %}
 
 {%   if ep_doc['requirements'] -%}
@@ -83,7 +83,7 @@ Requirements
 The below requirements are needed on the remote host and/or the local controller node.
 
 {%     for req in ep_doc['requirements'] %}
-- @{ req | rst_ify(role_entrypoint=entry_point) | indent(width=2) }@
+- @{ req | rst_ify(role_entrypoint=entry_point) | rst_indent(width=2) }@
 {%     endfor %}
 
 {%   endif %}
@@ -109,7 +109,7 @@ Notes
 ^^^^^
 
 {%     for note in ep_doc['notes'] %}
-- @{ note | rst_ify(role_entrypoint=entry_point) | indent(width=2) }@
+- @{ note | rst_ify(role_entrypoint=entry_point) | rst_indent(width=2) }@
 {%     endfor %}
 {%   endif %}
 
@@ -121,7 +121,7 @@ See Also
 {%       if item.module is defined and item.description %}
 * @{ reference_plugin_rst(item['module'], 'module') }@
 
-  @{ item['description'] | rst_ify(role_entrypoint=entry_point) | indent(2) }@
+  @{ item['description'] | rst_ify(role_entrypoint=entry_point) | rst_indent(2) }@
 {%       elif item.module is defined %}
 * @{ reference_plugin_rst(item['module'], 'module') }@
 
@@ -129,7 +129,7 @@ See Also
 {%       elif item.plugin is defined and item.plugin_type is defined and item.description %}
 * @{ reference_plugin_rst(item['plugin'], item['plugin_type']) }@ @{ item['plugin_type'] }@ plugin
 
-  @{ item['description'] | rst_ify(role_entrypoint=entry_point) | indent(2) }@
+  @{ item['description'] | rst_ify(role_entrypoint=entry_point) | rst_indent(2) }@
 {%       elif item.plugin is defined and item.plugin_type is defined %}
 * @{ reference_plugin_rst(item['plugin'], item['plugin_type']) }@ @{ item['plugin_type'] }@ plugin
 
@@ -137,11 +137,11 @@ See Also
 {%       elif item.name is defined and item.link is defined and item.description %}
 * `@{ item['name'] }@ <@{ item['link'] }@>`_
 
-   @{ item['description'] | rst_ify(role_entrypoint=entry_point) | indent(2) }@
+   @{ item['description'] | rst_ify(role_entrypoint=entry_point) | rst_indent(2) }@
 {%       elif item.ref is defined and item.description %}
 * :ref:`@{ item['ref'] }@`
 
-  @{ item['description'] | rst_ify(role_entrypoint=entry_point) | indent(2) }@
+  @{ item['description'] | rst_ify(role_entrypoint=entry_point) | rst_indent(2) }@
 {%       endif %}
 {%     endfor %}
 {%   endif %}

--- a/src/antsibull_docs/jinja2/environment.py
+++ b/src/antsibull_docs/jinja2/environment.py
@@ -35,6 +35,7 @@ from .filters import (
     remove_options_from_list,
     rst_fmt,
     rst_format,
+    rst_indent,
     rst_xline,
     suboption_depth,
     to_ini_value,
@@ -169,6 +170,7 @@ def doc_environment(
     env.filters["plugin_shortname"] = plugin_shortname
     env.filters["suboption_depth"] = suboption_depth
     env.filters["rst_format"] = rst_format
+    env.filters["rst_indent"] = rst_indent
     if collection_url is not None:
         env.filters["collection_url"] = collection_url
     if collection_install is not None:

--- a/src/antsibull_docs/jinja2/filters.py
+++ b/src/antsibull_docs/jinja2/filters.py
@@ -256,3 +256,33 @@ def rst_format(fmt: str, for_sphinx: bool = False) -> str:
 
 def column_width(string: str) -> int:
     return _column_width(string)
+
+
+def rst_indent(
+    value: str, width: t.Union[int, str], first: bool = False, blank: bool = False
+) -> str:
+    """Return a copy of the string with each line indented.
+
+    :param width: Number of spaces, or a string, to indent by.
+    :param first: Do not skip indenting the first line.
+    :param blank: Do not skip indenting empty lines.
+    """
+    if isinstance(width, str):
+        indent = width
+    else:
+        indent = " " * width
+
+    # The "\n" makes sure we handle an empty input or an input ending with a newline correctly
+    lines = (value + "\n").splitlines()
+
+    # Remove trailing whitespace
+    lines = [line.lstrip() for line in lines]
+
+    if blank:
+        rv = ("\n" + indent).join(lines)
+    else:
+        rv = lines.pop(0)
+        if lines:
+            rv += "\n" + "\n".join(indent + line if line else line for line in lines)
+
+    return indent + rv if first else rv

--- a/src/antsibull_docs/jinja2/filters.py
+++ b/src/antsibull_docs/jinja2/filters.py
@@ -276,13 +276,15 @@ def rst_indent(
     lines = (value + "\n").splitlines()
 
     # Remove trailing whitespace
-    lines = [line.lstrip() for line in lines]
+    stripped_lines = [line.lstrip() for line in lines]
 
     if blank:
-        rv = ("\n" + indent).join(lines)
+        rv = ("\n" + indent).join(stripped_lines)
     else:
-        rv = lines.pop(0)
-        if lines:
-            rv += "\n" + "\n".join(indent + line if line else line for line in lines)
+        rv = stripped_lines.pop(0)
+        if stripped_lines:
+            rv += "\n" + "\n".join(
+                indent + line if line else line for line in stripped_lines
+            )
 
     return indent + rv if first else rv

--- a/src/antsibull_docs/write_docs/changelog.py
+++ b/src/antsibull_docs/write_docs/changelog.py
@@ -64,18 +64,23 @@ async def write_changelog(
 
         changes = load_changes(config)
 
-        generator = ChangelogGenerator(config, changes)
+        if not changes.has_release:
+            changelog_contents = f"The changelog of {collection_name} is empty."
+        else:
+            generator = ChangelogGenerator(config, changes)
 
-        renderer = create_document_renderer(output_format.changelog_format)
-        generator.generate(renderer)
+            renderer = create_document_renderer(output_format.changelog_format)
+            generator.generate(renderer)
 
-        changelog_contents = renderer.render()
-        for warning in renderer.get_warnings():
-            flog.warning(warning)
+            changelog_contents = renderer.render()
+            for warning in renderer.get_warnings():
+                flog.warning(warning)
     except Exception as exc:  # pylint: disable=broad-exception-caught
         flog.warning(f"Error while processing changelog for {collection_name}: {exc}")
         changelog_contents = f"""
-The changelog of {collection_name} could not be rendered::
+The changelog of {collection_name} could not be rendered:
+
+.. code-block:: text
 
   {exc}
 """

--- a/tests/functional/ansible-doc-cache-all-others.json
+++ b/tests/functional/ansible-doc-cache-all-others.json
@@ -22689,14 +22689,18 @@
        "support": "full"
       },
       "diff_mode": {
-       "description": "Will return details on what has changed (or possibly needs changing in check_mode), when in diff mode",
+       "description": [
+        "Will return details on what has changed (or possibly needs changing in check_mode), when in diff mode",
+        "Foo bar baz. Bamm - Bar baz\n       bam bum.\nBumm - Foo bar\n       baz bam!\n"
+       ],
        "support": "full"
       },
       "platform": {
        "description": "Target OS/families that can be operated against",
        "details": [
         "The module M(boo) is not using an FQCN.",
-        "Sometimes our markup is B(broken."
+        "Sometimes our markup is B(broken.",
+        "Foo bar baz. Bamm - Bar baz\n       bam bum.\nBumm - Foo bar\n       baz bam!\n"
        ],
        "platforms": "posix",
        "support": "N/A"
@@ -22713,16 +22717,21 @@
       "The return value RV(bar) exists, but RV(barbaz) does not.",
       "Again existing: O(ns.col2.foo#module:foo=1), RV(ns.col2.foo#module:bar=2)",
       "Again not existing: O(ns.col2.foo#module:foobar=1), RV(ns.col2.foo#module:barbaz=2)",
-      "C() I() B() C() U() L(,) R(,) V() O() RV() E()"
+      "C() I() B() C() U() L(,) R(,) V() O() RV() E()",
+      "Foo bar baz. Bamm - Bar baz\n       bam bum.\nBumm - Foo bar\n       baz bam!\n"
      ],
      "filename": "ansible_collections/ns/col2/plugins/modules/foo2.py",
      "has_action": false,
      "module": "foo2",
+     "notes": [
+      "Foo bar baz. Bamm - Bar baz\n       bam bum.\nBumm - Foo bar\n       baz bam!\n"
+     ],
      "options": {
       "bar": {
        "description": [
         "Bar.",
-        "Some O(broken markup)."
+        "Some O(broken markup).",
+        "Foo bar baz. Bamm - Bar baz\n       bam bum.\nBumm - Foo bar\n       baz bam!\n"
        ],
        "elements": "int",
        "type": "list"
@@ -22783,7 +22792,7 @@
        "plugin_type": "strategy"
       },
       {
-       "description": "A non-existing stragey plugin",
+       "description": "Foo bar baz. Bamm - Bar baz\n       bam bum.\nBumm - Foo bar\n       baz bam!\n",
        "plugin": "ansible.builtin.foobarbaz",
        "plugin_type": "strategy"
       }

--- a/tests/functional/ansible-doc-cache-all.json
+++ b/tests/functional/ansible-doc-cache-all.json
@@ -22606,14 +22606,18 @@
        "support": "full"
       },
       "diff_mode": {
-       "description": "Will return details on what has changed (or possibly needs changing in check_mode), when in diff mode",
+       "description": [
+        "Will return details on what has changed (or possibly needs changing in check_mode), when in diff mode",
+        "Foo bar baz. Bamm - Bar baz\n       bam bum.\nBumm - Foo bar\n       baz bam!\n"
+       ],
        "support": "full"
       },
       "platform": {
        "description": "Target OS/families that can be operated against",
        "details": [
         "The module M(boo) is not using an FQCN.",
-        "Sometimes our markup is B(broken."
+        "Sometimes our markup is B(broken.",
+        "Foo bar baz. Bamm - Bar baz\n       bam bum.\nBumm - Foo bar\n       baz bam!\n"
        ],
        "platforms": "posix",
        "support": "N/A"
@@ -22630,16 +22634,21 @@
       "The return value RV(bar) exists, but RV(barbaz) does not.",
       "Again existing: O(ns.col2.foo#module:foo=1), RV(ns.col2.foo#module:bar=2)",
       "Again not existing: O(ns.col2.foo#module:foobar=1), RV(ns.col2.foo#module:barbaz=2)",
-      "C() I() B() C() U() L(,) R(,) V() O() RV() E()"
+      "C() I() B() C() U() L(,) R(,) V() O() RV() E()",
+      "Foo bar baz. Bamm - Bar baz\n       bam bum.\nBumm - Foo bar\n       baz bam!\n"
      ],
      "filename": "ansible_collections/ns/col2/plugins/modules/foo2.py",
      "has_action": false,
      "module": "foo2",
+     "notes": [
+      "Foo bar baz. Bamm - Bar baz\n       bam bum.\nBumm - Foo bar\n       baz bam!\n"
+     ],
      "options": {
       "bar": {
        "description": [
         "Bar.",
-        "Some O(broken markup)."
+        "Some O(broken markup).",
+        "Foo bar baz. Bamm - Bar baz\n       bam bum.\nBumm - Foo bar\n       baz bam!\n"
        ],
        "elements": "int",
        "type": "list"
@@ -22700,7 +22709,7 @@
        "plugin_type": "strategy"
       },
       {
-       "description": "A non-existing stragey plugin",
+       "description": "Foo bar baz. Bamm - Bar baz\n       bam bum.\nBumm - Foo bar\n       baz bam!\n",
        "plugin": "ansible.builtin.foobarbaz",
        "plugin_type": "strategy"
       }

--- a/tests/functional/ansible-doc-cache-ansible.builtin-ns.col2-ns2.col.json
+++ b/tests/functional/ansible-doc-cache-ansible.builtin-ns.col2-ns2.col.json
@@ -22606,14 +22606,18 @@
        "support": "full"
       },
       "diff_mode": {
-       "description": "Will return details on what has changed (or possibly needs changing in check_mode), when in diff mode",
+       "description": [
+        "Will return details on what has changed (or possibly needs changing in check_mode), when in diff mode",
+        "Foo bar baz. Bamm - Bar baz\n       bam bum.\nBumm - Foo bar\n       baz bam!\n"
+       ],
        "support": "full"
       },
       "platform": {
        "description": "Target OS/families that can be operated against",
        "details": [
         "The module M(boo) is not using an FQCN.",
-        "Sometimes our markup is B(broken."
+        "Sometimes our markup is B(broken.",
+        "Foo bar baz. Bamm - Bar baz\n       bam bum.\nBumm - Foo bar\n       baz bam!\n"
        ],
        "platforms": "posix",
        "support": "N/A"
@@ -22630,16 +22634,21 @@
       "The return value RV(bar) exists, but RV(barbaz) does not.",
       "Again existing: O(ns.col2.foo#module:foo=1), RV(ns.col2.foo#module:bar=2)",
       "Again not existing: O(ns.col2.foo#module:foobar=1), RV(ns.col2.foo#module:barbaz=2)",
-      "C() I() B() C() U() L(,) R(,) V() O() RV() E()"
+      "C() I() B() C() U() L(,) R(,) V() O() RV() E()",
+      "Foo bar baz. Bamm - Bar baz\n       bam bum.\nBumm - Foo bar\n       baz bam!\n"
      ],
      "filename": "ansible_collections/ns/col2/plugins/modules/foo2.py",
      "has_action": false,
      "module": "foo2",
+     "notes": [
+      "Foo bar baz. Bamm - Bar baz\n       bam bum.\nBumm - Foo bar\n       baz bam!\n"
+     ],
      "options": {
       "bar": {
        "description": [
         "Bar.",
-        "Some O(broken markup)."
+        "Some O(broken markup).",
+        "Foo bar baz. Bamm - Bar baz\n       bam bum.\nBumm - Foo bar\n       baz bam!\n"
        ],
        "elements": "int",
        "type": "list"
@@ -22700,7 +22709,7 @@
        "plugin_type": "strategy"
       },
       {
-       "description": "A non-existing stragey plugin",
+       "description": "Foo bar baz. Bamm - Bar baz\n       bam bum.\nBumm - Foo bar\n       baz bam!\n",
        "plugin": "ansible.builtin.foobarbaz",
        "plugin_type": "strategy"
       }

--- a/tests/functional/ansible-doc-cache-ns.col1-ns.col2-ns2.col-ns2.flatcol.json
+++ b/tests/functional/ansible-doc-cache-ns.col1-ns.col2-ns2.col-ns2.flatcol.json
@@ -1216,14 +1216,18 @@
        "support": "full"
       },
       "diff_mode": {
-       "description": "Will return details on what has changed (or possibly needs changing in check_mode), when in diff mode",
+       "description": [
+        "Will return details on what has changed (or possibly needs changing in check_mode), when in diff mode",
+        "Foo bar baz. Bamm - Bar baz\n       bam bum.\nBumm - Foo bar\n       baz bam!\n"
+       ],
        "support": "full"
       },
       "platform": {
        "description": "Target OS/families that can be operated against",
        "details": [
         "The module M(boo) is not using an FQCN.",
-        "Sometimes our markup is B(broken."
+        "Sometimes our markup is B(broken.",
+        "Foo bar baz. Bamm - Bar baz\n       bam bum.\nBumm - Foo bar\n       baz bam!\n"
        ],
        "platforms": "posix",
        "support": "N/A"
@@ -1240,16 +1244,21 @@
       "The return value RV(bar) exists, but RV(barbaz) does not.",
       "Again existing: O(ns.col2.foo#module:foo=1), RV(ns.col2.foo#module:bar=2)",
       "Again not existing: O(ns.col2.foo#module:foobar=1), RV(ns.col2.foo#module:barbaz=2)",
-      "C() I() B() C() U() L(,) R(,) V() O() RV() E()"
+      "C() I() B() C() U() L(,) R(,) V() O() RV() E()",
+      "Foo bar baz. Bamm - Bar baz\n       bam bum.\nBumm - Foo bar\n       baz bam!\n"
      ],
      "filename": "ansible_collections/ns/col2/plugins/modules/foo2.py",
      "has_action": false,
      "module": "foo2",
+     "notes": [
+      "Foo bar baz. Bamm - Bar baz\n       bam bum.\nBumm - Foo bar\n       baz bam!\n"
+     ],
      "options": {
       "bar": {
        "description": [
         "Bar.",
-        "Some O(broken markup)."
+        "Some O(broken markup).",
+        "Foo bar baz. Bamm - Bar baz\n       bam bum.\nBumm - Foo bar\n       baz bam!\n"
        ],
        "elements": "int",
        "type": "list"
@@ -1310,7 +1319,7 @@
        "plugin_type": "strategy"
       },
       {
-       "description": "A non-existing stragey plugin",
+       "description": "Foo bar baz. Bamm - Bar baz\n       bam bum.\nBumm - Foo bar\n       baz bam!\n",
        "plugin": "ansible.builtin.foobarbaz",
        "plugin_type": "strategy"
       }

--- a/tests/functional/ansible-doc-cache-ns.col2.json
+++ b/tests/functional/ansible-doc-cache-ns.col2.json
@@ -781,14 +781,18 @@
        "support": "full"
       },
       "diff_mode": {
-       "description": "Will return details on what has changed (or possibly needs changing in check_mode), when in diff mode",
+       "description": [
+        "Will return details on what has changed (or possibly needs changing in check_mode), when in diff mode",
+        "Foo bar baz. Bamm - Bar baz\n       bam bum.\nBumm - Foo bar\n       baz bam!\n"
+       ],
        "support": "full"
       },
       "platform": {
        "description": "Target OS/families that can be operated against",
        "details": [
         "The module M(boo) is not using an FQCN.",
-        "Sometimes our markup is B(broken."
+        "Sometimes our markup is B(broken.",
+        "Foo bar baz. Bamm - Bar baz\n       bam bum.\nBumm - Foo bar\n       baz bam!\n"
        ],
        "platforms": "posix",
        "support": "N/A"
@@ -805,16 +809,21 @@
       "The return value RV(bar) exists, but RV(barbaz) does not.",
       "Again existing: O(ns.col2.foo#module:foo=1), RV(ns.col2.foo#module:bar=2)",
       "Again not existing: O(ns.col2.foo#module:foobar=1), RV(ns.col2.foo#module:barbaz=2)",
-      "C() I() B() C() U() L(,) R(,) V() O() RV() E()"
+      "C() I() B() C() U() L(,) R(,) V() O() RV() E()",
+      "Foo bar baz. Bamm - Bar baz\n       bam bum.\nBumm - Foo bar\n       baz bam!\n"
      ],
      "filename": "ansible_collections/ns/col2/plugins/modules/foo2.py",
      "has_action": false,
      "module": "foo2",
+     "notes": [
+      "Foo bar baz. Bamm - Bar baz\n       bam bum.\nBumm - Foo bar\n       baz bam!\n"
+     ],
      "options": {
       "bar": {
        "description": [
         "Bar.",
-        "Some O(broken markup)."
+        "Some O(broken markup).",
+        "Foo bar baz. Bamm - Bar baz\n       bam bum.\nBumm - Foo bar\n       baz bam!\n"
        ],
        "elements": "int",
        "type": "list"
@@ -875,7 +884,7 @@
        "plugin_type": "strategy"
       },
       {
-       "description": "A non-existing stragey plugin",
+       "description": "Foo bar baz. Bamm - Bar baz\n       bam bum.\nBumm - Foo bar\n       baz bam!\n",
        "plugin": "ansible.builtin.foobarbaz",
        "plugin_type": "strategy"
       }

--- a/tests/functional/baseline-default/collections/ns/col2/foo2_module.rst
+++ b/tests/functional/baseline-default/collections/ns/col2/foo2_module.rst
@@ -56,6 +56,11 @@ Synopsis
 - Again existing: \ :ansopt:`ns.col2.foo#module:foo=1`\ , \ :ansretval:`ns.col2.foo#module:bar=2`\ 
 - Again not existing: \ :ansopt:`ns.col2.foo#module:foobar=1`\ , \ :ansretval:`ns.col2.foo#module:barbaz=2`\ 
 - \ :literal:`\ `\  \ :emphasis:`\ `\  \ :strong:`\ `\  \ :literal:`\ `\  \ \   \ :ref:`\  <>`\  \ :ansval:`\ `\  \ :ansopt:`ns.col2.foo2#module:`\  \ :ansretval:`ns.col2.foo2#module:`\  \ :ansenvvar:`\ `\ 
+- Foo bar baz. Bamm - Bar baz
+  bam bum.
+  Bumm - Foo bar
+  baz bam!
+
 
 
 .. Aliases
@@ -122,6 +127,12 @@ Parameters
       Bar.
 
       Some \ :ansopt:`ns.col2.foo2#module:broken markup`\ .
+
+      Foo bar baz. Bamm - Bar baz
+      bam bum.
+      Bumm - Foo bar
+      baz bam!
+
 
 
       .. raw:: html
@@ -384,6 +395,12 @@ Attributes
 
       Will return details on what has changed (or possibly needs changing in check\_mode), when in diff mode
 
+      Foo bar baz. Bamm - Bar baz
+      bam bum.
+      Bumm - Foo bar
+      baz bam!
+
+
 
       .. raw:: html
 
@@ -419,6 +436,12 @@ Attributes
 
       Sometimes our markup is \ :strong:`ERROR while parsing`\ : While parsing "B(broken." at index 25: Cannot find closing ")" after last parameter\ 
 
+      Foo bar baz. Bamm - Bar baz
+      bam bum.
+      Bumm - Foo bar
+      baz bam!
+
+
 
       .. raw:: html
 
@@ -438,6 +461,15 @@ Attributes
 
 
 .. Notes
+
+Notes
+-----
+
+.. note::
+   - Foo bar baz. Bamm - Bar baz
+     bam bum.
+     Bumm - Foo bar
+     baz bam!
 
 
 .. Seealso
@@ -462,7 +494,11 @@ See Also
    \ :ref:`ansible.builtin.linear <ansible_collections.ansible.builtin.linear_strategy>`\  strategy plugin
        The linear strategy plugin.
    \ :ref:`ansible.builtin.foobarbaz <ansible_collections.ansible.builtin.foobarbaz_strategy>`\  strategy plugin
-       A non-existing stragey plugin
+       Foo bar baz. Bamm - Bar baz
+       bam bum.
+       Bumm - Foo bar
+       baz bam!
+
 
 .. Examples
 

--- a/tests/functional/baseline-default/collections/ns/col2/foo3_module.rst
+++ b/tests/functional/baseline-default/collections/ns/col2/foo3_module.rst
@@ -427,7 +427,7 @@ There were some errors parsing the documentation for this plugin.  Please file a
 
 The errors were:
 
-* ::
+* .. code-block:: text
 
         Unable to normalize foo3: return due to: 2 validation errors for PluginReturnSchema
         return -> bar -> type

--- a/tests/functional/baseline-default/collections/ns/col2/foo_module.rst
+++ b/tests/functional/baseline-default/collections/ns/col2/foo_module.rst
@@ -22,7 +22,7 @@ The documentation for the module plugin, ns.col2.foo,  was malformed.
 
 The errors were:
 
-* ::
+* .. code-block:: text
 
         6 validation errors for ModuleDocSchema
         doc -> short_description

--- a/tests/functional/baseline-default/collections/ns2/col/changelog.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/changelog.rst
@@ -1,4 +1,1 @@
-
-The changelog of ns2.col could not be rendered::
-
-  list index out of range
+The changelog of ns2.col is empty.

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/foo2_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/foo2_module.rst
@@ -56,6 +56,11 @@ Synopsis
 - Again existing: \ :ansopt:`ns.col2.foo#module:foo=1`\ , \ :ansretval:`ns.col2.foo#module:bar=2`\ 
 - Again not existing: \ :ansopt:`ns.col2.foo#module:foobar=1`\ , \ :ansretval:`ns.col2.foo#module:barbaz=2`\ 
 - \ :literal:`\ `\  \ :emphasis:`\ `\  \ :strong:`\ `\  \ :literal:`\ `\  \ \   \ :ref:`\  <>`\  \ :ansval:`\ `\  \ :ansopt:`ns.col2.foo2#module:`\  \ :ansretval:`ns.col2.foo2#module:`\  \ :ansenvvar:`\ `\ 
+- Foo bar baz. Bamm - Bar baz
+  bam bum.
+  Bumm - Foo bar
+  baz bam!
+
 
 
 .. Aliases
@@ -122,6 +127,12 @@ Parameters
       Bar.
 
       Some \ :ansopt:`ns.col2.foo2#module:broken markup`\ .
+
+      Foo bar baz. Bamm - Bar baz
+      bam bum.
+      Bumm - Foo bar
+      baz bam!
+
 
 
       .. raw:: html
@@ -384,6 +395,12 @@ Attributes
 
       Will return details on what has changed (or possibly needs changing in check\_mode), when in diff mode
 
+      Foo bar baz. Bamm - Bar baz
+      bam bum.
+      Bumm - Foo bar
+      baz bam!
+
+
 
       .. raw:: html
 
@@ -419,6 +436,12 @@ Attributes
 
       Sometimes our markup is \ :strong:`ERROR while parsing`\ : While parsing "B(broken." at index 25: Cannot find closing ")" after last parameter\ 
 
+      Foo bar baz. Bamm - Bar baz
+      bam bum.
+      Bumm - Foo bar
+      baz bam!
+
+
 
       .. raw:: html
 
@@ -438,6 +461,15 @@ Attributes
 
 
 .. Notes
+
+Notes
+-----
+
+.. note::
+   - Foo bar baz. Bamm - Bar baz
+     bam bum.
+     Bumm - Foo bar
+     baz bam!
 
 
 .. Seealso
@@ -462,7 +494,11 @@ See Also
    \ :ref:`ansible.builtin.linear <ansible_collections.ansible.builtin.linear_strategy>`\  strategy plugin
        The linear strategy plugin.
    \ :ref:`ansible.builtin.foobarbaz <ansible_collections.ansible.builtin.foobarbaz_strategy>`\  strategy plugin
-       A non-existing stragey plugin
+       Foo bar baz. Bamm - Bar baz
+       bam bum.
+       Bumm - Foo bar
+       baz bam!
+
 
 .. Examples
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/foo3_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/foo3_module.rst
@@ -427,7 +427,7 @@ There were some errors parsing the documentation for this plugin.  Please file a
 
 The errors were:
 
-* ::
+* .. code-block:: text
 
         Unable to normalize foo3: return due to: 2 validation errors for PluginReturnSchema
         return -> bar -> type

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/foo_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/foo_module.rst
@@ -22,7 +22,7 @@ The documentation for the module plugin, ns.col2.foo,  was malformed.
 
 The errors were:
 
-* ::
+* .. code-block:: text
 
         6 validation errors for ModuleDocSchema
         doc -> short_description

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/changelog.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/changelog.rst
@@ -1,4 +1,1 @@
-
-The changelog of ns2.col could not be rendered::
-
-  list index out of range
+The changelog of ns2.col is empty.

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/changelog.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/changelog.rst
@@ -1,4 +1,1 @@
-
-The changelog of ns2.col could not be rendered::
-
-  list index out of range
+The changelog of ns2.col is empty.

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/changelog.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/changelog.rst
@@ -1,4 +1,1 @@
-
-The changelog of ns2.col could not be rendered::
-
-  list index out of range
+The changelog of ns2.col is empty.

--- a/tests/functional/baseline-simplified-rst/collections/ns/col2/foo2_module.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns/col2/foo2_module.rst
@@ -31,6 +31,11 @@ Synopsis
 - Again existing: \ :literal:`foo=1` (of module `ns.col2.foo <foo_module.rst>`__)\ , \ :literal:`bar=2` (of module `ns.col2.foo <foo_module.rst>`__)\ 
 - Again not existing: \ :literal:`foobar=1` (of module `ns.col2.foo <foo_module.rst>`__)\ , \ :literal:`barbaz=2` (of module `ns.col2.foo <foo_module.rst>`__)\ 
 - \ :literal:`\ `\  \ :emphasis:`\ `\  \ :strong:`\ `\  \ :literal:`\ `\  \ \   \ :ref:`\  <>`\  \ :literal:`\ `\  \ :literal:`` (`link <#parameter->`_)\  \ :literal:`` (`link <#return->`_)\  \ :literal:``\ 
+- Foo bar baz. Bamm - Bar baz
+  bam bum.
+  Bumm - Foo bar
+  baz bam!
+
 
 
 
@@ -73,6 +78,11 @@ Parameters
     <td valign="top">
       <p>Bar.</p>
       <p>Some <code class="ansible-option literal notranslate"><strong><a class="reference internal" href="#parameter-broken%2520markup"><span class="std std-ref"><span class="pre">broken markup</span></span></a></strong></code>.</p>
+      <p>Foo bar baz. Bamm - Bar baz
+      bam bum.
+      Bumm - Foo bar
+      baz bam!
+      </p>
     </td>
   </tr>
   <tr>
@@ -175,6 +185,12 @@ Attributes
     - 
       Will return details on what has changed (or possibly needs changing in check\_mode), when in diff mode
 
+      Foo bar baz. Bamm - Bar baz
+      bam bum.
+      Bumm - Foo bar
+      baz bam!
+
+
 
 
   * - .. _ansible_collections.ns.col2.foo2_module__attribute-platform:
@@ -187,12 +203,26 @@ Attributes
 
       Sometimes our markup is \ :strong:`ERROR while parsing`\ : While parsing "B(broken." at index 25: Cannot find closing ")" after last parameter\ 
 
+      Foo bar baz. Bamm - Bar baz
+      bam bum.
+      Bumm - Foo bar
+      baz bam!
+
+
 
     - 
       Target OS/families that can be operated against
 
 
 
+
+Notes
+-----
+
+- Foo bar baz. Bamm - Bar baz
+  bam bum.
+  Bumm - Foo bar
+  baz bam!
 
 
 See Also
@@ -221,7 +251,11 @@ See Also
   The linear strategy plugin.
 * \ `ansible.builtin.foobarbaz <foobarbaz_strategy.rst>`__\  strategy plugin
 
-  A non-existing stragey plugin
+  Foo bar baz. Bamm - Bar baz
+  bam bum.
+  Bumm - Foo bar
+  baz bam!
+
 
 Examples
 --------

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/changelog.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/changelog.rst
@@ -1,4 +1,1 @@
-
-The changelog of ns2.col could not be rendered::
-
-  list index out of range
+The changelog of ns2.col is empty.

--- a/tests/functional/baseline-squash-hierarchy/changelog.rst
+++ b/tests/functional/baseline-squash-hierarchy/changelog.rst
@@ -1,4 +1,1 @@
-
-The changelog of ns2.col could not be rendered::
-
-  list index out of range
+The changelog of ns2.col is empty.

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/changelog.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/changelog.rst
@@ -1,4 +1,1 @@
-
-The changelog of ns2.col could not be rendered::
-
-  list index out of range
+The changelog of ns2.col is empty.

--- a/tests/functional/collections/ansible_collections/ns/col2/plugins/modules/foo2.py
+++ b/tests/functional/collections/ansible_collections/ns/col2/plugins/modules/foo2.py
@@ -22,6 +22,19 @@ description:
     - "Again existing: O(ns.col2.foo#module:foo=1), RV(ns.col2.foo#module:bar=2)"
     - "Again not existing: O(ns.col2.foo#module:foobar=1), RV(ns.col2.foo#module:barbaz=2)"
     - C() I() B() C() U() L(,) R(,) V() O() RV() E()
+    - >
+      Foo bar baz.
+      Bamm - Bar baz
+             bam bum.
+      Bumm - Foo bar
+             baz bam!
+notes:
+    - >
+      Foo bar baz.
+      Bamm - Bar baz
+             bam bum.
+      Bumm - Foo bar
+             baz bam!
 options:
     foo:
         description: The foo source.
@@ -30,6 +43,12 @@ options:
         description:
           - Bar.
           - Some O(broken markup).
+          - >
+            Foo bar baz.
+            Bamm - Bar baz
+                   bam bum.
+            Bumm - Foo bar
+                   baz bam!
         type: list
         elements: int
     subfoo:
@@ -55,13 +74,26 @@ attributes:
         description: Can run in check_mode and return changed status prediction without modifying target
         support: full
     diff_mode:
-        description: Will return details on what has changed (or possibly needs changing in check_mode), when in diff mode
+        description:
+          - Will return details on what has changed (or possibly needs changing in check_mode), when in diff mode
+          - >
+            Foo bar baz.
+            Bamm - Bar baz
+                   bam bum.
+            Bumm - Foo bar
+                   baz bam!
         support: full
     platform:
         description: Target OS/families that can be operated against
         details:
           - The module M(boo) is not using an FQCN.
           - Sometimes our markup is B(broken.
+          - >
+            Foo bar baz.
+            Bamm - Bar baz
+                   bam bum.
+            Bumm - Foo bar
+                   baz bam!
         support: N/A
         platforms: posix
 
@@ -83,7 +115,12 @@ seealso:
       description: The linear strategy plugin.
     - plugin: ansible.builtin.foobarbaz
       plugin_type: strategy
-      description: A non-existing stragey plugin
+      description: >
+        Foo bar baz.
+        Bamm - Bar baz
+               bam bum.
+        Bumm - Foo bar
+               baz bam!
 """
 
 EXAMPLES = """


### PR DESCRIPTION
- Render errors as text code blocks, instead of using the default lexer (which happens to be YAML + Jinja2 for the Ansible docsite, for example, resulting in warnings).
- Improve handling of empty and broken changelogs.
- Remove leading spaces in RST paragraphs, to avoid them being interpreted as blockquotes.