### PR TITLE
Adjust nox workflow to use local checkouts

### DIFF
--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -21,6 +21,7 @@ name: nox
 
 env:
   FORCE_COLOR: "1"
+  OTHER_ANTSIBULL_MODE: local
 
 jobs:
   nox:
@@ -77,10 +78,10 @@ jobs:
           python-versions: "${{ matrix.python-versions }}"
       - name: Set up nox environments
         run: |
-          OTHER_ANTSIBULL_MODE=local nox -v -e "${{ matrix.session }}" ${{ matrix.codecov && 'coverage' || '' }} --install-only
+          nox -v -e "${{ matrix.session }}" ${{ matrix.codecov && 'coverage' || '' }} --install-only
       - name: "Run nox -e ${{ matrix.session }}"
         run: |
-          OTHER_ANTSIBULL_MODE=local nox -v -e "${{ matrix.session }}" --reuse-existing-virtualenvs --no-install
+          nox -v -e "${{ matrix.session }}" --reuse-existing-virtualenvs --no-install
       - name: Report coverage
         if: ${{ matrix.codecov }}
         run: |

--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -77,10 +77,10 @@ jobs:
           python-versions: "${{ matrix.python-versions }}"
       - name: Set up nox environments
         run: |
-          OTHER_ANTSIBULL_MODE=git nox -v -e "${{ matrix.session }}" ${{ matrix.codecov && 'coverage' || '' }} --install-only
+          OTHER_ANTSIBULL_MODE=local nox -v -e "${{ matrix.session }}" ${{ matrix.codecov && 'coverage' || '' }} --install-only
       - name: "Run nox -e ${{ matrix.session }}"
         run: |
-          OTHER_ANTSIBULL_MODE=git nox -v -e "${{ matrix.session }}" --reuse-existing-virtualenvs --no-install
+          OTHER_ANTSIBULL_MODE=local nox -v -e "${{ matrix.session }}" --reuse-existing-virtualenvs --no-install
       - name: Report coverage
         if: ${{ matrix.codecov }}
         run: |


### PR DESCRIPTION
The workflow checks them all out, and then tells nox to install them directly from git... Tell nox to use the local checkouts. (That will also make it complain if we forgot to check out a project.)