### PR TITLE
Update baseline for antsibull-docs-parser changes; fix escaping bug

### DIFF
--- a/changelogs/fragments/311-escaping.yml
+++ b/changelogs/fragments/311-escaping.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - "Fix RST escaping of the title in the collections per namespace list.
+     This causes a space to vanish between namespace name and the word ``Namespace`` with newer versions of antsibull-docs-parser
+     (https://github.com/ansible-community/antsibull-docs/pull/311)."

--- a/src/antsibull_docs/data/docsite/ansible-docsite/list_of_collections_by_namespace.rst.j2
+++ b/src/antsibull_docs/data/docsite/ansible-docsite/list_of_collections_by_namespace.rst.j2
@@ -13,7 +13,7 @@
 
 .. _list_of_collections_@{ namespace }@:
 
-{% set title = 'Collections in the ' ~ (namespace | title) ~ ' Namespace' | rst_ify -%}
+{% set title = ('Collections in the ' ~ (namespace | title) ~ ' Namespace') | rst_ify -%}
 
 @{ title }@
 @{ '=' * title|column_width }@

--- a/src/antsibull_docs/data/docsite/simplified-rst/list_of_collections_by_namespace.rst.j2
+++ b/src/antsibull_docs/data/docsite/simplified-rst/list_of_collections_by_namespace.rst.j2
@@ -12,7 +12,7 @@
 
 .. _list_of_collections_@{ namespace }@:
 
-{% set title = 'Collections in the ' ~ (namespace | title) ~ ' Namespace' | rst_ify -%}
+{% set title = ('Collections in the ' ~ (namespace | title) ~ ' Namespace') | rst_ify -%}
 
 @{ title }@
 @{ '=' * title|column_width }@

--- a/tests/functional/ansible-doc-cache-all-others.json
+++ b/tests/functional/ansible-doc-cache-all-others.json
@@ -7499,7 +7499,8 @@
      "author": "Jan-Piet Mens (@jpmens) <jpmens(at)gmail.com>",
      "collection": "ansible.builtin",
      "description": [
-      "The csvfile lookup reads the contents of a file in CSV (comma-separated value) format. The lookup looks for the row where the first column matches keyname (which can be multiple words) and returns the value in the O(col) column (default 1, which indexed from 0 means the second column in the file)."
+      "The csvfile lookup reads the contents of a file in CSV (comma-separated value) format. The lookup looks for the row where the first column matches keyname (which can be multiple words) and returns the value in the O(col) column (default 1, which indexed from 0 means the second column in the file).",
+      "At least one keyname is required, provided as a positional argument(s) to the lookup."
      ],
      "filename": "/ansible/plugins/lookup/csvfile.py",
      "name": "csvfile",
@@ -7549,7 +7550,7 @@
      "version_added": "1.5",
      "version_added_collection": "ansible.builtin"
     },
-    "examples": "\n- name:  Match 'Li' on the first column, return the second column (0 based index)\n  ansible.builtin.debug: msg=\"The atomic number of Lithium is {{ lookup('ansible.builtin.csvfile', 'Li file=elements.csv delimiter=,') }}\"\n\n- name: msg=\"Match 'Li' on the first column, but return the 3rd column (columns start counting after the match)\"\n  ansible.builtin.debug: msg=\"The atomic mass of Lithium is {{ lookup('ansible.builtin.csvfile', 'Li file=elements.csv delimiter=, col=2') }}\"\n\n# Contents of bgp_neighbors.csv\n# 127.0.0.1,10.0.0.1,24,nones,lola,pepe,127.0.0.2\n# 128.0.0.1,10.1.0.1,20,notes,lolita,pepito,128.0.0.2\n# 129.0.0.1,10.2.0.1,23,nines,aayush,pepete,129.0.0.2\n\n- name: Define values from CSV file, this reads file in one go, but you could also use col= to read each in it's own lookup.\n  ansible.builtin.set_fact:\n    '{{ columns[item|int] }}': \"{{ csvline }}\"\n  vars:\n    csvline: \"{{ lookup('csvfile', bgp_neighbor_ip, file='bgp_neighbors.csv', delimiter=',', col=item) }}\"\n    columns: ['loop_ip', 'int_ip', 'int_mask', 'int_name', 'local_as', 'neighbour_as', 'neight_int_ip']\n    bgp_neighbor_ip: '127.0.0.1'\n  loop: '{{ range(columns|length|int) }}'\n  delegate_to: localhost\n  delegate_facts: true\n\n# Contents of people.csv\n# # Last,First,Email,Extension\n# Smith,Jane,jsmith@example.com,1234\n\n- name: Specify the column (by keycol) in which the string should be searched\n  assert:\n    that:\n    - lookup('ansible.builtin.csvfile', 'Jane', file='people.csv', delimiter=',', col=0, keycol=1) == \"Smith\"\n",
+    "examples": "\n- name:  Match 'Li' on the first column, return the second column (0 based index)\n  ansible.builtin.debug: msg=\"The atomic number of Lithium is {{ lookup('ansible.builtin.csvfile', 'Li file=elements.csv delimiter=,') }}\"\n\n- name: msg=\"Match 'Li' on the first column, but return the 3rd column (columns start counting after the match)\"\n  ansible.builtin.debug: msg=\"The atomic mass of Lithium is {{ lookup('ansible.builtin.csvfile', 'Li file=elements.csv delimiter=, col=2') }}\"\n\n# Contents of bgp_neighbors.csv\n# 127.0.0.1,10.0.0.1,24,nones,lola,pepe,127.0.0.2\n# 128.0.0.1,10.1.0.1,20,notes,lolita,pepito,128.0.0.2\n# 129.0.0.1,10.2.0.1,23,nines,aayush,pepete,129.0.0.2\n\n- name: Define values from CSV file, this reads file in one go, but you could also use col= to read each in it's own lookup.\n  ansible.builtin.set_fact:\n    '{{ columns[item|int] }}': \"{{ csvline }}\"\n  vars:\n    csvline: \"{{ lookup('csvfile', bgp_neighbor_ip, file='bgp_neighbors.csv', delimiter=',', col=item) }}\"\n    columns: ['loop_ip', 'int_ip', 'int_mask', 'int_name', 'local_as', 'neighbour_as', 'neight_int_ip']\n    bgp_neighbor_ip: '127.0.0.1'\n  loop: '{{ range(columns|length|int) }}'\n  delegate_to: localhost\n  delegate_facts: true\n\n# Contents of people.csv\n# # Last,First,Email,Extension\n# Smith,Jane,jsmith@example.com,1234\n\n- name: Specify the column (by keycol) in which the string should be searched\n  assert:\n    that:\n    - lookup('ansible.builtin.csvfile', 'Jane', file='people.csv', delimiter=',', col=0, keycol=1) == \"Smith\"\n\n# Contents of debug.csv\n# test1 ret1.1 ret2.1\n# test2 ret1.2 ret2.2\n# test3 ret1.3 ret2.3\n\n- name: \"Lookup multiple keynames in the first column (index 0), returning the values from the second column (index 1)\"\n  debug:\n    msg: \"{{ lookup('csvfile', 'test1', 'test2', file='debug.csv', delimiter=' ') }}\"\n\n- name: Lookup multiple keynames using old style syntax\n  debug:\n    msg: \"{{ lookup('csvfile', term1, term2) }}\"\n  vars:\n    term1: \"test1 file=debug.csv delimiter=' '\"\n    term2: \"test2 file=debug.csv delimiter=' '\"\n",
     "metadata": null,
     "return": {
      "_raw": {
@@ -7877,6 +7878,13 @@
       "file": {
        "default": "ansible.ini",
        "description": "Name of the file to load."
+      },
+      "interpolation": {
+       "default": true,
+       "description": "Allows for interpolation of values, see https://docs.python.org/3/library/configparser.html#configparser.BasicInterpolation",
+       "type": "bool",
+       "version_added": "2.18",
+       "version_added_collection": "ansible.builtin"
       },
       "re": {
        "default": false,
@@ -16603,7 +16611,8 @@
         "noop",
         "refresh_inventory",
         "reset_connection",
-        "end_batch"
+        "end_batch",
+        "end_role"
        ],
        "description": [
         "This module takes a free form command, as a string. There is not an actual option named \"free form\".  See the examples!",
@@ -16615,7 +16624,8 @@
         "V(end_play) (added in Ansible 2.2) causes the play to end without failing the host(s). Note that this affects all hosts.",
         "V(reset_connection) (added in Ansible 2.3) interrupts a persistent connection (i.e. ssh + control persist)",
         "V(end_host) (added in Ansible 2.8) is a per-host variation of V(end_play). Causes the play to end for the current host without failing it.",
-        "V(end_batch) (added in Ansible 2.12) causes the current batch (see C(serial)) to end without failing the host(s). Note that with C(serial=0) or undefined this behaves the same as V(end_play)."
+        "V(end_batch) (added in Ansible 2.12) causes the current batch (see C(serial)) to end without failing the host(s). Note that with C(serial=0) or undefined this behaves the same as V(end_play).",
+        "V(end_role) (added in Ansible 2.18) causes the currently executing role to end without failing the host(s). Effectively all tasks from within a role after V(end_role) is executed are ignored. Since handlers live in a global, play scope, all handlers added via the role are unaffected and are still executed if notified. It is an error to call V(end_role) from outside of a role or from a handler. Note that V(end_role) does not have an effect to the parent roles or roles that depend (via dependencies in meta/main.yml) on a role executing V(end_role)."
        ],
        "required": true
       }
@@ -17752,7 +17762,8 @@
         "The long-form fingerprint of the key being imported.",
         "This will be used to verify the specified key."
        ],
-       "type": "str",
+       "elements": "str",
+       "type": "list",
        "version_added": 2.9,
        "version_added_collection": "ansible.builtin"
       },
@@ -17788,7 +17799,7 @@
      "version_added": "1.3",
      "version_added_collection": "ansible.builtin"
     },
-    "examples": "\n- name: Import a key from a url\n  ansible.builtin.rpm_key:\n    state: present\n    key: http://apt.sw.be/RPM-GPG-KEY.dag.txt\n\n- name: Import a key from a file\n  ansible.builtin.rpm_key:\n    state: present\n    key: /path/to/key.gpg\n\n- name: Ensure a key is not present in the db\n  ansible.builtin.rpm_key:\n    state: absent\n    key: DEADB33F\n\n- name: Verify the key, using a fingerprint, before import\n  ansible.builtin.rpm_key:\n    key: /path/to/RPM-GPG-KEY.dag.txt\n    fingerprint: EBC6 E12C 62B1 C734 026B  2122 A20E 5214 6B8D 79E6\n",
+    "examples": "\n- name: Import a key from a url\n  ansible.builtin.rpm_key:\n    state: present\n    key: http://apt.sw.be/RPM-GPG-KEY.dag.txt\n\n- name: Import a key from a file\n  ansible.builtin.rpm_key:\n    state: present\n    key: /path/to/key.gpg\n\n- name: Ensure a key is not present in the db\n  ansible.builtin.rpm_key:\n    state: absent\n    key: DEADB33F\n\n- name: Verify the key, using a fingerprint, before import\n  ansible.builtin.rpm_key:\n    key: /path/to/RPM-GPG-KEY.dag.txt\n    fingerprint: EBC6 E12C 62B1 C734 026B  2122 A20E 5214 6B8D 79E6\n\n- name: Verify the key, using multiple fingerprints, before import\n  ansible.builtin.rpm_key:\n    key: /path/to/RPM-GPG-KEY.dag.txt\n    fingerprint:\n      - EBC6 E12C 62B1 C734 026B  2122 A20E 5214 6B8D 79E6\n      - 19B7 913E 6284 8E3F 4D78 D6B4 ECD9 1AB2 2EB6 8D86\n",
     "metadata": null,
     "return": null
    },
@@ -25476,27 +25487,57 @@
      "author": "Ansible Core",
      "collection": "ansible.builtin",
      "description": [
-      "Verifies if the input is an Ansible vault."
+      "Verifies if the input string is an Ansible vault or not"
      ],
      "filename": "/ansible/plugins/test/vault_encrypted.yml",
-     "name": "truthy",
+     "name": "vault_encrypted",
      "options": {
       "_input": {
-       "description": "The possible vault.",
+       "description": "The possible vault string",
        "required": true,
        "type": "string"
       }
      },
      "plugin_name": "ansible.builtin.vault_encrypted",
-     "short_description": "Is this an encrypted vault",
+     "short_description": "Is this an encrypted vault string",
      "version_added": "2.10",
      "version_added_collection": "ansible.builtin"
     },
-    "examples": "thisisfalse: '{{ \"any string\" is ansible_vault }}'\nthisistrue: '{{ \"$ANSIBLE_VAULT;1.2;AES256;dev....\" is ansible_vault }}'\n",
+    "examples": "thisisfalse: '{{ \"any string\" is vault_encryped}}'\nthisistrue: '{{ \"$ANSIBLE_VAULT;1.2;AES256;dev....\" is vault_encrypted}}'\n",
     "metadata": null,
     "return": {
      "_value": {
       "description": "Returns V(True) if the input is a valid ansible vault, V(False) otherwise.",
+      "type": "boolean"
+     }
+    }
+   },
+   "ansible.builtin.vaulted_file": {
+    "doc": {
+     "author": "Ansible Core",
+     "collection": "ansible.builtin",
+     "description": [
+      "Verifies if the input path is an Ansible vault file."
+     ],
+     "filename": "/ansible/plugins/test/vaulted_file.yml",
+     "name": "vaulted_file",
+     "options": {
+      "_input": {
+       "description": "The path to the possible vault.",
+       "required": true,
+       "type": "path"
+      }
+     },
+     "plugin_name": "ansible.builtin.vaulted_file",
+     "short_description": "Is this file an encrypted vault",
+     "version_added": "2.18",
+     "version_added_collection": "ansible.builtin"
+    },
+    "examples": "thisisfalse: '{{ \"/etc/hosts\" is vaulted_file}}'\nthisistrue: '{{ \"/path/to/vaulted/file\" is vaulted_file}}'\n",
+    "metadata": null,
+    "return": {
+     "_value": {
+      "description": "Returns V(True) if the path is a valid ansible vault, V(False) otherwise.",
       "type": "boolean"
      }
     }

--- a/tests/functional/ansible-doc-cache-all.json
+++ b/tests/functional/ansible-doc-cache-all.json
@@ -7499,7 +7499,8 @@
      "author": "Jan-Piet Mens (@jpmens) <jpmens(at)gmail.com>",
      "collection": "ansible.builtin",
      "description": [
-      "The csvfile lookup reads the contents of a file in CSV (comma-separated value) format. The lookup looks for the row where the first column matches keyname (which can be multiple words) and returns the value in the O(col) column (default 1, which indexed from 0 means the second column in the file)."
+      "The csvfile lookup reads the contents of a file in CSV (comma-separated value) format. The lookup looks for the row where the first column matches keyname (which can be multiple words) and returns the value in the O(col) column (default 1, which indexed from 0 means the second column in the file).",
+      "At least one keyname is required, provided as a positional argument(s) to the lookup."
      ],
      "filename": "/ansible/plugins/lookup/csvfile.py",
      "name": "csvfile",
@@ -7549,7 +7550,7 @@
      "version_added": "1.5",
      "version_added_collection": "ansible.builtin"
     },
-    "examples": "\n- name:  Match 'Li' on the first column, return the second column (0 based index)\n  ansible.builtin.debug: msg=\"The atomic number of Lithium is {{ lookup('ansible.builtin.csvfile', 'Li file=elements.csv delimiter=,') }}\"\n\n- name: msg=\"Match 'Li' on the first column, but return the 3rd column (columns start counting after the match)\"\n  ansible.builtin.debug: msg=\"The atomic mass of Lithium is {{ lookup('ansible.builtin.csvfile', 'Li file=elements.csv delimiter=, col=2') }}\"\n\n# Contents of bgp_neighbors.csv\n# 127.0.0.1,10.0.0.1,24,nones,lola,pepe,127.0.0.2\n# 128.0.0.1,10.1.0.1,20,notes,lolita,pepito,128.0.0.2\n# 129.0.0.1,10.2.0.1,23,nines,aayush,pepete,129.0.0.2\n\n- name: Define values from CSV file, this reads file in one go, but you could also use col= to read each in it's own lookup.\n  ansible.builtin.set_fact:\n    '{{ columns[item|int] }}': \"{{ csvline }}\"\n  vars:\n    csvline: \"{{ lookup('csvfile', bgp_neighbor_ip, file='bgp_neighbors.csv', delimiter=',', col=item) }}\"\n    columns: ['loop_ip', 'int_ip', 'int_mask', 'int_name', 'local_as', 'neighbour_as', 'neight_int_ip']\n    bgp_neighbor_ip: '127.0.0.1'\n  loop: '{{ range(columns|length|int) }}'\n  delegate_to: localhost\n  delegate_facts: true\n\n# Contents of people.csv\n# # Last,First,Email,Extension\n# Smith,Jane,jsmith@example.com,1234\n\n- name: Specify the column (by keycol) in which the string should be searched\n  assert:\n    that:\n    - lookup('ansible.builtin.csvfile', 'Jane', file='people.csv', delimiter=',', col=0, keycol=1) == \"Smith\"\n",
+    "examples": "\n- name:  Match 'Li' on the first column, return the second column (0 based index)\n  ansible.builtin.debug: msg=\"The atomic number of Lithium is {{ lookup('ansible.builtin.csvfile', 'Li file=elements.csv delimiter=,') }}\"\n\n- name: msg=\"Match 'Li' on the first column, but return the 3rd column (columns start counting after the match)\"\n  ansible.builtin.debug: msg=\"The atomic mass of Lithium is {{ lookup('ansible.builtin.csvfile', 'Li file=elements.csv delimiter=, col=2') }}\"\n\n# Contents of bgp_neighbors.csv\n# 127.0.0.1,10.0.0.1,24,nones,lola,pepe,127.0.0.2\n# 128.0.0.1,10.1.0.1,20,notes,lolita,pepito,128.0.0.2\n# 129.0.0.1,10.2.0.1,23,nines,aayush,pepete,129.0.0.2\n\n- name: Define values from CSV file, this reads file in one go, but you could also use col= to read each in it's own lookup.\n  ansible.builtin.set_fact:\n    '{{ columns[item|int] }}': \"{{ csvline }}\"\n  vars:\n    csvline: \"{{ lookup('csvfile', bgp_neighbor_ip, file='bgp_neighbors.csv', delimiter=',', col=item) }}\"\n    columns: ['loop_ip', 'int_ip', 'int_mask', 'int_name', 'local_as', 'neighbour_as', 'neight_int_ip']\n    bgp_neighbor_ip: '127.0.0.1'\n  loop: '{{ range(columns|length|int) }}'\n  delegate_to: localhost\n  delegate_facts: true\n\n# Contents of people.csv\n# # Last,First,Email,Extension\n# Smith,Jane,jsmith@example.com,1234\n\n- name: Specify the column (by keycol) in which the string should be searched\n  assert:\n    that:\n    - lookup('ansible.builtin.csvfile', 'Jane', file='people.csv', delimiter=',', col=0, keycol=1) == \"Smith\"\n\n# Contents of debug.csv\n# test1 ret1.1 ret2.1\n# test2 ret1.2 ret2.2\n# test3 ret1.3 ret2.3\n\n- name: \"Lookup multiple keynames in the first column (index 0), returning the values from the second column (index 1)\"\n  debug:\n    msg: \"{{ lookup('csvfile', 'test1', 'test2', file='debug.csv', delimiter=' ') }}\"\n\n- name: Lookup multiple keynames using old style syntax\n  debug:\n    msg: \"{{ lookup('csvfile', term1, term2) }}\"\n  vars:\n    term1: \"test1 file=debug.csv delimiter=' '\"\n    term2: \"test2 file=debug.csv delimiter=' '\"\n",
     "metadata": null,
     "return": {
      "_raw": {
@@ -7877,6 +7878,13 @@
       "file": {
        "default": "ansible.ini",
        "description": "Name of the file to load."
+      },
+      "interpolation": {
+       "default": true,
+       "description": "Allows for interpolation of values, see https://docs.python.org/3/library/configparser.html#configparser.BasicInterpolation",
+       "type": "bool",
+       "version_added": "2.18",
+       "version_added_collection": "ansible.builtin"
       },
       "re": {
        "default": false,
@@ -16568,7 +16576,8 @@
         "noop",
         "refresh_inventory",
         "reset_connection",
-        "end_batch"
+        "end_batch",
+        "end_role"
        ],
        "description": [
         "This module takes a free form command, as a string. There is not an actual option named \"free form\".  See the examples!",
@@ -16580,7 +16589,8 @@
         "V(end_play) (added in Ansible 2.2) causes the play to end without failing the host(s). Note that this affects all hosts.",
         "V(reset_connection) (added in Ansible 2.3) interrupts a persistent connection (i.e. ssh + control persist)",
         "V(end_host) (added in Ansible 2.8) is a per-host variation of V(end_play). Causes the play to end for the current host without failing it.",
-        "V(end_batch) (added in Ansible 2.12) causes the current batch (see C(serial)) to end without failing the host(s). Note that with C(serial=0) or undefined this behaves the same as V(end_play)."
+        "V(end_batch) (added in Ansible 2.12) causes the current batch (see C(serial)) to end without failing the host(s). Note that with C(serial=0) or undefined this behaves the same as V(end_play).",
+        "V(end_role) (added in Ansible 2.18) causes the currently executing role to end without failing the host(s). Effectively all tasks from within a role after V(end_role) is executed are ignored. Since handlers live in a global, play scope, all handlers added via the role are unaffected and are still executed if notified. It is an error to call V(end_role) from outside of a role or from a handler. Note that V(end_role) does not have an effect to the parent roles or roles that depend (via dependencies in meta/main.yml) on a role executing V(end_role)."
        ],
        "required": true
       }
@@ -17717,7 +17727,8 @@
         "The long-form fingerprint of the key being imported.",
         "This will be used to verify the specified key."
        ],
-       "type": "str",
+       "elements": "str",
+       "type": "list",
        "version_added": 2.9,
        "version_added_collection": "ansible.builtin"
       },
@@ -17753,7 +17764,7 @@
      "version_added": "1.3",
      "version_added_collection": "ansible.builtin"
     },
-    "examples": "\n- name: Import a key from a url\n  ansible.builtin.rpm_key:\n    state: present\n    key: http://apt.sw.be/RPM-GPG-KEY.dag.txt\n\n- name: Import a key from a file\n  ansible.builtin.rpm_key:\n    state: present\n    key: /path/to/key.gpg\n\n- name: Ensure a key is not present in the db\n  ansible.builtin.rpm_key:\n    state: absent\n    key: DEADB33F\n\n- name: Verify the key, using a fingerprint, before import\n  ansible.builtin.rpm_key:\n    key: /path/to/RPM-GPG-KEY.dag.txt\n    fingerprint: EBC6 E12C 62B1 C734 026B  2122 A20E 5214 6B8D 79E6\n",
+    "examples": "\n- name: Import a key from a url\n  ansible.builtin.rpm_key:\n    state: present\n    key: http://apt.sw.be/RPM-GPG-KEY.dag.txt\n\n- name: Import a key from a file\n  ansible.builtin.rpm_key:\n    state: present\n    key: /path/to/key.gpg\n\n- name: Ensure a key is not present in the db\n  ansible.builtin.rpm_key:\n    state: absent\n    key: DEADB33F\n\n- name: Verify the key, using a fingerprint, before import\n  ansible.builtin.rpm_key:\n    key: /path/to/RPM-GPG-KEY.dag.txt\n    fingerprint: EBC6 E12C 62B1 C734 026B  2122 A20E 5214 6B8D 79E6\n\n- name: Verify the key, using multiple fingerprints, before import\n  ansible.builtin.rpm_key:\n    key: /path/to/RPM-GPG-KEY.dag.txt\n    fingerprint:\n      - EBC6 E12C 62B1 C734 026B  2122 A20E 5214 6B8D 79E6\n      - 19B7 913E 6284 8E3F 4D78 D6B4 ECD9 1AB2 2EB6 8D86\n",
     "metadata": null,
     "return": null
    },
@@ -25393,27 +25404,57 @@
      "author": "Ansible Core",
      "collection": "ansible.builtin",
      "description": [
-      "Verifies if the input is an Ansible vault."
+      "Verifies if the input string is an Ansible vault or not"
      ],
      "filename": "/ansible/plugins/test/vault_encrypted.yml",
-     "name": "truthy",
+     "name": "vault_encrypted",
      "options": {
       "_input": {
-       "description": "The possible vault.",
+       "description": "The possible vault string",
        "required": true,
        "type": "string"
       }
      },
      "plugin_name": "ansible.builtin.vault_encrypted",
-     "short_description": "Is this an encrypted vault",
+     "short_description": "Is this an encrypted vault string",
      "version_added": "2.10",
      "version_added_collection": "ansible.builtin"
     },
-    "examples": "thisisfalse: '{{ \"any string\" is ansible_vault }}'\nthisistrue: '{{ \"$ANSIBLE_VAULT;1.2;AES256;dev....\" is ansible_vault }}'\n",
+    "examples": "thisisfalse: '{{ \"any string\" is vault_encryped}}'\nthisistrue: '{{ \"$ANSIBLE_VAULT;1.2;AES256;dev....\" is vault_encrypted}}'\n",
     "metadata": null,
     "return": {
      "_value": {
       "description": "Returns V(True) if the input is a valid ansible vault, V(False) otherwise.",
+      "type": "boolean"
+     }
+    }
+   },
+   "ansible.builtin.vaulted_file": {
+    "doc": {
+     "author": "Ansible Core",
+     "collection": "ansible.builtin",
+     "description": [
+      "Verifies if the input path is an Ansible vault file."
+     ],
+     "filename": "/ansible/plugins/test/vaulted_file.yml",
+     "name": "vaulted_file",
+     "options": {
+      "_input": {
+       "description": "The path to the possible vault.",
+       "required": true,
+       "type": "path"
+      }
+     },
+     "plugin_name": "ansible.builtin.vaulted_file",
+     "short_description": "Is this file an encrypted vault",
+     "version_added": "2.18",
+     "version_added_collection": "ansible.builtin"
+    },
+    "examples": "thisisfalse: '{{ \"/etc/hosts\" is vaulted_file}}'\nthisistrue: '{{ \"/path/to/vaulted/file\" is vaulted_file}}'\n",
+    "metadata": null,
+    "return": {
+     "_value": {
+      "description": "Returns V(True) if the path is a valid ansible vault, V(False) otherwise.",
       "type": "boolean"
      }
     }

--- a/tests/functional/ansible-doc-cache-ansible.builtin-ns.col2-ns2.col.json
+++ b/tests/functional/ansible-doc-cache-ansible.builtin-ns.col2-ns2.col.json
@@ -7499,7 +7499,8 @@
      "author": "Jan-Piet Mens (@jpmens) <jpmens(at)gmail.com>",
      "collection": "ansible.builtin",
      "description": [
-      "The csvfile lookup reads the contents of a file in CSV (comma-separated value) format. The lookup looks for the row where the first column matches keyname (which can be multiple words) and returns the value in the O(col) column (default 1, which indexed from 0 means the second column in the file)."
+      "The csvfile lookup reads the contents of a file in CSV (comma-separated value) format. The lookup looks for the row where the first column matches keyname (which can be multiple words) and returns the value in the O(col) column (default 1, which indexed from 0 means the second column in the file).",
+      "At least one keyname is required, provided as a positional argument(s) to the lookup."
      ],
      "filename": "/ansible/plugins/lookup/csvfile.py",
      "name": "csvfile",
@@ -7549,7 +7550,7 @@
      "version_added": "1.5",
      "version_added_collection": "ansible.builtin"
     },
-    "examples": "\n- name:  Match 'Li' on the first column, return the second column (0 based index)\n  ansible.builtin.debug: msg=\"The atomic number of Lithium is {{ lookup('ansible.builtin.csvfile', 'Li file=elements.csv delimiter=,') }}\"\n\n- name: msg=\"Match 'Li' on the first column, but return the 3rd column (columns start counting after the match)\"\n  ansible.builtin.debug: msg=\"The atomic mass of Lithium is {{ lookup('ansible.builtin.csvfile', 'Li file=elements.csv delimiter=, col=2') }}\"\n\n# Contents of bgp_neighbors.csv\n# 127.0.0.1,10.0.0.1,24,nones,lola,pepe,127.0.0.2\n# 128.0.0.1,10.1.0.1,20,notes,lolita,pepito,128.0.0.2\n# 129.0.0.1,10.2.0.1,23,nines,aayush,pepete,129.0.0.2\n\n- name: Define values from CSV file, this reads file in one go, but you could also use col= to read each in it's own lookup.\n  ansible.builtin.set_fact:\n    '{{ columns[item|int] }}': \"{{ csvline }}\"\n  vars:\n    csvline: \"{{ lookup('csvfile', bgp_neighbor_ip, file='bgp_neighbors.csv', delimiter=',', col=item) }}\"\n    columns: ['loop_ip', 'int_ip', 'int_mask', 'int_name', 'local_as', 'neighbour_as', 'neight_int_ip']\n    bgp_neighbor_ip: '127.0.0.1'\n  loop: '{{ range(columns|length|int) }}'\n  delegate_to: localhost\n  delegate_facts: true\n\n# Contents of people.csv\n# # Last,First,Email,Extension\n# Smith,Jane,jsmith@example.com,1234\n\n- name: Specify the column (by keycol) in which the string should be searched\n  assert:\n    that:\n    - lookup('ansible.builtin.csvfile', 'Jane', file='people.csv', delimiter=',', col=0, keycol=1) == \"Smith\"\n",
+    "examples": "\n- name:  Match 'Li' on the first column, return the second column (0 based index)\n  ansible.builtin.debug: msg=\"The atomic number of Lithium is {{ lookup('ansible.builtin.csvfile', 'Li file=elements.csv delimiter=,') }}\"\n\n- name: msg=\"Match 'Li' on the first column, but return the 3rd column (columns start counting after the match)\"\n  ansible.builtin.debug: msg=\"The atomic mass of Lithium is {{ lookup('ansible.builtin.csvfile', 'Li file=elements.csv delimiter=, col=2') }}\"\n\n# Contents of bgp_neighbors.csv\n# 127.0.0.1,10.0.0.1,24,nones,lola,pepe,127.0.0.2\n# 128.0.0.1,10.1.0.1,20,notes,lolita,pepito,128.0.0.2\n# 129.0.0.1,10.2.0.1,23,nines,aayush,pepete,129.0.0.2\n\n- name: Define values from CSV file, this reads file in one go, but you could also use col= to read each in it's own lookup.\n  ansible.builtin.set_fact:\n    '{{ columns[item|int] }}': \"{{ csvline }}\"\n  vars:\n    csvline: \"{{ lookup('csvfile', bgp_neighbor_ip, file='bgp_neighbors.csv', delimiter=',', col=item) }}\"\n    columns: ['loop_ip', 'int_ip', 'int_mask', 'int_name', 'local_as', 'neighbour_as', 'neight_int_ip']\n    bgp_neighbor_ip: '127.0.0.1'\n  loop: '{{ range(columns|length|int) }}'\n  delegate_to: localhost\n  delegate_facts: true\n\n# Contents of people.csv\n# # Last,First,Email,Extension\n# Smith,Jane,jsmith@example.com,1234\n\n- name: Specify the column (by keycol) in which the string should be searched\n  assert:\n    that:\n    - lookup('ansible.builtin.csvfile', 'Jane', file='people.csv', delimiter=',', col=0, keycol=1) == \"Smith\"\n\n# Contents of debug.csv\n# test1 ret1.1 ret2.1\n# test2 ret1.2 ret2.2\n# test3 ret1.3 ret2.3\n\n- name: \"Lookup multiple keynames in the first column (index 0), returning the values from the second column (index 1)\"\n  debug:\n    msg: \"{{ lookup('csvfile', 'test1', 'test2', file='debug.csv', delimiter=' ') }}\"\n\n- name: Lookup multiple keynames using old style syntax\n  debug:\n    msg: \"{{ lookup('csvfile', term1, term2) }}\"\n  vars:\n    term1: \"test1 file=debug.csv delimiter=' '\"\n    term2: \"test2 file=debug.csv delimiter=' '\"\n",
     "metadata": null,
     "return": {
      "_raw": {
@@ -7877,6 +7878,13 @@
       "file": {
        "default": "ansible.ini",
        "description": "Name of the file to load."
+      },
+      "interpolation": {
+       "default": true,
+       "description": "Allows for interpolation of values, see https://docs.python.org/3/library/configparser.html#configparser.BasicInterpolation",
+       "type": "bool",
+       "version_added": "2.18",
+       "version_added_collection": "ansible.builtin"
       },
       "re": {
        "default": false,
@@ -16568,7 +16576,8 @@
         "noop",
         "refresh_inventory",
         "reset_connection",
-        "end_batch"
+        "end_batch",
+        "end_role"
        ],
        "description": [
         "This module takes a free form command, as a string. There is not an actual option named \"free form\".  See the examples!",
@@ -16580,7 +16589,8 @@
         "V(end_play) (added in Ansible 2.2) causes the play to end without failing the host(s). Note that this affects all hosts.",
         "V(reset_connection) (added in Ansible 2.3) interrupts a persistent connection (i.e. ssh + control persist)",
         "V(end_host) (added in Ansible 2.8) is a per-host variation of V(end_play). Causes the play to end for the current host without failing it.",
-        "V(end_batch) (added in Ansible 2.12) causes the current batch (see C(serial)) to end without failing the host(s). Note that with C(serial=0) or undefined this behaves the same as V(end_play)."
+        "V(end_batch) (added in Ansible 2.12) causes the current batch (see C(serial)) to end without failing the host(s). Note that with C(serial=0) or undefined this behaves the same as V(end_play).",
+        "V(end_role) (added in Ansible 2.18) causes the currently executing role to end without failing the host(s). Effectively all tasks from within a role after V(end_role) is executed are ignored. Since handlers live in a global, play scope, all handlers added via the role are unaffected and are still executed if notified. It is an error to call V(end_role) from outside of a role or from a handler. Note that V(end_role) does not have an effect to the parent roles or roles that depend (via dependencies in meta/main.yml) on a role executing V(end_role)."
        ],
        "required": true
       }
@@ -17717,7 +17727,8 @@
         "The long-form fingerprint of the key being imported.",
         "This will be used to verify the specified key."
        ],
-       "type": "str",
+       "elements": "str",
+       "type": "list",
        "version_added": 2.9,
        "version_added_collection": "ansible.builtin"
       },
@@ -17753,7 +17764,7 @@
      "version_added": "1.3",
      "version_added_collection": "ansible.builtin"
     },
-    "examples": "\n- name: Import a key from a url\n  ansible.builtin.rpm_key:\n    state: present\n    key: http://apt.sw.be/RPM-GPG-KEY.dag.txt\n\n- name: Import a key from a file\n  ansible.builtin.rpm_key:\n    state: present\n    key: /path/to/key.gpg\n\n- name: Ensure a key is not present in the db\n  ansible.builtin.rpm_key:\n    state: absent\n    key: DEADB33F\n\n- name: Verify the key, using a fingerprint, before import\n  ansible.builtin.rpm_key:\n    key: /path/to/RPM-GPG-KEY.dag.txt\n    fingerprint: EBC6 E12C 62B1 C734 026B  2122 A20E 5214 6B8D 79E6\n",
+    "examples": "\n- name: Import a key from a url\n  ansible.builtin.rpm_key:\n    state: present\n    key: http://apt.sw.be/RPM-GPG-KEY.dag.txt\n\n- name: Import a key from a file\n  ansible.builtin.rpm_key:\n    state: present\n    key: /path/to/key.gpg\n\n- name: Ensure a key is not present in the db\n  ansible.builtin.rpm_key:\n    state: absent\n    key: DEADB33F\n\n- name: Verify the key, using a fingerprint, before import\n  ansible.builtin.rpm_key:\n    key: /path/to/RPM-GPG-KEY.dag.txt\n    fingerprint: EBC6 E12C 62B1 C734 026B  2122 A20E 5214 6B8D 79E6\n\n- name: Verify the key, using multiple fingerprints, before import\n  ansible.builtin.rpm_key:\n    key: /path/to/RPM-GPG-KEY.dag.txt\n    fingerprint:\n      - EBC6 E12C 62B1 C734 026B  2122 A20E 5214 6B8D 79E6\n      - 19B7 913E 6284 8E3F 4D78 D6B4 ECD9 1AB2 2EB6 8D86\n",
     "metadata": null,
     "return": null
    },
@@ -25275,27 +25286,57 @@
      "author": "Ansible Core",
      "collection": "ansible.builtin",
      "description": [
-      "Verifies if the input is an Ansible vault."
+      "Verifies if the input string is an Ansible vault or not"
      ],
      "filename": "/ansible/plugins/test/vault_encrypted.yml",
-     "name": "truthy",
+     "name": "vault_encrypted",
      "options": {
       "_input": {
-       "description": "The possible vault.",
+       "description": "The possible vault string",
        "required": true,
        "type": "string"
       }
      },
      "plugin_name": "ansible.builtin.vault_encrypted",
-     "short_description": "Is this an encrypted vault",
+     "short_description": "Is this an encrypted vault string",
      "version_added": "2.10",
      "version_added_collection": "ansible.builtin"
     },
-    "examples": "thisisfalse: '{{ \"any string\" is ansible_vault }}'\nthisistrue: '{{ \"$ANSIBLE_VAULT;1.2;AES256;dev....\" is ansible_vault }}'\n",
+    "examples": "thisisfalse: '{{ \"any string\" is vault_encryped}}'\nthisistrue: '{{ \"$ANSIBLE_VAULT;1.2;AES256;dev....\" is vault_encrypted}}'\n",
     "metadata": null,
     "return": {
      "_value": {
       "description": "Returns V(True) if the input is a valid ansible vault, V(False) otherwise.",
+      "type": "boolean"
+     }
+    }
+   },
+   "ansible.builtin.vaulted_file": {
+    "doc": {
+     "author": "Ansible Core",
+     "collection": "ansible.builtin",
+     "description": [
+      "Verifies if the input path is an Ansible vault file."
+     ],
+     "filename": "/ansible/plugins/test/vaulted_file.yml",
+     "name": "vaulted_file",
+     "options": {
+      "_input": {
+       "description": "The path to the possible vault.",
+       "required": true,
+       "type": "path"
+      }
+     },
+     "plugin_name": "ansible.builtin.vaulted_file",
+     "short_description": "Is this file an encrypted vault",
+     "version_added": "2.18",
+     "version_added_collection": "ansible.builtin"
+    },
+    "examples": "thisisfalse: '{{ \"/etc/hosts\" is vaulted_file}}'\nthisistrue: '{{ \"/path/to/vaulted/file\" is vaulted_file}}'\n",
+    "metadata": null,
+    "return": {
+     "_value": {
+      "description": "Returns V(True) if the path is a valid ansible vault, V(False) otherwise.",
       "type": "boolean"
      }
     }

--- a/tests/functional/ansible-doc-cache-ansible.builtin-ns2.col.json
+++ b/tests/functional/ansible-doc-cache-ansible.builtin-ns2.col.json
@@ -7499,7 +7499,8 @@
      "author": "Jan-Piet Mens (@jpmens) <jpmens(at)gmail.com>",
      "collection": "ansible.builtin",
      "description": [
-      "The csvfile lookup reads the contents of a file in CSV (comma-separated value) format. The lookup looks for the row where the first column matches keyname (which can be multiple words) and returns the value in the O(col) column (default 1, which indexed from 0 means the second column in the file)."
+      "The csvfile lookup reads the contents of a file in CSV (comma-separated value) format. The lookup looks for the row where the first column matches keyname (which can be multiple words) and returns the value in the O(col) column (default 1, which indexed from 0 means the second column in the file).",
+      "At least one keyname is required, provided as a positional argument(s) to the lookup."
      ],
      "filename": "/ansible/plugins/lookup/csvfile.py",
      "name": "csvfile",
@@ -7549,7 +7550,7 @@
      "version_added": "1.5",
      "version_added_collection": "ansible.builtin"
     },
-    "examples": "\n- name:  Match 'Li' on the first column, return the second column (0 based index)\n  ansible.builtin.debug: msg=\"The atomic number of Lithium is {{ lookup('ansible.builtin.csvfile', 'Li file=elements.csv delimiter=,') }}\"\n\n- name: msg=\"Match 'Li' on the first column, but return the 3rd column (columns start counting after the match)\"\n  ansible.builtin.debug: msg=\"The atomic mass of Lithium is {{ lookup('ansible.builtin.csvfile', 'Li file=elements.csv delimiter=, col=2') }}\"\n\n# Contents of bgp_neighbors.csv\n# 127.0.0.1,10.0.0.1,24,nones,lola,pepe,127.0.0.2\n# 128.0.0.1,10.1.0.1,20,notes,lolita,pepito,128.0.0.2\n# 129.0.0.1,10.2.0.1,23,nines,aayush,pepete,129.0.0.2\n\n- name: Define values from CSV file, this reads file in one go, but you could also use col= to read each in it's own lookup.\n  ansible.builtin.set_fact:\n    '{{ columns[item|int] }}': \"{{ csvline }}\"\n  vars:\n    csvline: \"{{ lookup('csvfile', bgp_neighbor_ip, file='bgp_neighbors.csv', delimiter=',', col=item) }}\"\n    columns: ['loop_ip', 'int_ip', 'int_mask', 'int_name', 'local_as', 'neighbour_as', 'neight_int_ip']\n    bgp_neighbor_ip: '127.0.0.1'\n  loop: '{{ range(columns|length|int) }}'\n  delegate_to: localhost\n  delegate_facts: true\n\n# Contents of people.csv\n# # Last,First,Email,Extension\n# Smith,Jane,jsmith@example.com,1234\n\n- name: Specify the column (by keycol) in which the string should be searched\n  assert:\n    that:\n    - lookup('ansible.builtin.csvfile', 'Jane', file='people.csv', delimiter=',', col=0, keycol=1) == \"Smith\"\n",
+    "examples": "\n- name:  Match 'Li' on the first column, return the second column (0 based index)\n  ansible.builtin.debug: msg=\"The atomic number of Lithium is {{ lookup('ansible.builtin.csvfile', 'Li file=elements.csv delimiter=,') }}\"\n\n- name: msg=\"Match 'Li' on the first column, but return the 3rd column (columns start counting after the match)\"\n  ansible.builtin.debug: msg=\"The atomic mass of Lithium is {{ lookup('ansible.builtin.csvfile', 'Li file=elements.csv delimiter=, col=2') }}\"\n\n# Contents of bgp_neighbors.csv\n# 127.0.0.1,10.0.0.1,24,nones,lola,pepe,127.0.0.2\n# 128.0.0.1,10.1.0.1,20,notes,lolita,pepito,128.0.0.2\n# 129.0.0.1,10.2.0.1,23,nines,aayush,pepete,129.0.0.2\n\n- name: Define values from CSV file, this reads file in one go, but you could also use col= to read each in it's own lookup.\n  ansible.builtin.set_fact:\n    '{{ columns[item|int] }}': \"{{ csvline }}\"\n  vars:\n    csvline: \"{{ lookup('csvfile', bgp_neighbor_ip, file='bgp_neighbors.csv', delimiter=',', col=item) }}\"\n    columns: ['loop_ip', 'int_ip', 'int_mask', 'int_name', 'local_as', 'neighbour_as', 'neight_int_ip']\n    bgp_neighbor_ip: '127.0.0.1'\n  loop: '{{ range(columns|length|int) }}'\n  delegate_to: localhost\n  delegate_facts: true\n\n# Contents of people.csv\n# # Last,First,Email,Extension\n# Smith,Jane,jsmith@example.com,1234\n\n- name: Specify the column (by keycol) in which the string should be searched\n  assert:\n    that:\n    - lookup('ansible.builtin.csvfile', 'Jane', file='people.csv', delimiter=',', col=0, keycol=1) == \"Smith\"\n\n# Contents of debug.csv\n# test1 ret1.1 ret2.1\n# test2 ret1.2 ret2.2\n# test3 ret1.3 ret2.3\n\n- name: \"Lookup multiple keynames in the first column (index 0), returning the values from the second column (index 1)\"\n  debug:\n    msg: \"{{ lookup('csvfile', 'test1', 'test2', file='debug.csv', delimiter=' ') }}\"\n\n- name: Lookup multiple keynames using old style syntax\n  debug:\n    msg: \"{{ lookup('csvfile', term1, term2) }}\"\n  vars:\n    term1: \"test1 file=debug.csv delimiter=' '\"\n    term2: \"test2 file=debug.csv delimiter=' '\"\n",
     "metadata": null,
     "return": {
      "_raw": {
@@ -7877,6 +7878,13 @@
       "file": {
        "default": "ansible.ini",
        "description": "Name of the file to load."
+      },
+      "interpolation": {
+       "default": true,
+       "description": "Allows for interpolation of values, see https://docs.python.org/3/library/configparser.html#configparser.BasicInterpolation",
+       "type": "bool",
+       "version_added": "2.18",
+       "version_added_collection": "ansible.builtin"
       },
       "re": {
        "default": false,
@@ -16568,7 +16576,8 @@
         "noop",
         "refresh_inventory",
         "reset_connection",
-        "end_batch"
+        "end_batch",
+        "end_role"
        ],
        "description": [
         "This module takes a free form command, as a string. There is not an actual option named \"free form\".  See the examples!",
@@ -16580,7 +16589,8 @@
         "V(end_play) (added in Ansible 2.2) causes the play to end without failing the host(s). Note that this affects all hosts.",
         "V(reset_connection) (added in Ansible 2.3) interrupts a persistent connection (i.e. ssh + control persist)",
         "V(end_host) (added in Ansible 2.8) is a per-host variation of V(end_play). Causes the play to end for the current host without failing it.",
-        "V(end_batch) (added in Ansible 2.12) causes the current batch (see C(serial)) to end without failing the host(s). Note that with C(serial=0) or undefined this behaves the same as V(end_play)."
+        "V(end_batch) (added in Ansible 2.12) causes the current batch (see C(serial)) to end without failing the host(s). Note that with C(serial=0) or undefined this behaves the same as V(end_play).",
+        "V(end_role) (added in Ansible 2.18) causes the currently executing role to end without failing the host(s). Effectively all tasks from within a role after V(end_role) is executed are ignored. Since handlers live in a global, play scope, all handlers added via the role are unaffected and are still executed if notified. It is an error to call V(end_role) from outside of a role or from a handler. Note that V(end_role) does not have an effect to the parent roles or roles that depend (via dependencies in meta/main.yml) on a role executing V(end_role)."
        ],
        "required": true
       }
@@ -17717,7 +17727,8 @@
         "The long-form fingerprint of the key being imported.",
         "This will be used to verify the specified key."
        ],
-       "type": "str",
+       "elements": "str",
+       "type": "list",
        "version_added": 2.9,
        "version_added_collection": "ansible.builtin"
       },
@@ -17753,7 +17764,7 @@
      "version_added": "1.3",
      "version_added_collection": "ansible.builtin"
     },
-    "examples": "\n- name: Import a key from a url\n  ansible.builtin.rpm_key:\n    state: present\n    key: http://apt.sw.be/RPM-GPG-KEY.dag.txt\n\n- name: Import a key from a file\n  ansible.builtin.rpm_key:\n    state: present\n    key: /path/to/key.gpg\n\n- name: Ensure a key is not present in the db\n  ansible.builtin.rpm_key:\n    state: absent\n    key: DEADB33F\n\n- name: Verify the key, using a fingerprint, before import\n  ansible.builtin.rpm_key:\n    key: /path/to/RPM-GPG-KEY.dag.txt\n    fingerprint: EBC6 E12C 62B1 C734 026B  2122 A20E 5214 6B8D 79E6\n",
+    "examples": "\n- name: Import a key from a url\n  ansible.builtin.rpm_key:\n    state: present\n    key: http://apt.sw.be/RPM-GPG-KEY.dag.txt\n\n- name: Import a key from a file\n  ansible.builtin.rpm_key:\n    state: present\n    key: /path/to/key.gpg\n\n- name: Ensure a key is not present in the db\n  ansible.builtin.rpm_key:\n    state: absent\n    key: DEADB33F\n\n- name: Verify the key, using a fingerprint, before import\n  ansible.builtin.rpm_key:\n    key: /path/to/RPM-GPG-KEY.dag.txt\n    fingerprint: EBC6 E12C 62B1 C734 026B  2122 A20E 5214 6B8D 79E6\n\n- name: Verify the key, using multiple fingerprints, before import\n  ansible.builtin.rpm_key:\n    key: /path/to/RPM-GPG-KEY.dag.txt\n    fingerprint:\n      - EBC6 E12C 62B1 C734 026B  2122 A20E 5214 6B8D 79E6\n      - 19B7 913E 6284 8E3F 4D78 D6B4 ECD9 1AB2 2EB6 8D86\n",
     "metadata": null,
     "return": null
    },
@@ -24852,27 +24863,57 @@
      "author": "Ansible Core",
      "collection": "ansible.builtin",
      "description": [
-      "Verifies if the input is an Ansible vault."
+      "Verifies if the input string is an Ansible vault or not"
      ],
      "filename": "/ansible/plugins/test/vault_encrypted.yml",
-     "name": "truthy",
+     "name": "vault_encrypted",
      "options": {
       "_input": {
-       "description": "The possible vault.",
+       "description": "The possible vault string",
        "required": true,
        "type": "string"
       }
      },
      "plugin_name": "ansible.builtin.vault_encrypted",
-     "short_description": "Is this an encrypted vault",
+     "short_description": "Is this an encrypted vault string",
      "version_added": "2.10",
      "version_added_collection": "ansible.builtin"
     },
-    "examples": "thisisfalse: '{{ \"any string\" is ansible_vault }}'\nthisistrue: '{{ \"$ANSIBLE_VAULT;1.2;AES256;dev....\" is ansible_vault }}'\n",
+    "examples": "thisisfalse: '{{ \"any string\" is vault_encryped}}'\nthisistrue: '{{ \"$ANSIBLE_VAULT;1.2;AES256;dev....\" is vault_encrypted}}'\n",
     "metadata": null,
     "return": {
      "_value": {
       "description": "Returns V(True) if the input is a valid ansible vault, V(False) otherwise.",
+      "type": "boolean"
+     }
+    }
+   },
+   "ansible.builtin.vaulted_file": {
+    "doc": {
+     "author": "Ansible Core",
+     "collection": "ansible.builtin",
+     "description": [
+      "Verifies if the input path is an Ansible vault file."
+     ],
+     "filename": "/ansible/plugins/test/vaulted_file.yml",
+     "name": "vaulted_file",
+     "options": {
+      "_input": {
+       "description": "The path to the possible vault.",
+       "required": true,
+       "type": "path"
+      }
+     },
+     "plugin_name": "ansible.builtin.vaulted_file",
+     "short_description": "Is this file an encrypted vault",
+     "version_added": "2.18",
+     "version_added_collection": "ansible.builtin"
+    },
+    "examples": "thisisfalse: '{{ \"/etc/hosts\" is vaulted_file}}'\nthisistrue: '{{ \"/path/to/vaulted/file\" is vaulted_file}}'\n",
+    "metadata": null,
+    "return": {
+     "_value": {
+      "description": "Returns V(True) if the path is a valid ansible vault, V(False) otherwise.",
       "type": "boolean"
      }
     }

--- a/tests/functional/ansible-doc-cache-ansible.builtin-ns2.flatcol.json
+++ b/tests/functional/ansible-doc-cache-ansible.builtin-ns2.flatcol.json
@@ -7110,7 +7110,8 @@
      "author": "Jan-Piet Mens (@jpmens) <jpmens(at)gmail.com>",
      "collection": "ansible.builtin",
      "description": [
-      "The csvfile lookup reads the contents of a file in CSV (comma-separated value) format. The lookup looks for the row where the first column matches keyname (which can be multiple words) and returns the value in the O(col) column (default 1, which indexed from 0 means the second column in the file)."
+      "The csvfile lookup reads the contents of a file in CSV (comma-separated value) format. The lookup looks for the row where the first column matches keyname (which can be multiple words) and returns the value in the O(col) column (default 1, which indexed from 0 means the second column in the file).",
+      "At least one keyname is required, provided as a positional argument(s) to the lookup."
      ],
      "filename": "/ansible/plugins/lookup/csvfile.py",
      "name": "csvfile",
@@ -7160,7 +7161,7 @@
      "version_added": "1.5",
      "version_added_collection": "ansible.builtin"
     },
-    "examples": "\n- name:  Match 'Li' on the first column, return the second column (0 based index)\n  ansible.builtin.debug: msg=\"The atomic number of Lithium is {{ lookup('ansible.builtin.csvfile', 'Li file=elements.csv delimiter=,') }}\"\n\n- name: msg=\"Match 'Li' on the first column, but return the 3rd column (columns start counting after the match)\"\n  ansible.builtin.debug: msg=\"The atomic mass of Lithium is {{ lookup('ansible.builtin.csvfile', 'Li file=elements.csv delimiter=, col=2') }}\"\n\n# Contents of bgp_neighbors.csv\n# 127.0.0.1,10.0.0.1,24,nones,lola,pepe,127.0.0.2\n# 128.0.0.1,10.1.0.1,20,notes,lolita,pepito,128.0.0.2\n# 129.0.0.1,10.2.0.1,23,nines,aayush,pepete,129.0.0.2\n\n- name: Define values from CSV file, this reads file in one go, but you could also use col= to read each in it's own lookup.\n  ansible.builtin.set_fact:\n    '{{ columns[item|int] }}': \"{{ csvline }}\"\n  vars:\n    csvline: \"{{ lookup('csvfile', bgp_neighbor_ip, file='bgp_neighbors.csv', delimiter=',', col=item) }}\"\n    columns: ['loop_ip', 'int_ip', 'int_mask', 'int_name', 'local_as', 'neighbour_as', 'neight_int_ip']\n    bgp_neighbor_ip: '127.0.0.1'\n  loop: '{{ range(columns|length|int) }}'\n  delegate_to: localhost\n  delegate_facts: true\n\n# Contents of people.csv\n# # Last,First,Email,Extension\n# Smith,Jane,jsmith@example.com,1234\n\n- name: Specify the column (by keycol) in which the string should be searched\n  assert:\n    that:\n    - lookup('ansible.builtin.csvfile', 'Jane', file='people.csv', delimiter=',', col=0, keycol=1) == \"Smith\"\n",
+    "examples": "\n- name:  Match 'Li' on the first column, return the second column (0 based index)\n  ansible.builtin.debug: msg=\"The atomic number of Lithium is {{ lookup('ansible.builtin.csvfile', 'Li file=elements.csv delimiter=,') }}\"\n\n- name: msg=\"Match 'Li' on the first column, but return the 3rd column (columns start counting after the match)\"\n  ansible.builtin.debug: msg=\"The atomic mass of Lithium is {{ lookup('ansible.builtin.csvfile', 'Li file=elements.csv delimiter=, col=2') }}\"\n\n# Contents of bgp_neighbors.csv\n# 127.0.0.1,10.0.0.1,24,nones,lola,pepe,127.0.0.2\n# 128.0.0.1,10.1.0.1,20,notes,lolita,pepito,128.0.0.2\n# 129.0.0.1,10.2.0.1,23,nines,aayush,pepete,129.0.0.2\n\n- name: Define values from CSV file, this reads file in one go, but you could also use col= to read each in it's own lookup.\n  ansible.builtin.set_fact:\n    '{{ columns[item|int] }}': \"{{ csvline }}\"\n  vars:\n    csvline: \"{{ lookup('csvfile', bgp_neighbor_ip, file='bgp_neighbors.csv', delimiter=',', col=item) }}\"\n    columns: ['loop_ip', 'int_ip', 'int_mask', 'int_name', 'local_as', 'neighbour_as', 'neight_int_ip']\n    bgp_neighbor_ip: '127.0.0.1'\n  loop: '{{ range(columns|length|int) }}'\n  delegate_to: localhost\n  delegate_facts: true\n\n# Contents of people.csv\n# # Last,First,Email,Extension\n# Smith,Jane,jsmith@example.com,1234\n\n- name: Specify the column (by keycol) in which the string should be searched\n  assert:\n    that:\n    - lookup('ansible.builtin.csvfile', 'Jane', file='people.csv', delimiter=',', col=0, keycol=1) == \"Smith\"\n\n# Contents of debug.csv\n# test1 ret1.1 ret2.1\n# test2 ret1.2 ret2.2\n# test3 ret1.3 ret2.3\n\n- name: \"Lookup multiple keynames in the first column (index 0), returning the values from the second column (index 1)\"\n  debug:\n    msg: \"{{ lookup('csvfile', 'test1', 'test2', file='debug.csv', delimiter=' ') }}\"\n\n- name: Lookup multiple keynames using old style syntax\n  debug:\n    msg: \"{{ lookup('csvfile', term1, term2) }}\"\n  vars:\n    term1: \"test1 file=debug.csv delimiter=' '\"\n    term2: \"test2 file=debug.csv delimiter=' '\"\n",
     "metadata": null,
     "return": {
      "_raw": {
@@ -7488,6 +7489,13 @@
       "file": {
        "default": "ansible.ini",
        "description": "Name of the file to load."
+      },
+      "interpolation": {
+       "default": true,
+       "description": "Allows for interpolation of values, see https://docs.python.org/3/library/configparser.html#configparser.BasicInterpolation",
+       "type": "bool",
+       "version_added": "2.18",
+       "version_added_collection": "ansible.builtin"
       },
       "re": {
        "default": false,
@@ -16140,7 +16148,8 @@
         "noop",
         "refresh_inventory",
         "reset_connection",
-        "end_batch"
+        "end_batch",
+        "end_role"
        ],
        "description": [
         "This module takes a free form command, as a string. There is not an actual option named \"free form\".  See the examples!",
@@ -16152,7 +16161,8 @@
         "V(end_play) (added in Ansible 2.2) causes the play to end without failing the host(s). Note that this affects all hosts.",
         "V(reset_connection) (added in Ansible 2.3) interrupts a persistent connection (i.e. ssh + control persist)",
         "V(end_host) (added in Ansible 2.8) is a per-host variation of V(end_play). Causes the play to end for the current host without failing it.",
-        "V(end_batch) (added in Ansible 2.12) causes the current batch (see C(serial)) to end without failing the host(s). Note that with C(serial=0) or undefined this behaves the same as V(end_play)."
+        "V(end_batch) (added in Ansible 2.12) causes the current batch (see C(serial)) to end without failing the host(s). Note that with C(serial=0) or undefined this behaves the same as V(end_play).",
+        "V(end_role) (added in Ansible 2.18) causes the currently executing role to end without failing the host(s). Effectively all tasks from within a role after V(end_role) is executed are ignored. Since handlers live in a global, play scope, all handlers added via the role are unaffected and are still executed if notified. It is an error to call V(end_role) from outside of a role or from a handler. Note that V(end_role) does not have an effect to the parent roles or roles that depend (via dependencies in meta/main.yml) on a role executing V(end_role)."
        ],
        "required": true
       }
@@ -17289,7 +17299,8 @@
         "The long-form fingerprint of the key being imported.",
         "This will be used to verify the specified key."
        ],
-       "type": "str",
+       "elements": "str",
+       "type": "list",
        "version_added": 2.9,
        "version_added_collection": "ansible.builtin"
       },
@@ -17325,7 +17336,7 @@
      "version_added": "1.3",
      "version_added_collection": "ansible.builtin"
     },
-    "examples": "\n- name: Import a key from a url\n  ansible.builtin.rpm_key:\n    state: present\n    key: http://apt.sw.be/RPM-GPG-KEY.dag.txt\n\n- name: Import a key from a file\n  ansible.builtin.rpm_key:\n    state: present\n    key: /path/to/key.gpg\n\n- name: Ensure a key is not present in the db\n  ansible.builtin.rpm_key:\n    state: absent\n    key: DEADB33F\n\n- name: Verify the key, using a fingerprint, before import\n  ansible.builtin.rpm_key:\n    key: /path/to/RPM-GPG-KEY.dag.txt\n    fingerprint: EBC6 E12C 62B1 C734 026B  2122 A20E 5214 6B8D 79E6\n",
+    "examples": "\n- name: Import a key from a url\n  ansible.builtin.rpm_key:\n    state: present\n    key: http://apt.sw.be/RPM-GPG-KEY.dag.txt\n\n- name: Import a key from a file\n  ansible.builtin.rpm_key:\n    state: present\n    key: /path/to/key.gpg\n\n- name: Ensure a key is not present in the db\n  ansible.builtin.rpm_key:\n    state: absent\n    key: DEADB33F\n\n- name: Verify the key, using a fingerprint, before import\n  ansible.builtin.rpm_key:\n    key: /path/to/RPM-GPG-KEY.dag.txt\n    fingerprint: EBC6 E12C 62B1 C734 026B  2122 A20E 5214 6B8D 79E6\n\n- name: Verify the key, using multiple fingerprints, before import\n  ansible.builtin.rpm_key:\n    key: /path/to/RPM-GPG-KEY.dag.txt\n    fingerprint:\n      - EBC6 E12C 62B1 C734 026B  2122 A20E 5214 6B8D 79E6\n      - 19B7 913E 6284 8E3F 4D78 D6B4 ECD9 1AB2 2EB6 8D86\n",
     "metadata": null,
     "return": null
    },
@@ -24148,27 +24159,57 @@
      "author": "Ansible Core",
      "collection": "ansible.builtin",
      "description": [
-      "Verifies if the input is an Ansible vault."
+      "Verifies if the input string is an Ansible vault or not"
      ],
      "filename": "/ansible/plugins/test/vault_encrypted.yml",
-     "name": "truthy",
+     "name": "vault_encrypted",
      "options": {
       "_input": {
-       "description": "The possible vault.",
+       "description": "The possible vault string",
        "required": true,
        "type": "string"
       }
      },
      "plugin_name": "ansible.builtin.vault_encrypted",
-     "short_description": "Is this an encrypted vault",
+     "short_description": "Is this an encrypted vault string",
      "version_added": "2.10",
      "version_added_collection": "ansible.builtin"
     },
-    "examples": "thisisfalse: '{{ \"any string\" is ansible_vault }}'\nthisistrue: '{{ \"$ANSIBLE_VAULT;1.2;AES256;dev....\" is ansible_vault }}'\n",
+    "examples": "thisisfalse: '{{ \"any string\" is vault_encryped}}'\nthisistrue: '{{ \"$ANSIBLE_VAULT;1.2;AES256;dev....\" is vault_encrypted}}'\n",
     "metadata": null,
     "return": {
      "_value": {
       "description": "Returns V(True) if the input is a valid ansible vault, V(False) otherwise.",
+      "type": "boolean"
+     }
+    }
+   },
+   "ansible.builtin.vaulted_file": {
+    "doc": {
+     "author": "Ansible Core",
+     "collection": "ansible.builtin",
+     "description": [
+      "Verifies if the input path is an Ansible vault file."
+     ],
+     "filename": "/ansible/plugins/test/vaulted_file.yml",
+     "name": "vaulted_file",
+     "options": {
+      "_input": {
+       "description": "The path to the possible vault.",
+       "required": true,
+       "type": "path"
+      }
+     },
+     "plugin_name": "ansible.builtin.vaulted_file",
+     "short_description": "Is this file an encrypted vault",
+     "version_added": "2.18",
+     "version_added_collection": "ansible.builtin"
+    },
+    "examples": "thisisfalse: '{{ \"/etc/hosts\" is vaulted_file}}'\nthisistrue: '{{ \"/path/to/vaulted/file\" is vaulted_file}}'\n",
+    "metadata": null,
+    "return": {
+     "_value": {
+      "description": "Returns V(True) if the path is a valid ansible vault, V(False) otherwise.",
       "type": "boolean"
      }
     }

--- a/tests/functional/ansible-version.output
+++ b/tests/functional/ansible-version.output
@@ -1,4 +1,4 @@
-ansible [core 2.18.0.dev0] (devel 207a5fbebb) last updated 2024/08/05 09:57:47 (GMT +200)
+ansible [core 2.18.0.dev0] (devel b5e0293645) last updated 2024/08/23 09:10:39 (GMT +200)
   config file = None
   configured module search path = ['<<<<<HOME>>>>>/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
   ansible python module location = <<<<<ANSIBLE>>>>>

--- a/tests/functional/baseline-default/collections/callback_index_stdout.rst
+++ b/tests/functional/baseline-default/collections/callback_index_stdout.rst
@@ -14,5 +14,5 @@ See :ref:`list_of_callback_plugins` for the list of *all* callback plugins.
 ns2.col
 -------
 
-* :ansplugin:`ns2.col.foo#callback` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
+* :ansplugin:`ns2.col.foo#callback` -- Foo output :ansopt:`ns2.col.foo#callback:bar`
 

--- a/tests/functional/baseline-default/collections/index_become.rst
+++ b/tests/functional/baseline-default/collections/index_become.rst
@@ -12,5 +12,5 @@ Index of all Become Plugins
 ns2.col
 -------
 
-* :ansplugin:`ns2.col.foo#become` -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
+* :ansplugin:`ns2.col.foo#become` -- Use foo :ansopt:`ns2.col.foo#become:bar`
 

--- a/tests/functional/baseline-default/collections/index_cache.rst
+++ b/tests/functional/baseline-default/collections/index_cache.rst
@@ -12,5 +12,5 @@ Index of all Cache Plugins
 ns2.col
 -------
 
-* :ansplugin:`ns2.col.foo#cache` -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
+* :ansplugin:`ns2.col.foo#cache` -- Foo files :ansopt:`ns2.col.foo#cache:bar`
 

--- a/tests/functional/baseline-default/collections/index_callback.rst
+++ b/tests/functional/baseline-default/collections/index_callback.rst
@@ -20,5 +20,5 @@ Index of all Callback Plugins
 ns2.col
 -------
 
-* :ansplugin:`ns2.col.foo#callback` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
+* :ansplugin:`ns2.col.foo#callback` -- Foo output :ansopt:`ns2.col.foo#callback:bar`
 

--- a/tests/functional/baseline-default/collections/index_connection.rst
+++ b/tests/functional/baseline-default/collections/index_connection.rst
@@ -12,5 +12,5 @@ Index of all Connection Plugins
 ns2.col
 -------
 
-* :ansplugin:`ns2.col.foo#connection` -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
+* :ansplugin:`ns2.col.foo#connection` -- Foo connection :ansopt:`ns2.col.foo#connection:bar`
 

--- a/tests/functional/baseline-default/collections/index_filter.rst
+++ b/tests/functional/baseline-default/collections/index_filter.rst
@@ -13,5 +13,5 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.bar#filter` -- The bar filter
-* :ansplugin:`ns2.col.foo#filter` -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
+* :ansplugin:`ns2.col.foo#filter` -- The foo filter :ansopt:`ns2.col.foo#filter:bar`
 

--- a/tests/functional/baseline-default/collections/index_inventory.rst
+++ b/tests/functional/baseline-default/collections/index_inventory.rst
@@ -12,5 +12,5 @@ Index of all Inventory Plugins
 ns2.col
 -------
 
-* :ansplugin:`ns2.col.foo#inventory` -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
+* :ansplugin:`ns2.col.foo#inventory` -- The foo inventory :ansopt:`ns2.col.foo#inventory:bar`
 

--- a/tests/functional/baseline-default/collections/index_lookup.rst
+++ b/tests/functional/baseline-default/collections/index_lookup.rst
@@ -12,5 +12,5 @@ Index of all Lookup Plugins
 ns2.col
 -------
 
-* :ansplugin:`ns2.col.foo#lookup` -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
+* :ansplugin:`ns2.col.foo#lookup` -- Look up some foo :ansopt:`ns2.col.foo#lookup:bar`
 

--- a/tests/functional/baseline-default/collections/index_module.rst
+++ b/tests/functional/baseline-default/collections/index_module.rst
@@ -20,13 +20,13 @@ ns.col2
 ns2.col
 -------
 
-* :ansplugin:`ns2.col.foo#module` -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
+* :ansplugin:`ns2.col.foo#module` -- Do some foo :ansopt:`ns2.col.foo#module:bar`
 * :ansplugin:`ns2.col.foo2#module` -- Another foo
 * :ansplugin:`ns2.col.sub.foo3#module` -- A sub-foo
 
 ns2.flatcol
 -----------
 
-* :ansplugin:`ns2.flatcol.foo#module` -- Do some foo \ :ansopt:`ns2.flatcol.foo#module:bar`\ 
+* :ansplugin:`ns2.flatcol.foo#module` -- Do some foo :ansopt:`ns2.flatcol.foo#module:bar`
 * :ansplugin:`ns2.flatcol.foo2#module` -- Another foo
 

--- a/tests/functional/baseline-default/collections/index_shell.rst
+++ b/tests/functional/baseline-default/collections/index_shell.rst
@@ -12,5 +12,5 @@ Index of all Shell Plugins
 ns2.col
 -------
 
-* :ansplugin:`ns2.col.foo#shell` -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
+* :ansplugin:`ns2.col.foo#shell` -- Foo shell :ansopt:`ns2.col.foo#shell:bar`
 

--- a/tests/functional/baseline-default/collections/index_test.rst
+++ b/tests/functional/baseline-default/collections/index_test.rst
@@ -13,5 +13,5 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.bar#test` -- Is something a bar
-* :ansplugin:`ns2.col.foo#test` -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
+* :ansplugin:`ns2.col.foo#test` -- Is something a foo :ansopt:`ns2.col.foo#test:bar`
 

--- a/tests/functional/baseline-default/collections/index_vars.rst
+++ b/tests/functional/baseline-default/collections/index_vars.rst
@@ -12,5 +12,5 @@ Index of all Vars Plugins
 ns2.col
 -------
 
-* :ansplugin:`ns2.col.foo#vars` -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
+* :ansplugin:`ns2.col.foo#vars` -- Load foo :ansopt:`ns2.col.foo#vars:bar`
 

--- a/tests/functional/baseline-default/collections/ns/col2/foo2_module.rst
+++ b/tests/functional/baseline-default/collections/ns/col2/foo2_module.rst
@@ -50,17 +50,16 @@ Synopsis
 .. Description
 
 - Does some foo on the remote host.
-- A broken reference \ :ref:`asdfasdfoobarTHISDOESNOTEXIST <asdfasdfoobarTHISDOESNOTEXIST>`\ .
-- The option \ :ansopt:`ns.col2.foo2#module:foo`\  exists, but \ :ansopt:`ns.col2.foo2#module:foobar`\  does not.
-- The return value \ :ansretval:`ns.col2.foo2#module:bar`\  exists, but \ :ansretval:`ns.col2.foo2#module:barbaz`\  does not.
-- Again existing: \ :ansopt:`ns.col2.foo#module:foo=1`\ , \ :ansretval:`ns.col2.foo#module:bar=2`\ 
-- Again not existing: \ :ansopt:`ns.col2.foo#module:foobar=1`\ , \ :ansretval:`ns.col2.foo#module:barbaz=2`\ 
-- \ :literal:`\ `\  \ :emphasis:`\ `\  \ :strong:`\ `\  \ :literal:`\ `\    \ :ref:`\  <>`\  \ :ansval:`\ `\  \ :ansopt:`ns.col2.foo2#module:`\  \ :ansretval:`ns.col2.foo2#module:`\  \ :ansenvvar:`\ `\ 
+- A broken reference :ref:`asdfasdfoobarTHISDOESNOTEXIST <asdfasdfoobarTHISDOESNOTEXIST>`.
+- The option :ansopt:`ns.col2.foo2#module:foo` exists, but :ansopt:`ns.col2.foo2#module:foobar` does not.
+- The return value :ansretval:`ns.col2.foo2#module:bar` exists, but :ansretval:`ns.col2.foo2#module:barbaz` does not.
+- Again existing: :ansopt:`ns.col2.foo#module:foo=1`\ , :ansretval:`ns.col2.foo#module:bar=2`
+- Again not existing: :ansopt:`ns.col2.foo#module:foobar=1`\ , :ansretval:`ns.col2.foo#module:barbaz=2`
+- :literal:`\ ` :emphasis:`\ ` :strong:`\ ` :literal:`\ `   :ref:`\  <>` :ansval:`\ ` :ansopt:`ns.col2.foo2#module:`\  :ansretval:`ns.col2.foo2#module:`\  :ansenvvar:`\ `
 - Foo bar baz. Bamm - Bar baz
   bam bum.
   Bumm - Foo bar
   baz bam!
-
 
 
 .. Aliases
@@ -126,13 +125,12 @@ Parameters
 
       Bar.
 
-      Some \ :ansopt:`ns.col2.foo2#module:broken markup`\ .
+      Some :ansopt:`ns.col2.foo2#module:broken markup`.
 
       Foo bar baz. Bamm - Bar baz
       bam bum.
       Bumm - Foo bar
       baz bam!
-
 
 
       .. raw:: html
@@ -288,9 +286,9 @@ Parameters
 
       Whatever.
 
-      Also required when \ :emphasis:`subfoo`\  is specified when \ :emphasis:`foo=bar`\  or \ :literal:`baz`\ .
+      Also required when :emphasis:`subfoo` is specified when :emphasis:`foo=bar` or :literal:`baz`.
 
-      \ :ansretval:`ns.col2.foo2#module:foobarbaz`\  does not exist.
+      :ansretval:`ns.col2.foo2#module:foobarbaz` does not exist.
 
 
       .. raw:: html
@@ -401,7 +399,6 @@ Attributes
       baz bam!
 
 
-
       .. raw:: html
 
         </div>
@@ -432,15 +429,14 @@ Attributes
 
       :ansible-attribute-support-property:`Platform:` |antsibull-internal-nbsp|:ansible-attribute-support-full:`posix`
 
-      The module \ :strong:`ERROR while parsing`\ : While parsing "M(boo)" at index 12: Module name "boo" is not a FQCN\  is not using an FQCN.
+      The module :strong:`ERROR while parsing`\ : While parsing "M(boo)" at index 12: Module name "boo" is not a FQCN is not using an FQCN.
 
-      Sometimes our markup is \ :strong:`ERROR while parsing`\ : While parsing "B(broken." at index 25: Cannot find closing ")" after last parameter\ 
+      Sometimes our markup is :strong:`ERROR while parsing`\ : While parsing "B(broken." at index 25: Cannot find closing ")" after last parameter
 
       Foo bar baz. Bamm - Bar baz
       bam bum.
       Bumm - Foo bar
       baz bam!
-
 
 
       .. raw:: html
@@ -471,7 +467,6 @@ Notes
      Bumm - Foo bar
      baz bam!
 
-
 .. Seealso
 
 See Also
@@ -498,7 +493,6 @@ See Also
        bam bum.
        Bumm - Foo bar
        baz bam!
-
 
 .. Examples
 

--- a/tests/functional/baseline-default/collections/ns/col2/foo3_module.rst
+++ b/tests/functional/baseline-default/collections/ns/col2/foo3_module.rst
@@ -227,7 +227,7 @@ Parameters
 
       Whatever.
 
-      Also required when \ :emphasis:`subfoo`\  is specified when \ :emphasis:`foo=bar`\  or \ :literal:`baz`\ .
+      Also required when :emphasis:`subfoo` is specified when :emphasis:`foo=bar` or :literal:`baz`.
 
 
       .. raw:: html

--- a/tests/functional/baseline-default/collections/ns/col2/foo4_module.rst
+++ b/tests/functional/baseline-default/collections/ns/col2/foo4_module.rst
@@ -102,19 +102,19 @@ Parameters
 
         <div class="ansible-option-cell">
 
-      \ :ansopt:`ansible.builtin.iptables#module:tcp\_flags.flags[]`\ 
+      :ansopt:`ansible.builtin.iptables#module:tcp\_flags.flags[]`
 
-      \ :ansopt:`ns2.col.bar#filter:foo`\ 
+      :ansopt:`ns2.col.bar#filter:foo`
 
-      \ :ansopt:`ns2.col.bar#filter:foo[]`\ 
+      :ansopt:`ns2.col.bar#filter:foo[]`
 
-      \ :ansopt:`ext.col.foo#module:foo[baz].bar`\ 
+      :ansopt:`ext.col.foo#module:foo[baz].bar`
 
-      \ :ansretval:`ext.col.foo#module:baz`\ 
+      :ansretval:`ext.col.foo#module:baz`
 
-      \ :ansretval:`ext.col.foo#module:baz[ ]`\ 
+      :ansretval:`ext.col.foo#module:baz[ ]`
 
-      \ :ansretval:`ansible.builtin.stat#module:stat[foo.bar]`\ 
+      :ansretval:`ansible.builtin.stat#module:stat[foo.bar]`
 
 
       .. raw:: html
@@ -148,47 +148,47 @@ Parameters
 
         <div class="ansible-option-cell">
 
-      \ :ref:`ansible.builtin.service <ansible_collections.ansible.builtin.service_module>`\ 
+      :ref:`ansible.builtin.service <ansible_collections.ansible.builtin.service_module>`
 
-      \ :ref:`ansible.builtin.pipe <ansible_collections.ansible.builtin.pipe_lookup>`\ 
+      :ref:`ansible.builtin.pipe <ansible_collections.ansible.builtin.pipe_lookup>`
 
-      \ :ansopt:`ansible.builtin.file#module:state`\ 
+      :ansopt:`ansible.builtin.file#module:state`
 
-      \ :ansretval:`ansible.builtin.stat#module:stat.exists`\ 
+      :ansretval:`ansible.builtin.stat#module:stat.exists`
 
-      \ :ref:`ns2.flatcol.foo <ansible_collections.ns2.flatcol.foo_module>`\ 
+      :ref:`ns2.flatcol.foo <ansible_collections.ns2.flatcol.foo_module>`
 
-      \ :ref:`ns2.flatcol.sub.foo2 <ansible_collections.ns2.flatcol.sub.foo2_module>`\ 
+      :ref:`ns2.flatcol.sub.foo2 <ansible_collections.ns2.flatcol.sub.foo2_module>`
 
-      \ :ansopt:`ns2.flatcol.foo#module:subbaz.bam`\ 
+      :ansopt:`ns2.flatcol.foo#module:subbaz.bam`
 
-      \ :ansretval:`ns2.flatcol.sub.foo2#module:bar`\ 
+      :ansretval:`ns2.flatcol.sub.foo2#module:bar`
 
-      \ :ref:`ns2.col.foo2 <ansible_collections.ns2.col.foo2_module>`\ 
+      :ref:`ns2.col.foo2 <ansible_collections.ns2.col.foo2_module>`
 
-      \ :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>`\ 
+      :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>`
 
-      \ :ansopt:`ns2.col.bar#filter:foo[-1]`\ 
+      :ansopt:`ns2.col.bar#filter:foo[-1]`
 
-      \ :ansretval:`ns2.col.bar#test:\_value`\ 
+      :ansretval:`ns2.col.bar#test:\_value`
 
-      \ :ref:`ns.col2.foo2 <ansible_collections.ns.col2.foo2_module>`\ 
+      :ref:`ns.col2.foo2 <ansible_collections.ns.col2.foo2_module>`
 
-      \ :ref:`ns.col2.foo2 <ansible_collections.ns.col2.foo2_module>`\ 
+      :ref:`ns.col2.foo2 <ansible_collections.ns.col2.foo2_module>`
 
-      \ :ansopt:`ns.col2.foo2#module:subfoo.foo`\ 
+      :ansopt:`ns.col2.foo2#module:subfoo.foo`
 
-      \ :ansretval:`ns.col2.foo2#module:bar`\ 
+      :ansretval:`ns.col2.foo2#module:bar`
 
-      \ :ref:`ext.col.foo <ansible_collections.ext.col.foo_module>`\ 
+      :ref:`ext.col.foo <ansible_collections.ext.col.foo_module>`
 
-      \ :ref:`ext.col.bar <ansible_collections.ext.col.bar_lookup>`\ 
+      :ref:`ext.col.bar <ansible_collections.ext.col.bar_lookup>`
 
-      \ :ansopt:`ext.col.foo#module:foo[len(foo)].bar`\ 
+      :ansopt:`ext.col.foo#module:foo[len(foo)].bar`
 
-      \ :ansretval:`ext.col.foo#module:baz[]`\ 
+      :ansretval:`ext.col.foo#module:baz[]`
 
-      \ :ansopt:`ns.col2.foo2#module:subfoo.BaZ`\ 
+      :ansopt:`ns.col2.foo2#module:subfoo.BaZ`
 
 
       .. raw:: html
@@ -222,17 +222,17 @@ Parameters
 
         <div class="ansible-option-cell">
 
-      \ :ansopt:`ansible.builtin.file#module:state[]`\ 
+      :ansopt:`ansible.builtin.file#module:state[]`
 
-      \ :ansretval:`ansible.builtin.stat#module:stat[foo.bar].exists`\ 
+      :ansretval:`ansible.builtin.stat#module:stat[foo.bar].exists`
 
-      \ :ansretval:`ansible.builtin.stat#module:stat.exists[]`\ 
+      :ansretval:`ansible.builtin.stat#module:stat.exists[]`
 
-      \ :ansopt:`ns.col2.foo2#module:subfoo[`\ 
+      :ansopt:`ns.col2.foo2#module:subfoo[`
 
-      \ :ansretval:`ns.col2.foo2#module:bar[]`\ 
+      :ansretval:`ns.col2.foo2#module:bar[]`
 
-      \ :ansopt:`ext.col.foo#module:foo.bar`\ 
+      :ansopt:`ext.col.foo#module:foo.bar`
 
 
       .. raw:: html
@@ -266,67 +266,67 @@ Parameters
 
         <div class="ansible-option-cell">
 
-      \ :ref:`ansible.builtin.foobar <ansible_collections.ansible.builtin.foobar_module>`\ 
+      :ref:`ansible.builtin.foobar <ansible_collections.ansible.builtin.foobar_module>`
 
-      \ :ref:`ansible.builtin.bazbam <ansible_collections.ansible.builtin.bazbam_lookup>`\ 
+      :ref:`ansible.builtin.bazbam <ansible_collections.ansible.builtin.bazbam_lookup>`
 
-      \ :ansopt:`ansible.builtin.file#module:foobarbaz`\ 
+      :ansopt:`ansible.builtin.file#module:foobarbaz`
 
-      \ :ansretval:`ansible.builtin.stat#module:baz.bam[]`\ 
+      :ansretval:`ansible.builtin.stat#module:baz.bam[]`
 
-      \ :ansopt:`ansible.builtin.foobar#module:state`\ 
+      :ansopt:`ansible.builtin.foobar#module:state`
 
-      \ :ansretval:`ansible.builtin.bazbam#module:stat.exists`\ 
+      :ansretval:`ansible.builtin.bazbam#module:stat.exists`
 
-      \ :ref:`ns2.flatcol.foobarbaz <ansible_collections.ns2.flatcol.foobarbaz_module>`\ 
+      :ref:`ns2.flatcol.foobarbaz <ansible_collections.ns2.flatcol.foobarbaz_module>`
 
-      \ :ref:`ns2.flatcol.sub.bazbam <ansible_collections.ns2.flatcol.sub.bazbam_module>`\ 
+      :ref:`ns2.flatcol.sub.bazbam <ansible_collections.ns2.flatcol.sub.bazbam_module>`
 
-      \ :ansopt:`ns2.flatcol.foo#module:foofoofoobar`\ 
+      :ansopt:`ns2.flatcol.foo#module:foofoofoobar`
 
-      \ :ansretval:`ns2.flatcol.sub.foo2#module:bazbarbam`\ 
+      :ansretval:`ns2.flatcol.sub.foo2#module:bazbarbam`
 
-      \ :ansopt:`ns2.flatcol.foobar#module:subbaz.bam`\ 
+      :ansopt:`ns2.flatcol.foobar#module:subbaz.bam`
 
-      \ :ansretval:`ns2.flatcol.sub.bazbam#module:bar`\ 
+      :ansretval:`ns2.flatcol.sub.bazbam#module:bar`
 
-      \ :ref:`ns2.col.joo <ansible_collections.ns2.col.joo_module>`\ 
+      :ref:`ns2.col.joo <ansible_collections.ns2.col.joo_module>`
 
-      \ :ref:`ns2.col.joo <ansible_collections.ns2.col.joo_lookup>`\ 
+      :ref:`ns2.col.joo <ansible_collections.ns2.col.joo_lookup>`
 
-      \ :ansopt:`ns2.col.bar#filter:jooo`\ 
+      :ansopt:`ns2.col.bar#filter:jooo`
 
-      \ :ansretval:`ns2.col.bar#test:booo`\ 
+      :ansretval:`ns2.col.bar#test:booo`
 
-      \ :ansopt:`ns2.col.joo#filter:foo[-1]`\ 
+      :ansopt:`ns2.col.joo#filter:foo[-1]`
 
-      \ :ansretval:`ns2.col.joo#test:\_value`\ 
+      :ansretval:`ns2.col.joo#test:\_value`
 
-      \ :ref:`ns.col2.foobarbaz <ansible_collections.ns.col2.foobarbaz_module>`\ 
+      :ref:`ns.col2.foobarbaz <ansible_collections.ns.col2.foobarbaz_module>`
 
-      \ :ref:`ns.col2.foobarbam <ansible_collections.ns.col2.foobarbam_filter>`\ 
+      :ref:`ns.col2.foobarbam <ansible_collections.ns.col2.foobarbam_filter>`
 
-      \ :ansopt:`ns.col2.foo2#module:barbazbam.foo`\ 
+      :ansopt:`ns.col2.foo2#module:barbazbam.foo`
 
-      \ :ansretval:`ns.col2.foo2#module:bambazbar`\ 
+      :ansretval:`ns.col2.foo2#module:bambazbar`
 
-      \ :ansopt:`ns.col2.foofoo#test:subfoo.foo`\ 
+      :ansopt:`ns.col2.foofoo#test:subfoo.foo`
 
-      \ :ansretval:`ns.col2.foofoo#lookup:baz`\ 
+      :ansretval:`ns.col2.foofoo#lookup:baz`
 
-      \ :ref:`ext.col.notthere <ansible_collections.ext.col.notthere_module>`\ 
+      :ref:`ext.col.notthere <ansible_collections.ext.col.notthere_module>`
 
-      \ :ref:`ext.col.notthere <ansible_collections.ext.col.notthere_lookup>`\ 
+      :ref:`ext.col.notthere <ansible_collections.ext.col.notthere_lookup>`
 
-      \ :ansopt:`ext.col.foo#module:foo[len(foo)].notthere`\ 
+      :ansopt:`ext.col.foo#module:foo[len(foo)].notthere`
 
-      \ :ansopt:`ext.col.foo#module:notthere[len(notthere)].bar`\ 
+      :ansopt:`ext.col.foo#module:notthere[len(notthere)].bar`
 
-      \ :ansretval:`ext.col.foo#module:notthere[]`\ 
+      :ansretval:`ext.col.foo#module:notthere[]`
 
-      \ :ansopt:`ext.col.notthere#module:foo[len(foo)].bar`\ 
+      :ansopt:`ext.col.notthere#module:foo[len(foo)].bar`
 
-      \ :ansretval:`ext.col.notthere#module:baz[]`\ 
+      :ansretval:`ext.col.notthere#module:baz[]`
 
 
       .. raw:: html

--- a/tests/functional/baseline-default/collections/ns2/col/bar_filter.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/bar_filter.rst
@@ -281,16 +281,16 @@ example: ``input | ns2.col.bar(key1=value1, key2=value2, ...)``
       :ansible-option-choices:`Choices:`
 
       - :ansible-option-choices-entry:`"a"`\ :
-        Whatever \ :literal:`a`\  is.
+        Whatever :literal:`a` is.
 
       - :ansible-option-choices-entry:`"b"`\ :
-        What is \ :literal:`b`\ ? I don't know.
+        What is :literal:`b`\ ? I don't know.
 
       - :ansible-option-choices-entry:`"cde"`\ :
         This is some more unknown. There are rumors this is related to the alphabet.
 
       - :ansible-option-choices-entry-default:`"foo"` :ansible-option-choices-default-mark:`(default)`\ :
-        Our default value, the glorious \ :literal:`foo`\ .
+        Our default value, the glorious :literal:`foo`.
 
         Even has two paragraphs.
 

--- a/tests/functional/baseline-default/collections/ns2/col/bar_test.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/bar_test.rst
@@ -189,7 +189,7 @@ Return Value
 
         <div class="ansible-option-cell">
 
-      Returns \ :literal:`true`\  if the path is a bar, \ :literal:`false`\  if it is not a bar.
+      Returns :literal:`true` if the path is a bar, :literal:`false` if it is not a bar.
 
 
       .. rst-class:: ansible-option-line

--- a/tests/functional/baseline-default/collections/ns2/col/foo2_module.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo2_module.rst
@@ -49,8 +49,8 @@ Synopsis
 .. Description
 
 - Foo bar.
-- See \ :ansopt:`ns2.col.foo#role:main:foo\_param\_1`\  for a random role parameter reference. And \ :ansopt:`ns2.col.foo#role:main:foo\_param\_2=42`\  for one with a value.
-- Reference using alias - \ :ansopt:`ns2.col.foo\_redirect#module:bar`\  and \ :ansopt:`ns2.col.foo\_redirect#module:baz`\ .
+- See :ansopt:`ns2.col.foo#role:main:foo\_param\_1` for a random role parameter reference. And :ansopt:`ns2.col.foo#role:main:foo\_param\_2=42` for one with a value.
+- Reference using alias - :ansopt:`ns2.col.foo\_redirect#module:bar` and :ansopt:`ns2.col.foo\_redirect#module:baz`.
 
 
 .. Aliases
@@ -108,7 +108,7 @@ Parameters
 
       Some bar.
 
-      See \ :ansopt:`ns2.col.foo#role:main:foo\_param\_1`\  for a random role parameter reference. And \ :ansopt:`ns2.col.foo#role:main:foo\_param\_2=42`\  for one with a value.
+      See :ansopt:`ns2.col.foo#role:main:foo\_param\_1` for a random role parameter reference. And :ansopt:`ns2.col.foo#role:main:foo\_param\_2=42` for one with a value.
 
 
       .. raw:: html
@@ -168,7 +168,7 @@ Attributes
 
         <div class="ansible-option-cell">
 
-      Use \ :literal:`group/ns2.col.foo\_group`\  or \ :literal:`group/ns2.col.bar\_group`\  in \ :literal:`module\_defaults`\  to set defaults for this module.
+      Use :literal:`group/ns2.col.foo\_group` or :literal:`group/ns2.col.bar\_group` in :literal:`module\_defaults` to set defaults for this module.
 
 
       .. raw:: html
@@ -373,9 +373,9 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
 
       Some bar.
 
-      Referencing myself as \ :ansretval:`ns2.col.foo2#module:bar`\ .
+      Referencing myself as :ansretval:`ns2.col.foo2#module:bar`.
 
-      Do not confuse with \ :ansopt:`ns2.col.foo2#module:bar`\ .
+      Do not confuse with :ansopt:`ns2.col.foo2#module:bar`.
 
 
       .. rst-class:: ansible-option-line

--- a/tests/functional/baseline-default/collections/ns2/col/foo_become.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_become.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo become -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo become -- Use foo :ansopt:`ns2.col.foo#become:bar`
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -48,11 +48,9 @@ DEPRECATED
 :Why: Just some text.
       This one has more than one line.
       And one more.
-
 :Alternative: I don't know
               of any
               alternative.
-
 
 Synopsis
 --------
@@ -118,11 +116,9 @@ Parameters
       This one has more than one line though.
       One more.
 
-
       Alternative: nothing
       relevant
       I know of
-
 
 
 
@@ -135,11 +131,11 @@ Parameters
 
         <div class="ansible-option-cell">
 
-      Bar. \ :strong:`BAR!`\ 
+      Bar. :strong:`BAR!`
 
-      Totally unrelated to \ :ansopt:`ns2.col.foo#become:become\_user`\ . Even with \ :ansopt:`ns2.col.foo#become:become\_user=foo`\ .
+      Totally unrelated to :ansopt:`ns2.col.foo#become:become\_user`. Even with :ansopt:`ns2.col.foo#become:become\_user=foo`.
 
-      Might not be compatible when \ :ansopt:`ns2.col.foo#become:become\_user`\  is \ :ansval:`bar`\ , though.
+      Might not be compatible when :ansopt:`ns2.col.foo#become:become\_user` is :ansval:`bar`\ , though.
 
 
       .. raw:: html

--- a/tests/functional/baseline-default/collections/ns2/col/foo_cache.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_cache.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo cache -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo cache -- Foo files :ansopt:`ns2.col.foo#cache:bar`
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_callback.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_callback.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo callback -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo callback -- Foo output :ansopt:`ns2.col.foo#callback:bar`
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_connection.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_connection.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo connection -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo connection -- Foo connection :ansopt:`ns2.col.foo#connection:bar`
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -51,7 +51,7 @@ Synopsis
 
 .. Description
 
-- This is for the \ :literal:`foo`\  connection.
+- This is for the :literal:`foo` connection.
 
 
 .. Aliases
@@ -183,8 +183,8 @@ Notes
 -----
 
 .. note::
-   - Some note. \ :strong:`Something in bold`\ . \ :literal:`And in code`\ . \ :emphasis:`And in italics`\ . An URL: \ `https://example.org <https://example.org>`__\ .
-   - And another one. \ `A link <https://example.com>`__\ .
+   - Some note. :strong:`Something in bold`. :literal:`And in code`. :emphasis:`And in italics`. An URL: \ `https://example.org <https://example.org>`__.
+   - And another one. \ `A link <https://example.com>`__.
 
 .. Seealso
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_filter.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_filter.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo filter -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo filter -- The foo filter :ansopt:`ns2.col.foo#filter:bar`
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_inventory.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_inventory.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo inventory -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo inventory -- The foo inventory :ansopt:`ns2.col.foo#inventory:bar`
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_lookup.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_lookup.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo lookup -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo lookup -- Look up some foo :ansopt:`ns2.col.foo#lookup:bar`
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_module.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo module -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo module -- Do some foo :ansopt:`ns2.col.foo#module:bar`
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -55,7 +55,7 @@ Synopsis
 
 - Does some foo on the remote host.
 - Whether foo is magic or not has not yet been determined.
-- \ :ansenvvarref:`FOOBAR1`\ , \ :ansenvvarref:`FOOBAR2`\ , \ :ansenvvar:`FOOBAR3`\ , \ :ansenvvar:`FOOBAR4`\ .
+- :ansenvvarref:`FOOBAR1`\ , :ansenvvarref:`FOOBAR2`\ , :ansenvvar:`FOOBAR3`\ , :ansenvvar:`FOOBAR4`.
 
 
 .. Aliases
@@ -126,9 +126,9 @@ Parameters
 
       A bar.
 
-      Independent from \ :ansopt:`ns2.col.foo#module:foo`\ .
+      Independent from :ansopt:`ns2.col.foo#module:foo`.
 
-      Do not confuse with \ :ansretval:`ns2.col.foo#module:bar`\ .
+      Do not confuse with :ansretval:`ns2.col.foo#module:bar`.
 
 
       .. raw:: html
@@ -204,7 +204,7 @@ Parameters
 
       The 'pkg\_info' option was added in version 2.13.
 
-      Aliases were added in 2.18, to support using \ :literal:`auto={{ansible\_facts['pkg\_mgr']}}`\ 
+      Aliases were added in 2.18, to support using :literal:`auto={{ansible\_facts['pkg\_mgr']}}`
 
 
       .. rst-class:: ansible-option-line
@@ -215,10 +215,10 @@ Parameters
         Alpine Linux package manager
 
       - :ansible-option-choices-entry:`"apt"`\ :
-        For DEB based distros, \ :literal:`python-apt`\  package must be installed on targeted hosts
+        For DEB based distros, :literal:`python-apt` package must be installed on targeted hosts
 
       - :ansible-option-choices-entry-default:`"auto"` :ansible-option-choices-default-mark:`(default)`\ :
-        Depending on \ :ansopt:`strategy`\ , will match the first or all package managers provided, in order
+        Depending on :ansopt:`strategy`\ , will match the first or all package managers provided, in order
 
       - :ansible-option-choices-entry:`"dnf"`\ :
         Alias to rpm
@@ -245,7 +245,7 @@ Parameters
         Alias to pkg
 
       - :ansible-option-choices-entry:`"portage"`\ :
-        Handles ebuild packages, it requires the \ :literal:`qlist`\  utility, which is part of 'app-portage/portage-utils'
+        Handles ebuild packages, it requires the :literal:`qlist` utility, which is part of 'app-portage/portage-utils'
 
       - :ansible-option-choices-entry:`"rpm"`\ :
         For RPM based distros, requires RPM Python bindings, not installed by default on Suse (python3-rpm)
@@ -342,7 +342,7 @@ Parameters
 
       Whatever.
 
-      Also required when \ :ansopt:`ns2.col.foo#module:subfoo`\  is specified when \ :ansopt:`ns2.col.foo#module:foo=bar`\  or \ :ansval:`baz`\ .
+      Also required when :ansopt:`ns2.col.foo#module:subfoo` is specified when :ansopt:`ns2.col.foo#module:foo=bar` or :ansval:`baz`.
 
 
       .. raw:: html
@@ -403,7 +403,7 @@ Attributes
 
         <div class="ansible-option-cell">
 
-      Use \ :literal:`group/ns2.col.foo\_group`\  in \ :literal:`module\_defaults`\  to set defaults for this module.
+      Use :literal:`group/ns2.col.foo\_group` in :literal:`module\_defaults` to set defaults for this module.
 
 
       .. raw:: html
@@ -551,7 +551,7 @@ See Also
    \ :ref:`ns2.col.foo2 <ansible_collections.ns2.col.foo2_module>`\ 
        Another foo.
    \ :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>`\  lookup plugin
-       Look up some foo \ :ansopt:`ns2.col.foo#module:bar`\ .
+       Look up some foo :ansopt:`ns2.col.foo#module:bar`.
    \ :ref:`ansible.builtin.service <ansible_collections.ansible.builtin.service_module>`\ 
        The service module.
    \ :ref:`ansible.builtin.ssh <ansible_collections.ansible.builtin.ssh_connection>`\  connection plugin
@@ -627,9 +627,9 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
 
       Some bar.
 
-      Referencing myself as \ :ansretval:`ns2.col.foo#module:bar`\ .
+      Referencing myself as :ansretval:`ns2.col.foo#module:bar`.
 
-      Do not confuse with \ :ansopt:`ns2.col.foo#module:bar`\ .
+      Do not confuse with :ansopt:`ns2.col.foo#module:bar`.
 
 
       .. rst-class:: ansible-option-line

--- a/tests/functional/baseline-default/collections/ns2/col/foo_role.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_role.rst
@@ -55,11 +55,9 @@ DEPRECATED
 :Why: Just some text.
       This one has more than one line.
       And one more.
-
 :Alternative: I don't know
               of any
               alternative.
-
 
 Synopsis
 ^^^^^^^^
@@ -67,7 +65,7 @@ Synopsis
 .. Description
 
 - This is the foo role.
-- If you set \ :ansopt:`ns2.col.foo#role:main:foo\_param\_1`\  while \ :ansopt:`ns2.col.foo#role:main:foo\_param\_2=3`\ , this might behave funny.
+- If you set :ansopt:`ns2.col.foo#role:main:foo\_param\_1` while :ansopt:`ns2.col.foo#role:main:foo\_param\_2=3`\ , this might behave funny.
 
 .. Requirements
 
@@ -120,7 +118,7 @@ Parameters
 
       A string parameter
 
-      If you set \ :ansopt:`ns2.col.foo#role:main:foo\_param\_1`\  while \ :ansopt:`ns2.col.foo#role:main:foo\_param\_2=3`\ , this might behave funny.
+      If you set :ansopt:`ns2.col.foo#role:main:foo\_param\_1` while :ansopt:`ns2.col.foo#role:main:foo\_param\_2=3`\ , this might behave funny.
 
 
       .. raw:: html

--- a/tests/functional/baseline-default/collections/ns2/col/foo_shell.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_shell.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo shell -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo shell -- Foo shell :ansopt:`ns2.col.foo#shell:bar`
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_test.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_test.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo test -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo test -- Is something a foo :ansopt:`ns2.col.foo#test:bar`
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_vars.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_vars.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo vars -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo vars -- Load foo :ansopt:`ns2.col.foo#vars:bar`
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-default/collections/ns2/col/index.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/index.rst
@@ -19,9 +19,7 @@ Description
 -----------
 
 This is a description.
-
 With multiple paragraphs.
-
 
 **Author:**
 
@@ -92,7 +90,7 @@ These are the plugins in the ns2.col collection:
 Modules
 ~~~~~~~
 
-* :ansplugin:`foo module <ns2.col.foo#module>` -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
+* :ansplugin:`foo module <ns2.col.foo#module>` -- Do some foo :ansopt:`ns2.col.foo#module:bar`
 * :ansplugin:`foo2 module <ns2.col.foo2#module>` -- Another foo
 * :ansplugin:`sub.foo3 module <ns2.col.sub.foo3#module>` -- A sub-foo
 
@@ -108,7 +106,7 @@ Modules
 Become Plugins
 ~~~~~~~~~~~~~~
 
-* :ansplugin:`foo become <ns2.col.foo#become>` -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
+* :ansplugin:`foo become <ns2.col.foo#become>` -- Use foo :ansopt:`ns2.col.foo#become:bar`
 
 .. toctree::
     :maxdepth: 1
@@ -120,7 +118,7 @@ Become Plugins
 Cache Plugins
 ~~~~~~~~~~~~~
 
-* :ansplugin:`foo cache <ns2.col.foo#cache>` -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
+* :ansplugin:`foo cache <ns2.col.foo#cache>` -- Foo files :ansopt:`ns2.col.foo#cache:bar`
 
 .. toctree::
     :maxdepth: 1
@@ -132,7 +130,7 @@ Cache Plugins
 Callback Plugins
 ~~~~~~~~~~~~~~~~
 
-* :ansplugin:`foo callback <ns2.col.foo#callback>` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
+* :ansplugin:`foo callback <ns2.col.foo#callback>` -- Foo output :ansopt:`ns2.col.foo#callback:bar`
 
 .. toctree::
     :maxdepth: 1
@@ -156,7 +154,7 @@ Cliconf Plugins
 Connection Plugins
 ~~~~~~~~~~~~~~~~~~
 
-* :ansplugin:`foo connection <ns2.col.foo#connection>` -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
+* :ansplugin:`foo connection <ns2.col.foo#connection>` -- Foo connection :ansopt:`ns2.col.foo#connection:bar`
 
 .. toctree::
     :maxdepth: 1
@@ -169,7 +167,7 @@ Filter Plugins
 ~~~~~~~~~~~~~~
 
 * :ansplugin:`bar filter <ns2.col.bar#filter>` -- The bar filter
-* :ansplugin:`foo filter <ns2.col.foo#filter>` -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
+* :ansplugin:`foo filter <ns2.col.foo#filter>` -- The foo filter :ansopt:`ns2.col.foo#filter:bar`
 
 .. toctree::
     :maxdepth: 1
@@ -182,7 +180,7 @@ Filter Plugins
 Inventory Plugins
 ~~~~~~~~~~~~~~~~~
 
-* :ansplugin:`foo inventory <ns2.col.foo#inventory>` -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
+* :ansplugin:`foo inventory <ns2.col.foo#inventory>` -- The foo inventory :ansopt:`ns2.col.foo#inventory:bar`
 
 .. toctree::
     :maxdepth: 1
@@ -194,7 +192,7 @@ Inventory Plugins
 Lookup Plugins
 ~~~~~~~~~~~~~~
 
-* :ansplugin:`foo lookup <ns2.col.foo#lookup>` -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
+* :ansplugin:`foo lookup <ns2.col.foo#lookup>` -- Look up some foo :ansopt:`ns2.col.foo#lookup:bar`
 
 .. toctree::
     :maxdepth: 1
@@ -206,7 +204,7 @@ Lookup Plugins
 Shell Plugins
 ~~~~~~~~~~~~~
 
-* :ansplugin:`foo shell <ns2.col.foo#shell>` -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
+* :ansplugin:`foo shell <ns2.col.foo#shell>` -- Foo shell :ansopt:`ns2.col.foo#shell:bar`
 
 .. toctree::
     :maxdepth: 1
@@ -231,7 +229,7 @@ Test Plugins
 ~~~~~~~~~~~~
 
 * :ansplugin:`bar test <ns2.col.bar#test>` -- Is something a bar
-* :ansplugin:`foo test <ns2.col.foo#test>` -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
+* :ansplugin:`foo test <ns2.col.foo#test>` -- Is something a foo :ansopt:`ns2.col.foo#test:bar`
 
 .. toctree::
     :maxdepth: 1
@@ -244,7 +242,7 @@ Test Plugins
 Vars Plugins
 ~~~~~~~~~~~~
 
-* :ansplugin:`foo vars <ns2.col.foo#vars>` -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
+* :ansplugin:`foo vars <ns2.col.foo#vars>` -- Load foo :ansopt:`ns2.col.foo#vars:bar`
 
 .. toctree::
     :maxdepth: 1

--- a/tests/functional/baseline-default/collections/ns2/col/sub.foo3_module.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/sub.foo3_module.rst
@@ -49,7 +49,7 @@ Synopsis
 .. Description
 
 - Foo sub bar.
-- See \ :ansopt:`ns2.col.foo#role:main:foo\_param\_1`\  for a random role parameter reference. And \ :ansopt:`ns2.col.foo#role:main:foo\_param\_2=42`\  for one with a value.
+- See :ansopt:`ns2.col.foo#role:main:foo\_param\_1` for a random role parameter reference. And :ansopt:`ns2.col.foo#role:main:foo\_param\_2=42` for one with a value.
 
 
 .. Aliases
@@ -107,7 +107,7 @@ Parameters
 
       Some bar.
 
-      See \ :ansopt:`ns2.col.foo#role:main:foo\_param\_1`\  for a random role parameter reference. And \ :ansopt:`ns2.col.foo#role:main:foo\_param\_2=42`\  for one with a value.
+      See :ansopt:`ns2.col.foo#role:main:foo\_param\_1` for a random role parameter reference. And :ansopt:`ns2.col.foo#role:main:foo\_param\_2=42` for one with a value.
 
 
       .. raw:: html
@@ -167,7 +167,7 @@ Attributes
 
         <div class="ansible-option-cell">
 
-      Use \ :literal:`group/ns2.col.foo\_group`\  or \ :literal:`group/ns2.col.bar\_group`\  in \ :literal:`module\_defaults`\  to set defaults for this module.
+      Use :literal:`group/ns2.col.foo\_group` or :literal:`group/ns2.col.bar\_group` in :literal:`module\_defaults` to set defaults for this module.
 
 
       .. raw:: html
@@ -372,9 +372,9 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
 
       Some bar.
 
-      Referencing myself as \ :ansretval:`ns2.col.sub.foo3#module:bar`\ .
+      Referencing myself as :ansretval:`ns2.col.sub.foo3#module:bar`.
 
-      Do not confuse with \ :ansopt:`ns2.col.sub.foo3#module:bar`\ .
+      Do not confuse with :ansopt:`ns2.col.sub.foo3#module:bar`.
 
 
       .. rst-class:: ansible-option-line

--- a/tests/functional/baseline-default/collections/ns2/flatcol/foo2_module.rst
+++ b/tests/functional/baseline-default/collections/ns2/flatcol/foo2_module.rst
@@ -49,7 +49,7 @@ Synopsis
 .. Description
 
 - Foo bar.
-- See \ :ansopt:`ns2.flatcol.foo#role:main:foo\_param\_1`\  for a random role parameter reference. And \ :ansopt:`ns2.flatcol.foo#role:main:foo\_param\_2=42`\  for one with a value.
+- See :ansopt:`ns2.flatcol.foo#role:main:foo\_param\_1` for a random role parameter reference. And :ansopt:`ns2.flatcol.foo#role:main:foo\_param\_2=42` for one with a value.
 
 
 .. Aliases
@@ -107,7 +107,7 @@ Parameters
 
       Some bar.
 
-      See \ :ansopt:`ns2.flatcol.foo#role:main:foo\_param\_1`\  for a random role parameter reference. And \ :ansopt:`ns2.flatcol.foo#role:main:foo\_param\_2=42`\  for one with a value.
+      See :ansopt:`ns2.flatcol.foo#role:main:foo\_param\_1` for a random role parameter reference. And :ansopt:`ns2.flatcol.foo#role:main:foo\_param\_2=42` for one with a value.
 
 
       .. raw:: html
@@ -188,9 +188,9 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
 
       Some bar.
 
-      Referencing myself as \ :ansretval:`ns2.flatcol.foo2#module:bar`\ .
+      Referencing myself as :ansretval:`ns2.flatcol.foo2#module:bar`.
 
-      Do not confuse with \ :ansopt:`ns2.flatcol.foo2#module:bar`\ .
+      Do not confuse with :ansopt:`ns2.flatcol.foo2#module:bar`.
 
 
       .. rst-class:: ansible-option-line

--- a/tests/functional/baseline-default/collections/ns2/flatcol/foo_module.rst
+++ b/tests/functional/baseline-default/collections/ns2/flatcol/foo_module.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.flatcol.foo module -- Do some foo \ :ansopt:`ns2.flatcol.foo#module:bar`\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.flatcol.foo module -- Do some foo :ansopt:`ns2.flatcol.foo#module:bar`
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -114,9 +114,9 @@ Parameters
 
       A bar.
 
-      Independent from \ :ansopt:`ns2.flatcol.foo#module:foo`\ .
+      Independent from :ansopt:`ns2.flatcol.foo#module:foo`.
 
-      Do not confuse with \ :ansretval:`ns2.flatcol.foo#module:bar`\ .
+      Do not confuse with :ansretval:`ns2.flatcol.foo#module:bar`.
 
 
       .. raw:: html
@@ -245,11 +245,11 @@ Parameters
 
       Whatever.
 
-      Also required when \ :ansopt:`ns2.flatcol.foo#module:subfoo`\  is specified when \ :ansopt:`ns2.flatcol.foo#module:foo=bar`\  or \ :ansval:`baz`\ .
+      Also required when :ansopt:`ns2.flatcol.foo#module:subfoo` is specified when :ansopt:`ns2.flatcol.foo#module:foo=bar` or :ansval:`baz`.
 
-      Note that \ :ansopt:`ns2.flatcol.foo#module:subfoo.foo`\  is the same as \ :ansopt:`ns2.flatcol.foo#module:subbaz.foo`\ , \ :ansopt:`ns2.flatcol.foo#module:subbaz.bam`\ , and \ :ansopt:`ns2.flatcol.foo#module:subfoo.bam`\ .
+      Note that :ansopt:`ns2.flatcol.foo#module:subfoo.foo` is the same as :ansopt:`ns2.flatcol.foo#module:subbaz.foo`\ , :ansopt:`ns2.flatcol.foo#module:subbaz.bam`\ , and :ansopt:`ns2.flatcol.foo#module:subfoo.bam`.
 
-      \ :ansenvvarref:`FOOBAR1`\ , \ :ansenvvarref:`FOOBAR2`\ , \ :ansenvvar:`FOOBAR3`\ , \ :ansenvvar:`FOOBAR4`\ .
+      :ansenvvarref:`FOOBAR1`\ , :ansenvvarref:`FOOBAR2`\ , :ansenvvar:`FOOBAR3`\ , :ansenvvar:`FOOBAR4`.
 
 
       .. raw:: html
@@ -337,9 +337,9 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
 
       Some bar.
 
-      Referencing myself as \ :ansretval:`ns2.flatcol.foo#module:bar`\ .
+      Referencing myself as :ansretval:`ns2.flatcol.foo#module:bar`.
 
-      Do not confuse with \ :ansopt:`ns2.flatcol.foo#module:bar`\ .
+      Do not confuse with :ansopt:`ns2.flatcol.foo#module:bar`.
 
 
       .. rst-class:: ansible-option-line

--- a/tests/functional/baseline-default/collections/ns2/flatcol/index.rst
+++ b/tests/functional/baseline-default/collections/ns2/flatcol/index.rst
@@ -57,7 +57,7 @@ These are the plugins in the ns2.flatcol collection:
 Modules
 ~~~~~~~
 
-* :ansplugin:`foo module <ns2.flatcol.foo#module>` -- Do some foo \ :ansopt:`ns2.flatcol.foo#module:bar`\ 
+* :ansplugin:`foo module <ns2.flatcol.foo#module>` -- Do some foo :ansopt:`ns2.flatcol.foo#module:bar`
 * :ansplugin:`foo2 module <ns2.flatcol.foo2#module>` -- Another foo
 
 .. toctree::

--- a/tests/functional/baseline-no-breadcrumbs/collections/callback_index_stdout.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/callback_index_stdout.rst
@@ -14,5 +14,5 @@ See :ref:`list_of_callback_plugins` for the list of *all* callback plugins.
 ns2.col
 -------
 
-* :ansplugin:`ns2.col.foo#callback` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
+* :ansplugin:`ns2.col.foo#callback` -- Foo output :ansopt:`ns2.col.foo#callback:bar`
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_become.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_become.rst
@@ -12,5 +12,5 @@ Index of all Become Plugins
 ns2.col
 -------
 
-* :ansplugin:`ns2.col.foo#become` -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
+* :ansplugin:`ns2.col.foo#become` -- Use foo :ansopt:`ns2.col.foo#become:bar`
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_cache.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_cache.rst
@@ -12,5 +12,5 @@ Index of all Cache Plugins
 ns2.col
 -------
 
-* :ansplugin:`ns2.col.foo#cache` -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
+* :ansplugin:`ns2.col.foo#cache` -- Foo files :ansopt:`ns2.col.foo#cache:bar`
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_callback.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_callback.rst
@@ -20,5 +20,5 @@ Index of all Callback Plugins
 ns2.col
 -------
 
-* :ansplugin:`ns2.col.foo#callback` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
+* :ansplugin:`ns2.col.foo#callback` -- Foo output :ansopt:`ns2.col.foo#callback:bar`
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_connection.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_connection.rst
@@ -12,5 +12,5 @@ Index of all Connection Plugins
 ns2.col
 -------
 
-* :ansplugin:`ns2.col.foo#connection` -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
+* :ansplugin:`ns2.col.foo#connection` -- Foo connection :ansopt:`ns2.col.foo#connection:bar`
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_filter.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_filter.rst
@@ -13,5 +13,5 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.bar#filter` -- The bar filter
-* :ansplugin:`ns2.col.foo#filter` -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
+* :ansplugin:`ns2.col.foo#filter` -- The foo filter :ansopt:`ns2.col.foo#filter:bar`
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_inventory.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_inventory.rst
@@ -12,5 +12,5 @@ Index of all Inventory Plugins
 ns2.col
 -------
 
-* :ansplugin:`ns2.col.foo#inventory` -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
+* :ansplugin:`ns2.col.foo#inventory` -- The foo inventory :ansopt:`ns2.col.foo#inventory:bar`
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_lookup.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_lookup.rst
@@ -12,5 +12,5 @@ Index of all Lookup Plugins
 ns2.col
 -------
 
-* :ansplugin:`ns2.col.foo#lookup` -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
+* :ansplugin:`ns2.col.foo#lookup` -- Look up some foo :ansopt:`ns2.col.foo#lookup:bar`
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_module.rst
@@ -20,13 +20,13 @@ ns.col2
 ns2.col
 -------
 
-* :ansplugin:`ns2.col.foo#module` -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
+* :ansplugin:`ns2.col.foo#module` -- Do some foo :ansopt:`ns2.col.foo#module:bar`
 * :ansplugin:`ns2.col.foo2#module` -- Another foo
 * :ansplugin:`ns2.col.sub.foo3#module` -- A sub-foo
 
 ns2.flatcol
 -----------
 
-* :ansplugin:`ns2.flatcol.foo#module` -- Do some foo \ :ansopt:`ns2.flatcol.foo#module:bar`\ 
+* :ansplugin:`ns2.flatcol.foo#module` -- Do some foo :ansopt:`ns2.flatcol.foo#module:bar`
 * :ansplugin:`ns2.flatcol.foo2#module` -- Another foo
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_shell.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_shell.rst
@@ -12,5 +12,5 @@ Index of all Shell Plugins
 ns2.col
 -------
 
-* :ansplugin:`ns2.col.foo#shell` -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
+* :ansplugin:`ns2.col.foo#shell` -- Foo shell :ansopt:`ns2.col.foo#shell:bar`
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_test.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_test.rst
@@ -13,5 +13,5 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.bar#test` -- Is something a bar
-* :ansplugin:`ns2.col.foo#test` -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
+* :ansplugin:`ns2.col.foo#test` -- Is something a foo :ansopt:`ns2.col.foo#test:bar`
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_vars.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_vars.rst
@@ -12,5 +12,5 @@ Index of all Vars Plugins
 ns2.col
 -------
 
-* :ansplugin:`ns2.col.foo#vars` -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
+* :ansplugin:`ns2.col.foo#vars` -- Load foo :ansopt:`ns2.col.foo#vars:bar`
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/foo2_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/foo2_module.rst
@@ -50,17 +50,16 @@ Synopsis
 .. Description
 
 - Does some foo on the remote host.
-- A broken reference \ :ref:`asdfasdfoobarTHISDOESNOTEXIST <asdfasdfoobarTHISDOESNOTEXIST>`\ .
-- The option \ :ansopt:`ns.col2.foo2#module:foo`\  exists, but \ :ansopt:`ns.col2.foo2#module:foobar`\  does not.
-- The return value \ :ansretval:`ns.col2.foo2#module:bar`\  exists, but \ :ansretval:`ns.col2.foo2#module:barbaz`\  does not.
-- Again existing: \ :ansopt:`ns.col2.foo#module:foo=1`\ , \ :ansretval:`ns.col2.foo#module:bar=2`\ 
-- Again not existing: \ :ansopt:`ns.col2.foo#module:foobar=1`\ , \ :ansretval:`ns.col2.foo#module:barbaz=2`\ 
-- \ :literal:`\ `\  \ :emphasis:`\ `\  \ :strong:`\ `\  \ :literal:`\ `\    \ :ref:`\  <>`\  \ :ansval:`\ `\  \ :ansopt:`ns.col2.foo2#module:`\  \ :ansretval:`ns.col2.foo2#module:`\  \ :ansenvvar:`\ `\ 
+- A broken reference :ref:`asdfasdfoobarTHISDOESNOTEXIST <asdfasdfoobarTHISDOESNOTEXIST>`.
+- The option :ansopt:`ns.col2.foo2#module:foo` exists, but :ansopt:`ns.col2.foo2#module:foobar` does not.
+- The return value :ansretval:`ns.col2.foo2#module:bar` exists, but :ansretval:`ns.col2.foo2#module:barbaz` does not.
+- Again existing: :ansopt:`ns.col2.foo#module:foo=1`\ , :ansretval:`ns.col2.foo#module:bar=2`
+- Again not existing: :ansopt:`ns.col2.foo#module:foobar=1`\ , :ansretval:`ns.col2.foo#module:barbaz=2`
+- :literal:`\ ` :emphasis:`\ ` :strong:`\ ` :literal:`\ `   :ref:`\  <>` :ansval:`\ ` :ansopt:`ns.col2.foo2#module:`\  :ansretval:`ns.col2.foo2#module:`\  :ansenvvar:`\ `
 - Foo bar baz. Bamm - Bar baz
   bam bum.
   Bumm - Foo bar
   baz bam!
-
 
 
 .. Aliases
@@ -126,13 +125,12 @@ Parameters
 
       Bar.
 
-      Some \ :ansopt:`ns.col2.foo2#module:broken markup`\ .
+      Some :ansopt:`ns.col2.foo2#module:broken markup`.
 
       Foo bar baz. Bamm - Bar baz
       bam bum.
       Bumm - Foo bar
       baz bam!
-
 
 
       .. raw:: html
@@ -288,9 +286,9 @@ Parameters
 
       Whatever.
 
-      Also required when \ :emphasis:`subfoo`\  is specified when \ :emphasis:`foo=bar`\  or \ :literal:`baz`\ .
+      Also required when :emphasis:`subfoo` is specified when :emphasis:`foo=bar` or :literal:`baz`.
 
-      \ :ansretval:`ns.col2.foo2#module:foobarbaz`\  does not exist.
+      :ansretval:`ns.col2.foo2#module:foobarbaz` does not exist.
 
 
       .. raw:: html
@@ -401,7 +399,6 @@ Attributes
       baz bam!
 
 
-
       .. raw:: html
 
         </div>
@@ -432,15 +429,14 @@ Attributes
 
       :ansible-attribute-support-property:`Platform:` |antsibull-internal-nbsp|:ansible-attribute-support-full:`posix`
 
-      The module \ :strong:`ERROR while parsing`\ : While parsing "M(boo)" at index 12: Module name "boo" is not a FQCN\  is not using an FQCN.
+      The module :strong:`ERROR while parsing`\ : While parsing "M(boo)" at index 12: Module name "boo" is not a FQCN is not using an FQCN.
 
-      Sometimes our markup is \ :strong:`ERROR while parsing`\ : While parsing "B(broken." at index 25: Cannot find closing ")" after last parameter\ 
+      Sometimes our markup is :strong:`ERROR while parsing`\ : While parsing "B(broken." at index 25: Cannot find closing ")" after last parameter
 
       Foo bar baz. Bamm - Bar baz
       bam bum.
       Bumm - Foo bar
       baz bam!
-
 
 
       .. raw:: html
@@ -471,7 +467,6 @@ Notes
      Bumm - Foo bar
      baz bam!
 
-
 .. Seealso
 
 See Also
@@ -498,7 +493,6 @@ See Also
        bam bum.
        Bumm - Foo bar
        baz bam!
-
 
 .. Examples
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/foo3_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/foo3_module.rst
@@ -227,7 +227,7 @@ Parameters
 
       Whatever.
 
-      Also required when \ :emphasis:`subfoo`\  is specified when \ :emphasis:`foo=bar`\  or \ :literal:`baz`\ .
+      Also required when :emphasis:`subfoo` is specified when :emphasis:`foo=bar` or :literal:`baz`.
 
 
       .. raw:: html

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/foo4_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/foo4_module.rst
@@ -102,19 +102,19 @@ Parameters
 
         <div class="ansible-option-cell">
 
-      \ :ansopt:`ansible.builtin.iptables#module:tcp\_flags.flags[]`\ 
+      :ansopt:`ansible.builtin.iptables#module:tcp\_flags.flags[]`
 
-      \ :ansopt:`ns2.col.bar#filter:foo`\ 
+      :ansopt:`ns2.col.bar#filter:foo`
 
-      \ :ansopt:`ns2.col.bar#filter:foo[]`\ 
+      :ansopt:`ns2.col.bar#filter:foo[]`
 
-      \ :ansopt:`ext.col.foo#module:foo[baz].bar`\ 
+      :ansopt:`ext.col.foo#module:foo[baz].bar`
 
-      \ :ansretval:`ext.col.foo#module:baz`\ 
+      :ansretval:`ext.col.foo#module:baz`
 
-      \ :ansretval:`ext.col.foo#module:baz[ ]`\ 
+      :ansretval:`ext.col.foo#module:baz[ ]`
 
-      \ :ansretval:`ansible.builtin.stat#module:stat[foo.bar]`\ 
+      :ansretval:`ansible.builtin.stat#module:stat[foo.bar]`
 
 
       .. raw:: html
@@ -148,47 +148,47 @@ Parameters
 
         <div class="ansible-option-cell">
 
-      \ :ref:`ansible.builtin.service <ansible_collections.ansible.builtin.service_module>`\ 
+      :ref:`ansible.builtin.service <ansible_collections.ansible.builtin.service_module>`
 
-      \ :ref:`ansible.builtin.pipe <ansible_collections.ansible.builtin.pipe_lookup>`\ 
+      :ref:`ansible.builtin.pipe <ansible_collections.ansible.builtin.pipe_lookup>`
 
-      \ :ansopt:`ansible.builtin.file#module:state`\ 
+      :ansopt:`ansible.builtin.file#module:state`
 
-      \ :ansretval:`ansible.builtin.stat#module:stat.exists`\ 
+      :ansretval:`ansible.builtin.stat#module:stat.exists`
 
-      \ :ref:`ns2.flatcol.foo <ansible_collections.ns2.flatcol.foo_module>`\ 
+      :ref:`ns2.flatcol.foo <ansible_collections.ns2.flatcol.foo_module>`
 
-      \ :ref:`ns2.flatcol.sub.foo2 <ansible_collections.ns2.flatcol.sub.foo2_module>`\ 
+      :ref:`ns2.flatcol.sub.foo2 <ansible_collections.ns2.flatcol.sub.foo2_module>`
 
-      \ :ansopt:`ns2.flatcol.foo#module:subbaz.bam`\ 
+      :ansopt:`ns2.flatcol.foo#module:subbaz.bam`
 
-      \ :ansretval:`ns2.flatcol.sub.foo2#module:bar`\ 
+      :ansretval:`ns2.flatcol.sub.foo2#module:bar`
 
-      \ :ref:`ns2.col.foo2 <ansible_collections.ns2.col.foo2_module>`\ 
+      :ref:`ns2.col.foo2 <ansible_collections.ns2.col.foo2_module>`
 
-      \ :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>`\ 
+      :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>`
 
-      \ :ansopt:`ns2.col.bar#filter:foo[-1]`\ 
+      :ansopt:`ns2.col.bar#filter:foo[-1]`
 
-      \ :ansretval:`ns2.col.bar#test:\_value`\ 
+      :ansretval:`ns2.col.bar#test:\_value`
 
-      \ :ref:`ns.col2.foo2 <ansible_collections.ns.col2.foo2_module>`\ 
+      :ref:`ns.col2.foo2 <ansible_collections.ns.col2.foo2_module>`
 
-      \ :ref:`ns.col2.foo2 <ansible_collections.ns.col2.foo2_module>`\ 
+      :ref:`ns.col2.foo2 <ansible_collections.ns.col2.foo2_module>`
 
-      \ :ansopt:`ns.col2.foo2#module:subfoo.foo`\ 
+      :ansopt:`ns.col2.foo2#module:subfoo.foo`
 
-      \ :ansretval:`ns.col2.foo2#module:bar`\ 
+      :ansretval:`ns.col2.foo2#module:bar`
 
-      \ :ref:`ext.col.foo <ansible_collections.ext.col.foo_module>`\ 
+      :ref:`ext.col.foo <ansible_collections.ext.col.foo_module>`
 
-      \ :ref:`ext.col.bar <ansible_collections.ext.col.bar_lookup>`\ 
+      :ref:`ext.col.bar <ansible_collections.ext.col.bar_lookup>`
 
-      \ :ansopt:`ext.col.foo#module:foo[len(foo)].bar`\ 
+      :ansopt:`ext.col.foo#module:foo[len(foo)].bar`
 
-      \ :ansretval:`ext.col.foo#module:baz[]`\ 
+      :ansretval:`ext.col.foo#module:baz[]`
 
-      \ :ansopt:`ns.col2.foo2#module:subfoo.BaZ`\ 
+      :ansopt:`ns.col2.foo2#module:subfoo.BaZ`
 
 
       .. raw:: html
@@ -222,17 +222,17 @@ Parameters
 
         <div class="ansible-option-cell">
 
-      \ :ansopt:`ansible.builtin.file#module:state[]`\ 
+      :ansopt:`ansible.builtin.file#module:state[]`
 
-      \ :ansretval:`ansible.builtin.stat#module:stat[foo.bar].exists`\ 
+      :ansretval:`ansible.builtin.stat#module:stat[foo.bar].exists`
 
-      \ :ansretval:`ansible.builtin.stat#module:stat.exists[]`\ 
+      :ansretval:`ansible.builtin.stat#module:stat.exists[]`
 
-      \ :ansopt:`ns.col2.foo2#module:subfoo[`\ 
+      :ansopt:`ns.col2.foo2#module:subfoo[`
 
-      \ :ansretval:`ns.col2.foo2#module:bar[]`\ 
+      :ansretval:`ns.col2.foo2#module:bar[]`
 
-      \ :ansopt:`ext.col.foo#module:foo.bar`\ 
+      :ansopt:`ext.col.foo#module:foo.bar`
 
 
       .. raw:: html
@@ -266,67 +266,67 @@ Parameters
 
         <div class="ansible-option-cell">
 
-      \ :ref:`ansible.builtin.foobar <ansible_collections.ansible.builtin.foobar_module>`\ 
+      :ref:`ansible.builtin.foobar <ansible_collections.ansible.builtin.foobar_module>`
 
-      \ :ref:`ansible.builtin.bazbam <ansible_collections.ansible.builtin.bazbam_lookup>`\ 
+      :ref:`ansible.builtin.bazbam <ansible_collections.ansible.builtin.bazbam_lookup>`
 
-      \ :ansopt:`ansible.builtin.file#module:foobarbaz`\ 
+      :ansopt:`ansible.builtin.file#module:foobarbaz`
 
-      \ :ansretval:`ansible.builtin.stat#module:baz.bam[]`\ 
+      :ansretval:`ansible.builtin.stat#module:baz.bam[]`
 
-      \ :ansopt:`ansible.builtin.foobar#module:state`\ 
+      :ansopt:`ansible.builtin.foobar#module:state`
 
-      \ :ansretval:`ansible.builtin.bazbam#module:stat.exists`\ 
+      :ansretval:`ansible.builtin.bazbam#module:stat.exists`
 
-      \ :ref:`ns2.flatcol.foobarbaz <ansible_collections.ns2.flatcol.foobarbaz_module>`\ 
+      :ref:`ns2.flatcol.foobarbaz <ansible_collections.ns2.flatcol.foobarbaz_module>`
 
-      \ :ref:`ns2.flatcol.sub.bazbam <ansible_collections.ns2.flatcol.sub.bazbam_module>`\ 
+      :ref:`ns2.flatcol.sub.bazbam <ansible_collections.ns2.flatcol.sub.bazbam_module>`
 
-      \ :ansopt:`ns2.flatcol.foo#module:foofoofoobar`\ 
+      :ansopt:`ns2.flatcol.foo#module:foofoofoobar`
 
-      \ :ansretval:`ns2.flatcol.sub.foo2#module:bazbarbam`\ 
+      :ansretval:`ns2.flatcol.sub.foo2#module:bazbarbam`
 
-      \ :ansopt:`ns2.flatcol.foobar#module:subbaz.bam`\ 
+      :ansopt:`ns2.flatcol.foobar#module:subbaz.bam`
 
-      \ :ansretval:`ns2.flatcol.sub.bazbam#module:bar`\ 
+      :ansretval:`ns2.flatcol.sub.bazbam#module:bar`
 
-      \ :ref:`ns2.col.joo <ansible_collections.ns2.col.joo_module>`\ 
+      :ref:`ns2.col.joo <ansible_collections.ns2.col.joo_module>`
 
-      \ :ref:`ns2.col.joo <ansible_collections.ns2.col.joo_lookup>`\ 
+      :ref:`ns2.col.joo <ansible_collections.ns2.col.joo_lookup>`
 
-      \ :ansopt:`ns2.col.bar#filter:jooo`\ 
+      :ansopt:`ns2.col.bar#filter:jooo`
 
-      \ :ansretval:`ns2.col.bar#test:booo`\ 
+      :ansretval:`ns2.col.bar#test:booo`
 
-      \ :ansopt:`ns2.col.joo#filter:foo[-1]`\ 
+      :ansopt:`ns2.col.joo#filter:foo[-1]`
 
-      \ :ansretval:`ns2.col.joo#test:\_value`\ 
+      :ansretval:`ns2.col.joo#test:\_value`
 
-      \ :ref:`ns.col2.foobarbaz <ansible_collections.ns.col2.foobarbaz_module>`\ 
+      :ref:`ns.col2.foobarbaz <ansible_collections.ns.col2.foobarbaz_module>`
 
-      \ :ref:`ns.col2.foobarbam <ansible_collections.ns.col2.foobarbam_filter>`\ 
+      :ref:`ns.col2.foobarbam <ansible_collections.ns.col2.foobarbam_filter>`
 
-      \ :ansopt:`ns.col2.foo2#module:barbazbam.foo`\ 
+      :ansopt:`ns.col2.foo2#module:barbazbam.foo`
 
-      \ :ansretval:`ns.col2.foo2#module:bambazbar`\ 
+      :ansretval:`ns.col2.foo2#module:bambazbar`
 
-      \ :ansopt:`ns.col2.foofoo#test:subfoo.foo`\ 
+      :ansopt:`ns.col2.foofoo#test:subfoo.foo`
 
-      \ :ansretval:`ns.col2.foofoo#lookup:baz`\ 
+      :ansretval:`ns.col2.foofoo#lookup:baz`
 
-      \ :ref:`ext.col.notthere <ansible_collections.ext.col.notthere_module>`\ 
+      :ref:`ext.col.notthere <ansible_collections.ext.col.notthere_module>`
 
-      \ :ref:`ext.col.notthere <ansible_collections.ext.col.notthere_lookup>`\ 
+      :ref:`ext.col.notthere <ansible_collections.ext.col.notthere_lookup>`
 
-      \ :ansopt:`ext.col.foo#module:foo[len(foo)].notthere`\ 
+      :ansopt:`ext.col.foo#module:foo[len(foo)].notthere`
 
-      \ :ansopt:`ext.col.foo#module:notthere[len(notthere)].bar`\ 
+      :ansopt:`ext.col.foo#module:notthere[len(notthere)].bar`
 
-      \ :ansretval:`ext.col.foo#module:notthere[]`\ 
+      :ansretval:`ext.col.foo#module:notthere[]`
 
-      \ :ansopt:`ext.col.notthere#module:foo[len(foo)].bar`\ 
+      :ansopt:`ext.col.notthere#module:foo[len(foo)].bar`
 
-      \ :ansretval:`ext.col.notthere#module:baz[]`\ 
+      :ansretval:`ext.col.notthere#module:baz[]`
 
 
       .. raw:: html

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/bar_filter.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/bar_filter.rst
@@ -281,16 +281,16 @@ example: ``input | ns2.col.bar(key1=value1, key2=value2, ...)``
       :ansible-option-choices:`Choices:`
 
       - :ansible-option-choices-entry:`"a"`\ :
-        Whatever \ :literal:`a`\  is.
+        Whatever :literal:`a` is.
 
       - :ansible-option-choices-entry:`"b"`\ :
-        What is \ :literal:`b`\ ? I don't know.
+        What is :literal:`b`\ ? I don't know.
 
       - :ansible-option-choices-entry:`"cde"`\ :
         This is some more unknown. There are rumors this is related to the alphabet.
 
       - :ansible-option-choices-entry-default:`"foo"` :ansible-option-choices-default-mark:`(default)`\ :
-        Our default value, the glorious \ :literal:`foo`\ .
+        Our default value, the glorious :literal:`foo`.
 
         Even has two paragraphs.
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/bar_test.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/bar_test.rst
@@ -189,7 +189,7 @@ Return Value
 
         <div class="ansible-option-cell">
 
-      Returns \ :literal:`true`\  if the path is a bar, \ :literal:`false`\  if it is not a bar.
+      Returns :literal:`true` if the path is a bar, :literal:`false` if it is not a bar.
 
 
       .. rst-class:: ansible-option-line

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo2_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo2_module.rst
@@ -49,8 +49,8 @@ Synopsis
 .. Description
 
 - Foo bar.
-- See \ :ansopt:`ns2.col.foo#role:main:foo\_param\_1`\  for a random role parameter reference. And \ :ansopt:`ns2.col.foo#role:main:foo\_param\_2=42`\  for one with a value.
-- Reference using alias - \ :ansopt:`ns2.col.foo\_redirect#module:bar`\  and \ :ansopt:`ns2.col.foo\_redirect#module:baz`\ .
+- See :ansopt:`ns2.col.foo#role:main:foo\_param\_1` for a random role parameter reference. And :ansopt:`ns2.col.foo#role:main:foo\_param\_2=42` for one with a value.
+- Reference using alias - :ansopt:`ns2.col.foo\_redirect#module:bar` and :ansopt:`ns2.col.foo\_redirect#module:baz`.
 
 
 .. Aliases
@@ -108,7 +108,7 @@ Parameters
 
       Some bar.
 
-      See \ :ansopt:`ns2.col.foo#role:main:foo\_param\_1`\  for a random role parameter reference. And \ :ansopt:`ns2.col.foo#role:main:foo\_param\_2=42`\  for one with a value.
+      See :ansopt:`ns2.col.foo#role:main:foo\_param\_1` for a random role parameter reference. And :ansopt:`ns2.col.foo#role:main:foo\_param\_2=42` for one with a value.
 
 
       .. raw:: html
@@ -168,7 +168,7 @@ Attributes
 
         <div class="ansible-option-cell">
 
-      Use \ :literal:`group/ns2.col.foo\_group`\  or \ :literal:`group/ns2.col.bar\_group`\  in \ :literal:`module\_defaults`\  to set defaults for this module.
+      Use :literal:`group/ns2.col.foo\_group` or :literal:`group/ns2.col.bar\_group` in :literal:`module\_defaults` to set defaults for this module.
 
 
       .. raw:: html
@@ -373,9 +373,9 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
 
       Some bar.
 
-      Referencing myself as \ :ansretval:`ns2.col.foo2#module:bar`\ .
+      Referencing myself as :ansretval:`ns2.col.foo2#module:bar`.
 
-      Do not confuse with \ :ansopt:`ns2.col.foo2#module:bar`\ .
+      Do not confuse with :ansopt:`ns2.col.foo2#module:bar`.
 
 
       .. rst-class:: ansible-option-line

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_become.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_become.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo become -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo become -- Use foo :ansopt:`ns2.col.foo#become:bar`
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -48,11 +48,9 @@ DEPRECATED
 :Why: Just some text.
       This one has more than one line.
       And one more.
-
 :Alternative: I don't know
               of any
               alternative.
-
 
 Synopsis
 --------
@@ -118,11 +116,9 @@ Parameters
       This one has more than one line though.
       One more.
 
-
       Alternative: nothing
       relevant
       I know of
-
 
 
 
@@ -135,11 +131,11 @@ Parameters
 
         <div class="ansible-option-cell">
 
-      Bar. \ :strong:`BAR!`\ 
+      Bar. :strong:`BAR!`
 
-      Totally unrelated to \ :ansopt:`ns2.col.foo#become:become\_user`\ . Even with \ :ansopt:`ns2.col.foo#become:become\_user=foo`\ .
+      Totally unrelated to :ansopt:`ns2.col.foo#become:become\_user`. Even with :ansopt:`ns2.col.foo#become:become\_user=foo`.
 
-      Might not be compatible when \ :ansopt:`ns2.col.foo#become:become\_user`\  is \ :ansval:`bar`\ , though.
+      Might not be compatible when :ansopt:`ns2.col.foo#become:become\_user` is :ansval:`bar`\ , though.
 
 
       .. raw:: html

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_cache.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_cache.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo cache -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo cache -- Foo files :ansopt:`ns2.col.foo#cache:bar`
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_callback.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_callback.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo callback -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo callback -- Foo output :ansopt:`ns2.col.foo#callback:bar`
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_connection.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_connection.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo connection -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo connection -- Foo connection :ansopt:`ns2.col.foo#connection:bar`
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -51,7 +51,7 @@ Synopsis
 
 .. Description
 
-- This is for the \ :literal:`foo`\  connection.
+- This is for the :literal:`foo` connection.
 
 
 .. Aliases
@@ -183,8 +183,8 @@ Notes
 -----
 
 .. note::
-   - Some note. \ :strong:`Something in bold`\ . \ :literal:`And in code`\ . \ :emphasis:`And in italics`\ . An URL: \ `https://example.org <https://example.org>`__\ .
-   - And another one. \ `A link <https://example.com>`__\ .
+   - Some note. :strong:`Something in bold`. :literal:`And in code`. :emphasis:`And in italics`. An URL: \ `https://example.org <https://example.org>`__.
+   - And another one. \ `A link <https://example.com>`__.
 
 .. Seealso
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_filter.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_filter.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo filter -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo filter -- The foo filter :ansopt:`ns2.col.foo#filter:bar`
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_inventory.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_inventory.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo inventory -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo inventory -- The foo inventory :ansopt:`ns2.col.foo#inventory:bar`
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_lookup.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_lookup.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo lookup -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo lookup -- Look up some foo :ansopt:`ns2.col.foo#lookup:bar`
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_module.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo module -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo module -- Do some foo :ansopt:`ns2.col.foo#module:bar`
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -55,7 +55,7 @@ Synopsis
 
 - Does some foo on the remote host.
 - Whether foo is magic or not has not yet been determined.
-- \ :ansenvvarref:`FOOBAR1`\ , \ :ansenvvarref:`FOOBAR2`\ , \ :ansenvvar:`FOOBAR3`\ , \ :ansenvvar:`FOOBAR4`\ .
+- :ansenvvarref:`FOOBAR1`\ , :ansenvvarref:`FOOBAR2`\ , :ansenvvar:`FOOBAR3`\ , :ansenvvar:`FOOBAR4`.
 
 
 .. Aliases
@@ -126,9 +126,9 @@ Parameters
 
       A bar.
 
-      Independent from \ :ansopt:`ns2.col.foo#module:foo`\ .
+      Independent from :ansopt:`ns2.col.foo#module:foo`.
 
-      Do not confuse with \ :ansretval:`ns2.col.foo#module:bar`\ .
+      Do not confuse with :ansretval:`ns2.col.foo#module:bar`.
 
 
       .. raw:: html
@@ -204,7 +204,7 @@ Parameters
 
       The 'pkg\_info' option was added in version 2.13.
 
-      Aliases were added in 2.18, to support using \ :literal:`auto={{ansible\_facts['pkg\_mgr']}}`\ 
+      Aliases were added in 2.18, to support using :literal:`auto={{ansible\_facts['pkg\_mgr']}}`
 
 
       .. rst-class:: ansible-option-line
@@ -215,10 +215,10 @@ Parameters
         Alpine Linux package manager
 
       - :ansible-option-choices-entry:`"apt"`\ :
-        For DEB based distros, \ :literal:`python-apt`\  package must be installed on targeted hosts
+        For DEB based distros, :literal:`python-apt` package must be installed on targeted hosts
 
       - :ansible-option-choices-entry-default:`"auto"` :ansible-option-choices-default-mark:`(default)`\ :
-        Depending on \ :ansopt:`strategy`\ , will match the first or all package managers provided, in order
+        Depending on :ansopt:`strategy`\ , will match the first or all package managers provided, in order
 
       - :ansible-option-choices-entry:`"dnf"`\ :
         Alias to rpm
@@ -245,7 +245,7 @@ Parameters
         Alias to pkg
 
       - :ansible-option-choices-entry:`"portage"`\ :
-        Handles ebuild packages, it requires the \ :literal:`qlist`\  utility, which is part of 'app-portage/portage-utils'
+        Handles ebuild packages, it requires the :literal:`qlist` utility, which is part of 'app-portage/portage-utils'
 
       - :ansible-option-choices-entry:`"rpm"`\ :
         For RPM based distros, requires RPM Python bindings, not installed by default on Suse (python3-rpm)
@@ -342,7 +342,7 @@ Parameters
 
       Whatever.
 
-      Also required when \ :ansopt:`ns2.col.foo#module:subfoo`\  is specified when \ :ansopt:`ns2.col.foo#module:foo=bar`\  or \ :ansval:`baz`\ .
+      Also required when :ansopt:`ns2.col.foo#module:subfoo` is specified when :ansopt:`ns2.col.foo#module:foo=bar` or :ansval:`baz`.
 
 
       .. raw:: html
@@ -403,7 +403,7 @@ Attributes
 
         <div class="ansible-option-cell">
 
-      Use \ :literal:`group/ns2.col.foo\_group`\  in \ :literal:`module\_defaults`\  to set defaults for this module.
+      Use :literal:`group/ns2.col.foo\_group` in :literal:`module\_defaults` to set defaults for this module.
 
 
       .. raw:: html
@@ -551,7 +551,7 @@ See Also
    \ :ref:`ns2.col.foo2 <ansible_collections.ns2.col.foo2_module>`\ 
        Another foo.
    \ :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>`\  lookup plugin
-       Look up some foo \ :ansopt:`ns2.col.foo#module:bar`\ .
+       Look up some foo :ansopt:`ns2.col.foo#module:bar`.
    \ :ref:`ansible.builtin.service <ansible_collections.ansible.builtin.service_module>`\ 
        The service module.
    \ :ref:`ansible.builtin.ssh <ansible_collections.ansible.builtin.ssh_connection>`\  connection plugin
@@ -627,9 +627,9 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
 
       Some bar.
 
-      Referencing myself as \ :ansretval:`ns2.col.foo#module:bar`\ .
+      Referencing myself as :ansretval:`ns2.col.foo#module:bar`.
 
-      Do not confuse with \ :ansopt:`ns2.col.foo#module:bar`\ .
+      Do not confuse with :ansopt:`ns2.col.foo#module:bar`.
 
 
       .. rst-class:: ansible-option-line

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_role.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_role.rst
@@ -55,11 +55,9 @@ DEPRECATED
 :Why: Just some text.
       This one has more than one line.
       And one more.
-
 :Alternative: I don't know
               of any
               alternative.
-
 
 Synopsis
 ^^^^^^^^
@@ -67,7 +65,7 @@ Synopsis
 .. Description
 
 - This is the foo role.
-- If you set \ :ansopt:`ns2.col.foo#role:main:foo\_param\_1`\  while \ :ansopt:`ns2.col.foo#role:main:foo\_param\_2=3`\ , this might behave funny.
+- If you set :ansopt:`ns2.col.foo#role:main:foo\_param\_1` while :ansopt:`ns2.col.foo#role:main:foo\_param\_2=3`\ , this might behave funny.
 
 .. Requirements
 
@@ -120,7 +118,7 @@ Parameters
 
       A string parameter
 
-      If you set \ :ansopt:`ns2.col.foo#role:main:foo\_param\_1`\  while \ :ansopt:`ns2.col.foo#role:main:foo\_param\_2=3`\ , this might behave funny.
+      If you set :ansopt:`ns2.col.foo#role:main:foo\_param\_1` while :ansopt:`ns2.col.foo#role:main:foo\_param\_2=3`\ , this might behave funny.
 
 
       .. raw:: html

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_shell.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_shell.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo shell -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo shell -- Foo shell :ansopt:`ns2.col.foo#shell:bar`
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_test.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_test.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo test -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo test -- Is something a foo :ansopt:`ns2.col.foo#test:bar`
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_vars.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_vars.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo vars -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo vars -- Load foo :ansopt:`ns2.col.foo#vars:bar`
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/index.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/index.rst
@@ -20,9 +20,7 @@ Description
 -----------
 
 This is a description.
-
 With multiple paragraphs.
-
 
 **Author:**
 
@@ -93,7 +91,7 @@ These are the plugins in the ns2.col collection:
 Modules
 ~~~~~~~
 
-* :ansplugin:`foo module <ns2.col.foo#module>` -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
+* :ansplugin:`foo module <ns2.col.foo#module>` -- Do some foo :ansopt:`ns2.col.foo#module:bar`
 * :ansplugin:`foo2 module <ns2.col.foo2#module>` -- Another foo
 * :ansplugin:`sub.foo3 module <ns2.col.sub.foo3#module>` -- A sub-foo
 
@@ -101,19 +99,19 @@ Modules
 Become Plugins
 ~~~~~~~~~~~~~~
 
-* :ansplugin:`foo become <ns2.col.foo#become>` -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
+* :ansplugin:`foo become <ns2.col.foo#become>` -- Use foo :ansopt:`ns2.col.foo#become:bar`
 
 
 Cache Plugins
 ~~~~~~~~~~~~~
 
-* :ansplugin:`foo cache <ns2.col.foo#cache>` -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
+* :ansplugin:`foo cache <ns2.col.foo#cache>` -- Foo files :ansopt:`ns2.col.foo#cache:bar`
 
 
 Callback Plugins
 ~~~~~~~~~~~~~~~~
 
-* :ansplugin:`foo callback <ns2.col.foo#callback>` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
+* :ansplugin:`foo callback <ns2.col.foo#callback>` -- Foo output :ansopt:`ns2.col.foo#callback:bar`
 
 
 Cliconf Plugins
@@ -125,32 +123,32 @@ Cliconf Plugins
 Connection Plugins
 ~~~~~~~~~~~~~~~~~~
 
-* :ansplugin:`foo connection <ns2.col.foo#connection>` -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
+* :ansplugin:`foo connection <ns2.col.foo#connection>` -- Foo connection :ansopt:`ns2.col.foo#connection:bar`
 
 
 Filter Plugins
 ~~~~~~~~~~~~~~
 
 * :ansplugin:`bar filter <ns2.col.bar#filter>` -- The bar filter
-* :ansplugin:`foo filter <ns2.col.foo#filter>` -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
+* :ansplugin:`foo filter <ns2.col.foo#filter>` -- The foo filter :ansopt:`ns2.col.foo#filter:bar`
 
 
 Inventory Plugins
 ~~~~~~~~~~~~~~~~~
 
-* :ansplugin:`foo inventory <ns2.col.foo#inventory>` -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
+* :ansplugin:`foo inventory <ns2.col.foo#inventory>` -- The foo inventory :ansopt:`ns2.col.foo#inventory:bar`
 
 
 Lookup Plugins
 ~~~~~~~~~~~~~~
 
-* :ansplugin:`foo lookup <ns2.col.foo#lookup>` -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
+* :ansplugin:`foo lookup <ns2.col.foo#lookup>` -- Look up some foo :ansopt:`ns2.col.foo#lookup:bar`
 
 
 Shell Plugins
 ~~~~~~~~~~~~~
 
-* :ansplugin:`foo shell <ns2.col.foo#shell>` -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
+* :ansplugin:`foo shell <ns2.col.foo#shell>` -- Foo shell :ansopt:`ns2.col.foo#shell:bar`
 
 
 Strategy Plugins
@@ -163,13 +161,13 @@ Test Plugins
 ~~~~~~~~~~~~
 
 * :ansplugin:`bar test <ns2.col.bar#test>` -- Is something a bar
-* :ansplugin:`foo test <ns2.col.foo#test>` -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
+* :ansplugin:`foo test <ns2.col.foo#test>` -- Is something a foo :ansopt:`ns2.col.foo#test:bar`
 
 
 Vars Plugins
 ~~~~~~~~~~~~
 
-* :ansplugin:`foo vars <ns2.col.foo#vars>` -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
+* :ansplugin:`foo vars <ns2.col.foo#vars>` -- Load foo :ansopt:`ns2.col.foo#vars:bar`
 
 
 Role Index

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/sub.foo3_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/sub.foo3_module.rst
@@ -49,7 +49,7 @@ Synopsis
 .. Description
 
 - Foo sub bar.
-- See \ :ansopt:`ns2.col.foo#role:main:foo\_param\_1`\  for a random role parameter reference. And \ :ansopt:`ns2.col.foo#role:main:foo\_param\_2=42`\  for one with a value.
+- See :ansopt:`ns2.col.foo#role:main:foo\_param\_1` for a random role parameter reference. And :ansopt:`ns2.col.foo#role:main:foo\_param\_2=42` for one with a value.
 
 
 .. Aliases
@@ -107,7 +107,7 @@ Parameters
 
       Some bar.
 
-      See \ :ansopt:`ns2.col.foo#role:main:foo\_param\_1`\  for a random role parameter reference. And \ :ansopt:`ns2.col.foo#role:main:foo\_param\_2=42`\  for one with a value.
+      See :ansopt:`ns2.col.foo#role:main:foo\_param\_1` for a random role parameter reference. And :ansopt:`ns2.col.foo#role:main:foo\_param\_2=42` for one with a value.
 
 
       .. raw:: html
@@ -167,7 +167,7 @@ Attributes
 
         <div class="ansible-option-cell">
 
-      Use \ :literal:`group/ns2.col.foo\_group`\  or \ :literal:`group/ns2.col.bar\_group`\  in \ :literal:`module\_defaults`\  to set defaults for this module.
+      Use :literal:`group/ns2.col.foo\_group` or :literal:`group/ns2.col.bar\_group` in :literal:`module\_defaults` to set defaults for this module.
 
 
       .. raw:: html
@@ -372,9 +372,9 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
 
       Some bar.
 
-      Referencing myself as \ :ansretval:`ns2.col.sub.foo3#module:bar`\ .
+      Referencing myself as :ansretval:`ns2.col.sub.foo3#module:bar`.
 
-      Do not confuse with \ :ansopt:`ns2.col.sub.foo3#module:bar`\ .
+      Do not confuse with :ansopt:`ns2.col.sub.foo3#module:bar`.
 
 
       .. rst-class:: ansible-option-line

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/flatcol/foo2_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/flatcol/foo2_module.rst
@@ -49,7 +49,7 @@ Synopsis
 .. Description
 
 - Foo bar.
-- See \ :ansopt:`ns2.flatcol.foo#role:main:foo\_param\_1`\  for a random role parameter reference. And \ :ansopt:`ns2.flatcol.foo#role:main:foo\_param\_2=42`\  for one with a value.
+- See :ansopt:`ns2.flatcol.foo#role:main:foo\_param\_1` for a random role parameter reference. And :ansopt:`ns2.flatcol.foo#role:main:foo\_param\_2=42` for one with a value.
 
 
 .. Aliases
@@ -107,7 +107,7 @@ Parameters
 
       Some bar.
 
-      See \ :ansopt:`ns2.flatcol.foo#role:main:foo\_param\_1`\  for a random role parameter reference. And \ :ansopt:`ns2.flatcol.foo#role:main:foo\_param\_2=42`\  for one with a value.
+      See :ansopt:`ns2.flatcol.foo#role:main:foo\_param\_1` for a random role parameter reference. And :ansopt:`ns2.flatcol.foo#role:main:foo\_param\_2=42` for one with a value.
 
 
       .. raw:: html
@@ -188,9 +188,9 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
 
       Some bar.
 
-      Referencing myself as \ :ansretval:`ns2.flatcol.foo2#module:bar`\ .
+      Referencing myself as :ansretval:`ns2.flatcol.foo2#module:bar`.
 
-      Do not confuse with \ :ansopt:`ns2.flatcol.foo2#module:bar`\ .
+      Do not confuse with :ansopt:`ns2.flatcol.foo2#module:bar`.
 
 
       .. rst-class:: ansible-option-line

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/flatcol/foo_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/flatcol/foo_module.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.flatcol.foo module -- Do some foo \ :ansopt:`ns2.flatcol.foo#module:bar`\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.flatcol.foo module -- Do some foo :ansopt:`ns2.flatcol.foo#module:bar`
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -114,9 +114,9 @@ Parameters
 
       A bar.
 
-      Independent from \ :ansopt:`ns2.flatcol.foo#module:foo`\ .
+      Independent from :ansopt:`ns2.flatcol.foo#module:foo`.
 
-      Do not confuse with \ :ansretval:`ns2.flatcol.foo#module:bar`\ .
+      Do not confuse with :ansretval:`ns2.flatcol.foo#module:bar`.
 
 
       .. raw:: html
@@ -245,11 +245,11 @@ Parameters
 
       Whatever.
 
-      Also required when \ :ansopt:`ns2.flatcol.foo#module:subfoo`\  is specified when \ :ansopt:`ns2.flatcol.foo#module:foo=bar`\  or \ :ansval:`baz`\ .
+      Also required when :ansopt:`ns2.flatcol.foo#module:subfoo` is specified when :ansopt:`ns2.flatcol.foo#module:foo=bar` or :ansval:`baz`.
 
-      Note that \ :ansopt:`ns2.flatcol.foo#module:subfoo.foo`\  is the same as \ :ansopt:`ns2.flatcol.foo#module:subbaz.foo`\ , \ :ansopt:`ns2.flatcol.foo#module:subbaz.bam`\ , and \ :ansopt:`ns2.flatcol.foo#module:subfoo.bam`\ .
+      Note that :ansopt:`ns2.flatcol.foo#module:subfoo.foo` is the same as :ansopt:`ns2.flatcol.foo#module:subbaz.foo`\ , :ansopt:`ns2.flatcol.foo#module:subbaz.bam`\ , and :ansopt:`ns2.flatcol.foo#module:subfoo.bam`.
 
-      \ :ansenvvarref:`FOOBAR1`\ , \ :ansenvvarref:`FOOBAR2`\ , \ :ansenvvar:`FOOBAR3`\ , \ :ansenvvar:`FOOBAR4`\ .
+      :ansenvvarref:`FOOBAR1`\ , :ansenvvarref:`FOOBAR2`\ , :ansenvvar:`FOOBAR3`\ , :ansenvvar:`FOOBAR4`.
 
 
       .. raw:: html
@@ -337,9 +337,9 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
 
       Some bar.
 
-      Referencing myself as \ :ansretval:`ns2.flatcol.foo#module:bar`\ .
+      Referencing myself as :ansretval:`ns2.flatcol.foo#module:bar`.
 
-      Do not confuse with \ :ansopt:`ns2.flatcol.foo#module:bar`\ .
+      Do not confuse with :ansopt:`ns2.flatcol.foo#module:bar`.
 
 
       .. rst-class:: ansible-option-line

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/flatcol/index.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/flatcol/index.rst
@@ -58,7 +58,7 @@ These are the plugins in the ns2.flatcol collection:
 Modules
 ~~~~~~~
 
-* :ansplugin:`foo module <ns2.flatcol.foo#module>` -- Do some foo \ :ansopt:`ns2.flatcol.foo#module:bar`\ 
+* :ansplugin:`foo module <ns2.flatcol.foo#module>` -- Do some foo :ansopt:`ns2.flatcol.foo#module:bar`
 * :ansplugin:`foo2 module <ns2.flatcol.foo2#module>` -- Another foo
 
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/bar_filter.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/bar_filter.rst
@@ -281,16 +281,16 @@ example: ``input | ns2.col.bar(key1=value1, key2=value2, ...)``
       :ansible-option-choices:`Choices:`
 
       - :ansible-option-choices-entry:`"a"`\ :
-        Whatever \ :literal:`a`\  is.
+        Whatever :literal:`a` is.
 
       - :ansible-option-choices-entry:`"b"`\ :
-        What is \ :literal:`b`\ ? I don't know.
+        What is :literal:`b`\ ? I don't know.
 
       - :ansible-option-choices-entry:`"cde"`\ :
         This is some more unknown. There are rumors this is related to the alphabet.
 
       - :ansible-option-choices-entry-default:`"foo"` :ansible-option-choices-default-mark:`(default)`\ :
-        Our default value, the glorious \ :literal:`foo`\ .
+        Our default value, the glorious :literal:`foo`.
 
         Even has two paragraphs.
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/bar_test.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/bar_test.rst
@@ -189,7 +189,7 @@ Return Value
 
         <div class="ansible-option-cell">
 
-      Returns \ :literal:`true`\  if the path is a bar, \ :literal:`false`\  if it is not a bar.
+      Returns :literal:`true` if the path is a bar, :literal:`false` if it is not a bar.
 
 
       .. rst-class:: ansible-option-line

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo2_module.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo2_module.rst
@@ -49,8 +49,8 @@ Synopsis
 .. Description
 
 - Foo bar.
-- See \ :ansopt:`ns2.col.foo#role:main:foo\_param\_1`\  for a random role parameter reference. And \ :ansopt:`ns2.col.foo#role:main:foo\_param\_2=42`\  for one with a value.
-- Reference using alias - \ :ansopt:`ns2.col.foo\_redirect#module:bar`\  and \ :ansopt:`ns2.col.foo\_redirect#module:baz`\ .
+- See :ansopt:`ns2.col.foo#role:main:foo\_param\_1` for a random role parameter reference. And :ansopt:`ns2.col.foo#role:main:foo\_param\_2=42` for one with a value.
+- Reference using alias - :ansopt:`ns2.col.foo\_redirect#module:bar` and :ansopt:`ns2.col.foo\_redirect#module:baz`.
 
 
 .. Aliases
@@ -108,7 +108,7 @@ Parameters
 
       Some bar.
 
-      See \ :ansopt:`ns2.col.foo#role:main:foo\_param\_1`\  for a random role parameter reference. And \ :ansopt:`ns2.col.foo#role:main:foo\_param\_2=42`\  for one with a value.
+      See :ansopt:`ns2.col.foo#role:main:foo\_param\_1` for a random role parameter reference. And :ansopt:`ns2.col.foo#role:main:foo\_param\_2=42` for one with a value.
 
 
       .. raw:: html
@@ -168,7 +168,7 @@ Attributes
 
         <div class="ansible-option-cell">
 
-      Use \ :literal:`group/ns2.col.foo\_group`\  or \ :literal:`group/ns2.col.bar\_group`\  in \ :literal:`module\_defaults`\  to set defaults for this module.
+      Use :literal:`group/ns2.col.foo\_group` or :literal:`group/ns2.col.bar\_group` in :literal:`module\_defaults` to set defaults for this module.
 
 
       .. raw:: html
@@ -373,9 +373,9 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
 
       Some bar.
 
-      Referencing myself as \ :ansretval:`ns2.col.foo2#module:bar`\ .
+      Referencing myself as :ansretval:`ns2.col.foo2#module:bar`.
 
-      Do not confuse with \ :ansopt:`ns2.col.foo2#module:bar`\ .
+      Do not confuse with :ansopt:`ns2.col.foo2#module:bar`.
 
 
       .. rst-class:: ansible-option-line

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_become.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_become.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo become -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo become -- Use foo :ansopt:`ns2.col.foo#become:bar`
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -48,11 +48,9 @@ DEPRECATED
 :Why: Just some text.
       This one has more than one line.
       And one more.
-
 :Alternative: I don't know
               of any
               alternative.
-
 
 Synopsis
 --------
@@ -118,11 +116,9 @@ Parameters
       This one has more than one line though.
       One more.
 
-
       Alternative: nothing
       relevant
       I know of
-
 
 
 
@@ -135,11 +131,11 @@ Parameters
 
         <div class="ansible-option-cell">
 
-      Bar. \ :strong:`BAR!`\ 
+      Bar. :strong:`BAR!`
 
-      Totally unrelated to \ :ansopt:`ns2.col.foo#become:become\_user`\ . Even with \ :ansopt:`ns2.col.foo#become:become\_user=foo`\ .
+      Totally unrelated to :ansopt:`ns2.col.foo#become:become\_user`. Even with :ansopt:`ns2.col.foo#become:become\_user=foo`.
 
-      Might not be compatible when \ :ansopt:`ns2.col.foo#become:become\_user`\  is \ :ansval:`bar`\ , though.
+      Might not be compatible when :ansopt:`ns2.col.foo#become:become\_user` is :ansval:`bar`\ , though.
 
 
       .. raw:: html

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_cache.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_cache.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo cache -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo cache -- Foo files :ansopt:`ns2.col.foo#cache:bar`
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_callback.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_callback.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo callback -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo callback -- Foo output :ansopt:`ns2.col.foo#callback:bar`
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_connection.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_connection.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo connection -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo connection -- Foo connection :ansopt:`ns2.col.foo#connection:bar`
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -51,7 +51,7 @@ Synopsis
 
 .. Description
 
-- This is for the \ :literal:`foo`\  connection.
+- This is for the :literal:`foo` connection.
 
 
 .. Aliases
@@ -183,8 +183,8 @@ Notes
 -----
 
 .. note::
-   - Some note. \ :strong:`Something in bold`\ . \ :literal:`And in code`\ . \ :emphasis:`And in italics`\ . An URL: \ `https://example.org <https://example.org>`__\ .
-   - And another one. \ `A link <https://example.com>`__\ .
+   - Some note. :strong:`Something in bold`. :literal:`And in code`. :emphasis:`And in italics`. An URL: \ `https://example.org <https://example.org>`__.
+   - And another one. \ `A link <https://example.com>`__.
 
 .. Seealso
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_filter.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_filter.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo filter -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo filter -- The foo filter :ansopt:`ns2.col.foo#filter:bar`
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_inventory.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_inventory.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo inventory -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo inventory -- The foo inventory :ansopt:`ns2.col.foo#inventory:bar`
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_lookup.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_lookup.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo lookup -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo lookup -- Look up some foo :ansopt:`ns2.col.foo#lookup:bar`
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_module.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo module -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo module -- Do some foo :ansopt:`ns2.col.foo#module:bar`
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -55,7 +55,7 @@ Synopsis
 
 - Does some foo on the remote host.
 - Whether foo is magic or not has not yet been determined.
-- \ :ansenvvarref:`FOOBAR1`\ , \ :ansenvvarref:`FOOBAR2`\ , \ :ansenvvar:`FOOBAR3`\ , \ :ansenvvar:`FOOBAR4`\ .
+- :ansenvvarref:`FOOBAR1`\ , :ansenvvarref:`FOOBAR2`\ , :ansenvvar:`FOOBAR3`\ , :ansenvvar:`FOOBAR4`.
 
 
 .. Aliases
@@ -126,9 +126,9 @@ Parameters
 
       A bar.
 
-      Independent from \ :ansopt:`ns2.col.foo#module:foo`\ .
+      Independent from :ansopt:`ns2.col.foo#module:foo`.
 
-      Do not confuse with \ :ansretval:`ns2.col.foo#module:bar`\ .
+      Do not confuse with :ansretval:`ns2.col.foo#module:bar`.
 
 
       .. raw:: html
@@ -204,7 +204,7 @@ Parameters
 
       The 'pkg\_info' option was added in version 2.13.
 
-      Aliases were added in 2.18, to support using \ :literal:`auto={{ansible\_facts['pkg\_mgr']}}`\ 
+      Aliases were added in 2.18, to support using :literal:`auto={{ansible\_facts['pkg\_mgr']}}`
 
 
       .. rst-class:: ansible-option-line
@@ -215,10 +215,10 @@ Parameters
         Alpine Linux package manager
 
       - :ansible-option-choices-entry:`"apt"`\ :
-        For DEB based distros, \ :literal:`python-apt`\  package must be installed on targeted hosts
+        For DEB based distros, :literal:`python-apt` package must be installed on targeted hosts
 
       - :ansible-option-choices-entry-default:`"auto"` :ansible-option-choices-default-mark:`(default)`\ :
-        Depending on \ :ansopt:`strategy`\ , will match the first or all package managers provided, in order
+        Depending on :ansopt:`strategy`\ , will match the first or all package managers provided, in order
 
       - :ansible-option-choices-entry:`"dnf"`\ :
         Alias to rpm
@@ -245,7 +245,7 @@ Parameters
         Alias to pkg
 
       - :ansible-option-choices-entry:`"portage"`\ :
-        Handles ebuild packages, it requires the \ :literal:`qlist`\  utility, which is part of 'app-portage/portage-utils'
+        Handles ebuild packages, it requires the :literal:`qlist` utility, which is part of 'app-portage/portage-utils'
 
       - :ansible-option-choices-entry:`"rpm"`\ :
         For RPM based distros, requires RPM Python bindings, not installed by default on Suse (python3-rpm)
@@ -342,7 +342,7 @@ Parameters
 
       Whatever.
 
-      Also required when \ :ansopt:`ns2.col.foo#module:subfoo`\  is specified when \ :ansopt:`ns2.col.foo#module:foo=bar`\  or \ :ansval:`baz`\ .
+      Also required when :ansopt:`ns2.col.foo#module:subfoo` is specified when :ansopt:`ns2.col.foo#module:foo=bar` or :ansval:`baz`.
 
 
       .. raw:: html
@@ -403,7 +403,7 @@ Attributes
 
         <div class="ansible-option-cell">
 
-      Use \ :literal:`group/ns2.col.foo\_group`\  in \ :literal:`module\_defaults`\  to set defaults for this module.
+      Use :literal:`group/ns2.col.foo\_group` in :literal:`module\_defaults` to set defaults for this module.
 
 
       .. raw:: html
@@ -551,7 +551,7 @@ See Also
    \ :ref:`ns2.col.foo2 <ansible_collections.ns2.col.foo2_module>`\ 
        Another foo.
    \ :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>`\  lookup plugin
-       Look up some foo \ :ansopt:`ns2.col.foo#module:bar`\ .
+       Look up some foo :ansopt:`ns2.col.foo#module:bar`.
    \ :ref:`ansible.builtin.service <ansible_collections.ansible.builtin.service_module>`\ 
        The service module.
    \ :ref:`ansible.builtin.ssh <ansible_collections.ansible.builtin.ssh_connection>`\  connection plugin
@@ -627,9 +627,9 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
 
       Some bar.
 
-      Referencing myself as \ :ansretval:`ns2.col.foo#module:bar`\ .
+      Referencing myself as :ansretval:`ns2.col.foo#module:bar`.
 
-      Do not confuse with \ :ansopt:`ns2.col.foo#module:bar`\ .
+      Do not confuse with :ansopt:`ns2.col.foo#module:bar`.
 
 
       .. rst-class:: ansible-option-line

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_role.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_role.rst
@@ -55,11 +55,9 @@ DEPRECATED
 :Why: Just some text.
       This one has more than one line.
       And one more.
-
 :Alternative: I don't know
               of any
               alternative.
-
 
 Synopsis
 ^^^^^^^^
@@ -67,7 +65,7 @@ Synopsis
 .. Description
 
 - This is the foo role.
-- If you set \ :ansopt:`ns2.col.foo#role:main:foo\_param\_1`\  while \ :ansopt:`ns2.col.foo#role:main:foo\_param\_2=3`\ , this might behave funny.
+- If you set :ansopt:`ns2.col.foo#role:main:foo\_param\_1` while :ansopt:`ns2.col.foo#role:main:foo\_param\_2=3`\ , this might behave funny.
 
 .. Requirements
 
@@ -120,7 +118,7 @@ Parameters
 
       A string parameter
 
-      If you set \ :ansopt:`ns2.col.foo#role:main:foo\_param\_1`\  while \ :ansopt:`ns2.col.foo#role:main:foo\_param\_2=3`\ , this might behave funny.
+      If you set :ansopt:`ns2.col.foo#role:main:foo\_param\_1` while :ansopt:`ns2.col.foo#role:main:foo\_param\_2=3`\ , this might behave funny.
 
 
       .. raw:: html

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_shell.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_shell.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo shell -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo shell -- Foo shell :ansopt:`ns2.col.foo#shell:bar`
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_test.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_test.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo test -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo test -- Is something a foo :ansopt:`ns2.col.foo#test:bar`
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_vars.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_vars.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo vars -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo vars -- Load foo :ansopt:`ns2.col.foo#vars:bar`
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/index.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/index.rst
@@ -19,9 +19,7 @@ Description
 -----------
 
 This is a description.
-
 With multiple paragraphs.
-
 
 **Author:**
 
@@ -92,7 +90,7 @@ These are the plugins in the ns2.col collection:
 Modules
 ~~~~~~~
 
-* :ansplugin:`foo module <ns2.col.foo#module>` -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
+* :ansplugin:`foo module <ns2.col.foo#module>` -- Do some foo :ansopt:`ns2.col.foo#module:bar`
 * :ansplugin:`foo2 module <ns2.col.foo2#module>` -- Another foo
 * :ansplugin:`sub.foo3 module <ns2.col.sub.foo3#module>` -- A sub-foo
 
@@ -108,7 +106,7 @@ Modules
 Become Plugins
 ~~~~~~~~~~~~~~
 
-* :ansplugin:`foo become <ns2.col.foo#become>` -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
+* :ansplugin:`foo become <ns2.col.foo#become>` -- Use foo :ansopt:`ns2.col.foo#become:bar`
 
 .. toctree::
     :maxdepth: 1
@@ -120,7 +118,7 @@ Become Plugins
 Cache Plugins
 ~~~~~~~~~~~~~
 
-* :ansplugin:`foo cache <ns2.col.foo#cache>` -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
+* :ansplugin:`foo cache <ns2.col.foo#cache>` -- Foo files :ansopt:`ns2.col.foo#cache:bar`
 
 .. toctree::
     :maxdepth: 1
@@ -132,7 +130,7 @@ Cache Plugins
 Callback Plugins
 ~~~~~~~~~~~~~~~~
 
-* :ansplugin:`foo callback <ns2.col.foo#callback>` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
+* :ansplugin:`foo callback <ns2.col.foo#callback>` -- Foo output :ansopt:`ns2.col.foo#callback:bar`
 
 .. toctree::
     :maxdepth: 1
@@ -156,7 +154,7 @@ Cliconf Plugins
 Connection Plugins
 ~~~~~~~~~~~~~~~~~~
 
-* :ansplugin:`foo connection <ns2.col.foo#connection>` -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
+* :ansplugin:`foo connection <ns2.col.foo#connection>` -- Foo connection :ansopt:`ns2.col.foo#connection:bar`
 
 .. toctree::
     :maxdepth: 1
@@ -169,7 +167,7 @@ Filter Plugins
 ~~~~~~~~~~~~~~
 
 * :ansplugin:`bar filter <ns2.col.bar#filter>` -- The bar filter
-* :ansplugin:`foo filter <ns2.col.foo#filter>` -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
+* :ansplugin:`foo filter <ns2.col.foo#filter>` -- The foo filter :ansopt:`ns2.col.foo#filter:bar`
 
 .. toctree::
     :maxdepth: 1
@@ -182,7 +180,7 @@ Filter Plugins
 Inventory Plugins
 ~~~~~~~~~~~~~~~~~
 
-* :ansplugin:`foo inventory <ns2.col.foo#inventory>` -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
+* :ansplugin:`foo inventory <ns2.col.foo#inventory>` -- The foo inventory :ansopt:`ns2.col.foo#inventory:bar`
 
 .. toctree::
     :maxdepth: 1
@@ -194,7 +192,7 @@ Inventory Plugins
 Lookup Plugins
 ~~~~~~~~~~~~~~
 
-* :ansplugin:`foo lookup <ns2.col.foo#lookup>` -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
+* :ansplugin:`foo lookup <ns2.col.foo#lookup>` -- Look up some foo :ansopt:`ns2.col.foo#lookup:bar`
 
 .. toctree::
     :maxdepth: 1
@@ -206,7 +204,7 @@ Lookup Plugins
 Shell Plugins
 ~~~~~~~~~~~~~
 
-* :ansplugin:`foo shell <ns2.col.foo#shell>` -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
+* :ansplugin:`foo shell <ns2.col.foo#shell>` -- Foo shell :ansopt:`ns2.col.foo#shell:bar`
 
 .. toctree::
     :maxdepth: 1
@@ -231,7 +229,7 @@ Test Plugins
 ~~~~~~~~~~~~
 
 * :ansplugin:`bar test <ns2.col.bar#test>` -- Is something a bar
-* :ansplugin:`foo test <ns2.col.foo#test>` -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
+* :ansplugin:`foo test <ns2.col.foo#test>` -- Is something a foo :ansopt:`ns2.col.foo#test:bar`
 
 .. toctree::
     :maxdepth: 1
@@ -244,7 +242,7 @@ Test Plugins
 Vars Plugins
 ~~~~~~~~~~~~
 
-* :ansplugin:`foo vars <ns2.col.foo#vars>` -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
+* :ansplugin:`foo vars <ns2.col.foo#vars>` -- Load foo :ansopt:`ns2.col.foo#vars:bar`
 
 .. toctree::
     :maxdepth: 1

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/sub.foo3_module.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/sub.foo3_module.rst
@@ -49,7 +49,7 @@ Synopsis
 .. Description
 
 - Foo sub bar.
-- See \ :ansopt:`ns2.col.foo#role:main:foo\_param\_1`\  for a random role parameter reference. And \ :ansopt:`ns2.col.foo#role:main:foo\_param\_2=42`\  for one with a value.
+- See :ansopt:`ns2.col.foo#role:main:foo\_param\_1` for a random role parameter reference. And :ansopt:`ns2.col.foo#role:main:foo\_param\_2=42` for one with a value.
 
 
 .. Aliases
@@ -107,7 +107,7 @@ Parameters
 
       Some bar.
 
-      See \ :ansopt:`ns2.col.foo#role:main:foo\_param\_1`\  for a random role parameter reference. And \ :ansopt:`ns2.col.foo#role:main:foo\_param\_2=42`\  for one with a value.
+      See :ansopt:`ns2.col.foo#role:main:foo\_param\_1` for a random role parameter reference. And :ansopt:`ns2.col.foo#role:main:foo\_param\_2=42` for one with a value.
 
 
       .. raw:: html
@@ -167,7 +167,7 @@ Attributes
 
         <div class="ansible-option-cell">
 
-      Use \ :literal:`group/ns2.col.foo\_group`\  or \ :literal:`group/ns2.col.bar\_group`\  in \ :literal:`module\_defaults`\  to set defaults for this module.
+      Use :literal:`group/ns2.col.foo\_group` or :literal:`group/ns2.col.bar\_group` in :literal:`module\_defaults` to set defaults for this module.
 
 
       .. raw:: html
@@ -372,9 +372,9 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
 
       Some bar.
 
-      Referencing myself as \ :ansretval:`ns2.col.sub.foo3#module:bar`\ .
+      Referencing myself as :ansretval:`ns2.col.sub.foo3#module:bar`.
 
-      Do not confuse with \ :ansopt:`ns2.col.sub.foo3#module:bar`\ .
+      Do not confuse with :ansopt:`ns2.col.sub.foo3#module:bar`.
 
 
       .. rst-class:: ansible-option-line

--- a/tests/functional/baseline-no-indexes/collections/ns2/flatcol/foo2_module.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/flatcol/foo2_module.rst
@@ -49,7 +49,7 @@ Synopsis
 .. Description
 
 - Foo bar.
-- See \ :ansopt:`ns2.flatcol.foo#role:main:foo\_param\_1`\  for a random role parameter reference. And \ :ansopt:`ns2.flatcol.foo#role:main:foo\_param\_2=42`\  for one with a value.
+- See :ansopt:`ns2.flatcol.foo#role:main:foo\_param\_1` for a random role parameter reference. And :ansopt:`ns2.flatcol.foo#role:main:foo\_param\_2=42` for one with a value.
 
 
 .. Aliases
@@ -107,7 +107,7 @@ Parameters
 
       Some bar.
 
-      See \ :ansopt:`ns2.flatcol.foo#role:main:foo\_param\_1`\  for a random role parameter reference. And \ :ansopt:`ns2.flatcol.foo#role:main:foo\_param\_2=42`\  for one with a value.
+      See :ansopt:`ns2.flatcol.foo#role:main:foo\_param\_1` for a random role parameter reference. And :ansopt:`ns2.flatcol.foo#role:main:foo\_param\_2=42` for one with a value.
 
 
       .. raw:: html
@@ -188,9 +188,9 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
 
       Some bar.
 
-      Referencing myself as \ :ansretval:`ns2.flatcol.foo2#module:bar`\ .
+      Referencing myself as :ansretval:`ns2.flatcol.foo2#module:bar`.
 
-      Do not confuse with \ :ansopt:`ns2.flatcol.foo2#module:bar`\ .
+      Do not confuse with :ansopt:`ns2.flatcol.foo2#module:bar`.
 
 
       .. rst-class:: ansible-option-line

--- a/tests/functional/baseline-no-indexes/collections/ns2/flatcol/foo_module.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/flatcol/foo_module.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.flatcol.foo module -- Do some foo \ :ansopt:`ns2.flatcol.foo#module:bar`\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.flatcol.foo module -- Do some foo :ansopt:`ns2.flatcol.foo#module:bar`
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -114,9 +114,9 @@ Parameters
 
       A bar.
 
-      Independent from \ :ansopt:`ns2.flatcol.foo#module:foo`\ .
+      Independent from :ansopt:`ns2.flatcol.foo#module:foo`.
 
-      Do not confuse with \ :ansretval:`ns2.flatcol.foo#module:bar`\ .
+      Do not confuse with :ansretval:`ns2.flatcol.foo#module:bar`.
 
 
       .. raw:: html
@@ -245,11 +245,11 @@ Parameters
 
       Whatever.
 
-      Also required when \ :ansopt:`ns2.flatcol.foo#module:subfoo`\  is specified when \ :ansopt:`ns2.flatcol.foo#module:foo=bar`\  or \ :ansval:`baz`\ .
+      Also required when :ansopt:`ns2.flatcol.foo#module:subfoo` is specified when :ansopt:`ns2.flatcol.foo#module:foo=bar` or :ansval:`baz`.
 
-      Note that \ :ansopt:`ns2.flatcol.foo#module:subfoo.foo`\  is the same as \ :ansopt:`ns2.flatcol.foo#module:subbaz.foo`\ , \ :ansopt:`ns2.flatcol.foo#module:subbaz.bam`\ , and \ :ansopt:`ns2.flatcol.foo#module:subfoo.bam`\ .
+      Note that :ansopt:`ns2.flatcol.foo#module:subfoo.foo` is the same as :ansopt:`ns2.flatcol.foo#module:subbaz.foo`\ , :ansopt:`ns2.flatcol.foo#module:subbaz.bam`\ , and :ansopt:`ns2.flatcol.foo#module:subfoo.bam`.
 
-      \ :ansenvvarref:`FOOBAR1`\ , \ :ansenvvarref:`FOOBAR2`\ , \ :ansenvvar:`FOOBAR3`\ , \ :ansenvvar:`FOOBAR4`\ .
+      :ansenvvarref:`FOOBAR1`\ , :ansenvvarref:`FOOBAR2`\ , :ansenvvar:`FOOBAR3`\ , :ansenvvar:`FOOBAR4`.
 
 
       .. raw:: html
@@ -337,9 +337,9 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
 
       Some bar.
 
-      Referencing myself as \ :ansretval:`ns2.flatcol.foo#module:bar`\ .
+      Referencing myself as :ansretval:`ns2.flatcol.foo#module:bar`.
 
-      Do not confuse with \ :ansopt:`ns2.flatcol.foo#module:bar`\ .
+      Do not confuse with :ansopt:`ns2.flatcol.foo#module:bar`.
 
 
       .. rst-class:: ansible-option-line

--- a/tests/functional/baseline-no-indexes/collections/ns2/flatcol/index.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/flatcol/index.rst
@@ -57,7 +57,7 @@ These are the plugins in the ns2.flatcol collection:
 Modules
 ~~~~~~~
 
-* :ansplugin:`foo module <ns2.flatcol.foo#module>` -- Do some foo \ :ansopt:`ns2.flatcol.foo#module:bar`\ 
+* :ansplugin:`foo module <ns2.flatcol.foo#module>` -- Do some foo :ansopt:`ns2.flatcol.foo#module:bar`
 * :ansplugin:`foo2 module <ns2.flatcol.foo2#module>` -- Another foo
 
 .. toctree::

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo2_module.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo2_module.rst
@@ -23,8 +23,8 @@ Synopsis
 --------
 
 - Foo bar.
-- See \ :literal:`foo\_param\_1` (of role `ns2.col.foo <foo_role.rst>`__, entrypoint main)\  for a random role parameter reference. And \ :literal:`foo\_param\_2=42` (of role `ns2.col.foo <foo_role.rst>`__, entrypoint main)\  for one with a value.
-- Reference using alias - \ :literal:`bar` (of module `ns2.col.foo\_redirect <foo_redirect_module.rst>`__)\  and \ :literal:`baz` (of module `ns2.col.foo\_redirect <foo_redirect_module.rst>`__)\ .
+- See :literal:`foo\_param\_1` (of role `ns2.col.foo <foo_role.rst>`__, entrypoint main) for a random role parameter reference. And :literal:`foo\_param\_2=42` (of role `ns2.col.foo <foo_role.rst>`__, entrypoint main) for one with a value.
+- Reference using alias - :literal:`bar` (of module `ns2.col.foo\_redirect <foo_redirect_module.rst>`__) and :literal:`baz` (of module `ns2.col.foo\_redirect <foo_redirect_module.rst>`__).
 
 
 
@@ -85,7 +85,7 @@ Attributes
 
 
     - 
-      Use \ :literal:`group/ns2.col.foo\_group`\  or \ :literal:`group/ns2.col.bar\_group`\  in \ :literal:`module\_defaults`\  to set defaults for this module.
+      Use :literal:`group/ns2.col.foo\_group` or :literal:`group/ns2.col.bar\_group` in :literal:`module\_defaults` to set defaults for this module.
 
 
 

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_become.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_become.rst
@@ -1,8 +1,8 @@
 
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
-ns2.col.foo become -- Use foo \ :literal:`bar` (`link <#parameter-bar>`_)\ 
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo become -- Use foo :literal:`bar` (`link <#parameter-bar>`_)
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 This become plugin is part of the `ns2.col collection <https://galaxy.ansible.com/ui/repo/published/ns2/col/>`_ (version 2.1.0).
 
@@ -24,11 +24,9 @@ DEPRECATED
 :Why: Just some text.
       This one has more than one line.
       And one more.
-
 :Alternative: I don't know
               of any
               alternative.
-
 
 Synopsis
 --------

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_cache.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_cache.rst
@@ -1,8 +1,8 @@
 
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
-ns2.col.foo cache -- Foo files \ :literal:`bar` (`link <#parameter-bar>`_)\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo cache -- Foo files :literal:`bar` (`link <#parameter-bar>`_)
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 This cache plugin is part of the `ns2.col collection <https://galaxy.ansible.com/ui/repo/published/ns2/col/>`_ (version 2.1.0).
 

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_callback.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_callback.rst
@@ -1,8 +1,8 @@
 
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
-ns2.col.foo callback -- Foo output \ :literal:`bar` (`link <#parameter-bar>`_)\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo callback -- Foo output :literal:`bar` (`link <#parameter-bar>`_)
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 This callback plugin is part of the `ns2.col collection <https://galaxy.ansible.com/ui/repo/published/ns2/col/>`_ (version 2.1.0).
 

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_connection.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_connection.rst
@@ -1,8 +1,8 @@
 
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
-ns2.col.foo connection -- Foo connection \ :literal:`bar` (`link <#parameter-bar>`_)\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo connection -- Foo connection :literal:`bar` (`link <#parameter-bar>`_)
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 This connection plugin is part of the `ns2.col collection <https://galaxy.ansible.com/ui/repo/published/ns2/col/>`_ (version 2.1.0).
 
@@ -23,7 +23,7 @@ New in ns2.col 1.2.0
 Synopsis
 --------
 
-- This is for the \ :literal:`foo`\  connection.
+- This is for the :literal:`foo` connection.
 
 
 
@@ -106,8 +106,8 @@ Parameters
 Notes
 -----
 
-- Some note. \ :strong:`Something in bold`\ . \ :literal:`And in code`\ . \ :emphasis:`And in italics`\ . An URL: \ `https://example.org <https://example.org>`__\ .
-- And another one. \ `A link <https://example.com>`__\ .
+- Some note. :strong:`Something in bold`. :literal:`And in code`. :emphasis:`And in italics`. An URL: \ `https://example.org <https://example.org>`__.
+- And another one. \ `A link <https://example.com>`__.
 
 
 

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_filter.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_filter.rst
@@ -1,8 +1,8 @@
 
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
-ns2.col.foo filter -- The foo filter \ :literal:`bar` (`link <#parameter-bar>`_)\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo filter -- The foo filter :literal:`bar` (`link <#parameter-bar>`_)
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 This filter plugin is part of the `ns2.col collection <https://galaxy.ansible.com/ui/repo/published/ns2/col/>`_ (version 2.1.0).
 

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_inventory.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_inventory.rst
@@ -1,8 +1,8 @@
 
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
-ns2.col.foo inventory -- The foo inventory \ :literal:`bar` (`link <#parameter-bar>`_)\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo inventory -- The foo inventory :literal:`bar` (`link <#parameter-bar>`_)
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 This inventory plugin is part of the `ns2.col collection <https://galaxy.ansible.com/ui/repo/published/ns2/col/>`_ (version 2.1.0).
 

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_lookup.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_lookup.rst
@@ -1,8 +1,8 @@
 
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
-ns2.col.foo lookup -- Look up some foo \ :literal:`bar` (`link <#parameter-bar>`_)\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo lookup -- Look up some foo :literal:`bar` (`link <#parameter-bar>`_)
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 This lookup plugin is part of the `ns2.col collection <https://galaxy.ansible.com/ui/repo/published/ns2/col/>`_ (version 2.1.0).
 

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_module.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_module.rst
@@ -1,8 +1,8 @@
 
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
-ns2.col.foo module -- Do some foo \ :literal:`bar` (`link <#parameter-bar>`_)\ 
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo module -- Do some foo :literal:`bar` (`link <#parameter-bar>`_)
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 This module is part of the `ns2.col collection <https://galaxy.ansible.com/ui/repo/published/ns2/col/>`_ (version 2.1.0).
 
@@ -27,7 +27,7 @@ Synopsis
 
 - Does some foo on the remote host.
 - Whether foo is magic or not has not yet been determined.
-- \ :literal:`FOOBAR1`\ , \ :literal:`FOOBAR2`\ , \ :literal:`FOOBAR3`\ , \ :literal:`FOOBAR4`\ .
+- :literal:`FOOBAR1`\ , :literal:`FOOBAR2`\ , :literal:`FOOBAR3`\ , :literal:`FOOBAR4`.
 
 
 Aliases: foo_redirect
@@ -230,7 +230,7 @@ Attributes
 
 
     - 
-      Use \ :literal:`group/ns2.col.foo\_group`\  in \ :literal:`module\_defaults`\  to set defaults for this module.
+      Use :literal:`group/ns2.col.foo\_group` in :literal:`module\_defaults` to set defaults for this module.
 
 
 
@@ -282,7 +282,7 @@ See Also
   Another foo.
 * \ `ns2.col.foo <foo_lookup.rst>`__\  lookup plugin
 
-  Look up some foo \ :literal:`bar` (`link <#parameter-bar>`_)\ .
+  Look up some foo :literal:`bar` (`link <#parameter-bar>`_).
 * \ `ansible.builtin.service <service_module.rst>`__\ 
 
   The service module.

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_role.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_role.rst
@@ -29,17 +29,15 @@ DEPRECATED
 :Why: Just some text.
       This one has more than one line.
       And one more.
-
 :Alternative: I don't know
               of any
               alternative.
-
 
 Synopsis
 ^^^^^^^^
 
 - This is the foo role.
-- If you set \ :literal:`foo\_param\_1` (`link <#parameter-main--foo_param_1>`_)\  while \ :literal:`foo\_param\_2=3` (`link <#parameter-main--foo_param_2>`_)\ , this might behave funny.
+- If you set :literal:`foo\_param\_1` (`link <#parameter-main--foo_param_1>`_) while :literal:`foo\_param\_2=3` (`link <#parameter-main--foo_param_2>`_)\ , this might behave funny.
 
 
 Parameters

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_shell.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_shell.rst
@@ -1,8 +1,8 @@
 
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
-ns2.col.foo shell -- Foo shell \ :literal:`bar` (`link <#parameter-bar>`_)\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo shell -- Foo shell :literal:`bar` (`link <#parameter-bar>`_)
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 This shell plugin is part of the `ns2.col collection <https://galaxy.ansible.com/ui/repo/published/ns2/col/>`_ (version 2.1.0).
 

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_test.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_test.rst
@@ -1,8 +1,8 @@
 
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
-ns2.col.foo test -- Is something a foo \ :literal:`bar` (`link <#parameter-bar>`_)\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo test -- Is something a foo :literal:`bar` (`link <#parameter-bar>`_)
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 This test plugin is part of the `ns2.col collection <https://galaxy.ansible.com/ui/repo/published/ns2/col/>`_ (version 2.1.0).
 

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_vars.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_vars.rst
@@ -1,8 +1,8 @@
 
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
-ns2.col.foo vars -- Load foo \ :literal:`bar` (`link <#parameter-bar>`_)\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo vars -- Load foo :literal:`bar` (`link <#parameter-bar>`_)
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 This vars plugin is part of the `ns2.col collection <https://galaxy.ansible.com/ui/repo/published/ns2/col/>`_ (version 2.1.0).
 

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/index.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/index.rst
@@ -15,9 +15,7 @@ Description
 -----------
 
 This is a description.
-
 With multiple paragraphs.
-
 
 **Author:**
 
@@ -66,7 +64,7 @@ These are the plugins in the ns2.col collection:
 Modules
 ~~~~~~~
 
-* `foo module <foo_module.rst>`_ -- Do some foo \ :literal:`bar` (of module `ns2.col.foo <foo_module.rst>`__)\ 
+* `foo module <foo_module.rst>`_ -- Do some foo :literal:`bar` (of module `ns2.col.foo <foo_module.rst>`__)
 * `foo2 module <foo2_module.rst>`_ -- Another foo
 * `sub.foo3 module <sub.foo3_module.rst>`_ -- A sub-foo
 
@@ -74,19 +72,19 @@ Modules
 Become Plugins
 ~~~~~~~~~~~~~~
 
-* `foo become <foo_become.rst>`_ -- Use foo \ :literal:`bar` (of become plugin `ns2.col.foo <foo_become.rst>`__)\ 
+* `foo become <foo_become.rst>`_ -- Use foo :literal:`bar` (of become plugin `ns2.col.foo <foo_become.rst>`__)
 
 
 Cache Plugins
 ~~~~~~~~~~~~~
 
-* `foo cache <foo_cache.rst>`_ -- Foo files \ :literal:`bar` (of cache plugin `ns2.col.foo <foo_cache.rst>`__)\ 
+* `foo cache <foo_cache.rst>`_ -- Foo files :literal:`bar` (of cache plugin `ns2.col.foo <foo_cache.rst>`__)
 
 
 Callback Plugins
 ~~~~~~~~~~~~~~~~
 
-* `foo callback <foo_callback.rst>`_ -- Foo output \ :literal:`bar` (of callback plugin `ns2.col.foo <foo_callback.rst>`__)\ 
+* `foo callback <foo_callback.rst>`_ -- Foo output :literal:`bar` (of callback plugin `ns2.col.foo <foo_callback.rst>`__)
 
 
 Cliconf Plugins
@@ -98,32 +96,32 @@ Cliconf Plugins
 Connection Plugins
 ~~~~~~~~~~~~~~~~~~
 
-* `foo connection <foo_connection.rst>`_ -- Foo connection \ :literal:`bar` (of connection plugin `ns2.col.foo <foo_connection.rst>`__)\ 
+* `foo connection <foo_connection.rst>`_ -- Foo connection :literal:`bar` (of connection plugin `ns2.col.foo <foo_connection.rst>`__)
 
 
 Filter Plugins
 ~~~~~~~~~~~~~~
 
 * `bar filter <bar_filter.rst>`_ -- The bar filter
-* `foo filter <foo_filter.rst>`_ -- The foo filter \ :literal:`bar` (of filter plugin `ns2.col.foo <foo_filter.rst>`__)\ 
+* `foo filter <foo_filter.rst>`_ -- The foo filter :literal:`bar` (of filter plugin `ns2.col.foo <foo_filter.rst>`__)
 
 
 Inventory Plugins
 ~~~~~~~~~~~~~~~~~
 
-* `foo inventory <foo_inventory.rst>`_ -- The foo inventory \ :literal:`bar` (of inventory plugin `ns2.col.foo <foo_inventory.rst>`__)\ 
+* `foo inventory <foo_inventory.rst>`_ -- The foo inventory :literal:`bar` (of inventory plugin `ns2.col.foo <foo_inventory.rst>`__)
 
 
 Lookup Plugins
 ~~~~~~~~~~~~~~
 
-* `foo lookup <foo_lookup.rst>`_ -- Look up some foo \ :literal:`bar` (of lookup plugin `ns2.col.foo <foo_lookup.rst>`__)\ 
+* `foo lookup <foo_lookup.rst>`_ -- Look up some foo :literal:`bar` (of lookup plugin `ns2.col.foo <foo_lookup.rst>`__)
 
 
 Shell Plugins
 ~~~~~~~~~~~~~
 
-* `foo shell <foo_shell.rst>`_ -- Foo shell \ :literal:`bar` (of shell plugin `ns2.col.foo <foo_shell.rst>`__)\ 
+* `foo shell <foo_shell.rst>`_ -- Foo shell :literal:`bar` (of shell plugin `ns2.col.foo <foo_shell.rst>`__)
 
 
 Strategy Plugins
@@ -136,13 +134,13 @@ Test Plugins
 ~~~~~~~~~~~~
 
 * `bar test <bar_test.rst>`_ -- Is something a bar
-* `foo test <foo_test.rst>`_ -- Is something a foo \ :literal:`bar` (of test plugin `ns2.col.foo <foo_test.rst>`__)\ 
+* `foo test <foo_test.rst>`_ -- Is something a foo :literal:`bar` (of test plugin `ns2.col.foo <foo_test.rst>`__)
 
 
 Vars Plugins
 ~~~~~~~~~~~~
 
-* `foo vars <foo_vars.rst>`_ -- Load foo \ :literal:`bar` (of vars plugin `ns2.col.foo <foo_vars.rst>`__)\ 
+* `foo vars <foo_vars.rst>`_ -- Load foo :literal:`bar` (of vars plugin `ns2.col.foo <foo_vars.rst>`__)
 
 
 Role Index

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/sub.foo3_module.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/sub.foo3_module.rst
@@ -23,7 +23,7 @@ Synopsis
 --------
 
 - Foo sub bar.
-- See \ :literal:`foo\_param\_1` (of role `ns2.col.foo <foo_role.rst>`__, entrypoint main)\  for a random role parameter reference. And \ :literal:`foo\_param\_2=42` (of role `ns2.col.foo <foo_role.rst>`__, entrypoint main)\  for one with a value.
+- See :literal:`foo\_param\_1` (of role `ns2.col.foo <foo_role.rst>`__, entrypoint main) for a random role parameter reference. And :literal:`foo\_param\_2=42` (of role `ns2.col.foo <foo_role.rst>`__, entrypoint main) for one with a value.
 
 
 
@@ -84,7 +84,7 @@ Attributes
 
 
     - 
-      Use \ :literal:`group/ns2.col.foo\_group`\  or \ :literal:`group/ns2.col.bar\_group`\  in \ :literal:`module\_defaults`\  to set defaults for this module.
+      Use :literal:`group/ns2.col.foo\_group` or :literal:`group/ns2.col.bar\_group` in :literal:`module\_defaults` to set defaults for this module.
 
 
 

--- a/tests/functional/baseline-simplified-rst/collections/callback_index_stdout.rst
+++ b/tests/functional/baseline-simplified-rst/collections/callback_index_stdout.rst
@@ -9,5 +9,5 @@ See `List of all Callback Plugins <index_callback.rst>`_ for the list of *all* c
 ns2.col
 -------
 
-* `ns2.col.foo <ns2/col/foo_callback.rst>`_ -- Foo output \ :literal:`bar` (of callback plugin `ns2.col.foo <foo_callback.rst>`__)\ 
+* `ns2.col.foo <ns2/col/foo_callback.rst>`_ -- Foo output :literal:`bar` (of callback plugin `ns2.col.foo <foo_callback.rst>`__)
 

--- a/tests/functional/baseline-simplified-rst/collections/index_become.rst
+++ b/tests/functional/baseline-simplified-rst/collections/index_become.rst
@@ -7,5 +7,5 @@ Index of all Become Plugins
 ns2.col
 -------
 
-* `ns2.col.foo <ns2/col/foo_become.rst>`_ -- Use foo \ :literal:`bar` (of become plugin `ns2.col.foo <foo_become.rst>`__)\ 
+* `ns2.col.foo <ns2/col/foo_become.rst>`_ -- Use foo :literal:`bar` (of become plugin `ns2.col.foo <foo_become.rst>`__)
 

--- a/tests/functional/baseline-simplified-rst/collections/index_cache.rst
+++ b/tests/functional/baseline-simplified-rst/collections/index_cache.rst
@@ -7,5 +7,5 @@ Index of all Cache Plugins
 ns2.col
 -------
 
-* `ns2.col.foo <ns2/col/foo_cache.rst>`_ -- Foo files \ :literal:`bar` (of cache plugin `ns2.col.foo <foo_cache.rst>`__)\ 
+* `ns2.col.foo <ns2/col/foo_cache.rst>`_ -- Foo files :literal:`bar` (of cache plugin `ns2.col.foo <foo_cache.rst>`__)
 

--- a/tests/functional/baseline-simplified-rst/collections/index_callback.rst
+++ b/tests/functional/baseline-simplified-rst/collections/index_callback.rst
@@ -7,5 +7,5 @@ Index of all Callback Plugins
 ns2.col
 -------
 
-* `ns2.col.foo <ns2/col/foo_callback.rst>`_ -- Foo output \ :literal:`bar` (of callback plugin `ns2.col.foo <foo_callback.rst>`__)\ 
+* `ns2.col.foo <ns2/col/foo_callback.rst>`_ -- Foo output :literal:`bar` (of callback plugin `ns2.col.foo <foo_callback.rst>`__)
 

--- a/tests/functional/baseline-simplified-rst/collections/index_connection.rst
+++ b/tests/functional/baseline-simplified-rst/collections/index_connection.rst
@@ -7,5 +7,5 @@ Index of all Connection Plugins
 ns2.col
 -------
 
-* `ns2.col.foo <ns2/col/foo_connection.rst>`_ -- Foo connection \ :literal:`bar` (of connection plugin `ns2.col.foo <foo_connection.rst>`__)\ 
+* `ns2.col.foo <ns2/col/foo_connection.rst>`_ -- Foo connection :literal:`bar` (of connection plugin `ns2.col.foo <foo_connection.rst>`__)
 

--- a/tests/functional/baseline-simplified-rst/collections/index_filter.rst
+++ b/tests/functional/baseline-simplified-rst/collections/index_filter.rst
@@ -8,5 +8,5 @@ ns2.col
 -------
 
 * `ns2.col.bar <ns2/col/bar_filter.rst>`_ -- The bar filter
-* `ns2.col.foo <ns2/col/foo_filter.rst>`_ -- The foo filter \ :literal:`bar` (of filter plugin `ns2.col.foo <foo_filter.rst>`__)\ 
+* `ns2.col.foo <ns2/col/foo_filter.rst>`_ -- The foo filter :literal:`bar` (of filter plugin `ns2.col.foo <foo_filter.rst>`__)
 

--- a/tests/functional/baseline-simplified-rst/collections/index_inventory.rst
+++ b/tests/functional/baseline-simplified-rst/collections/index_inventory.rst
@@ -7,5 +7,5 @@ Index of all Inventory Plugins
 ns2.col
 -------
 
-* `ns2.col.foo <ns2/col/foo_inventory.rst>`_ -- The foo inventory \ :literal:`bar` (of inventory plugin `ns2.col.foo <foo_inventory.rst>`__)\ 
+* `ns2.col.foo <ns2/col/foo_inventory.rst>`_ -- The foo inventory :literal:`bar` (of inventory plugin `ns2.col.foo <foo_inventory.rst>`__)
 

--- a/tests/functional/baseline-simplified-rst/collections/index_lookup.rst
+++ b/tests/functional/baseline-simplified-rst/collections/index_lookup.rst
@@ -7,5 +7,5 @@ Index of all Lookup Plugins
 ns2.col
 -------
 
-* `ns2.col.foo <ns2/col/foo_lookup.rst>`_ -- Look up some foo \ :literal:`bar` (of lookup plugin `ns2.col.foo <foo_lookup.rst>`__)\ 
+* `ns2.col.foo <ns2/col/foo_lookup.rst>`_ -- Look up some foo :literal:`bar` (of lookup plugin `ns2.col.foo <foo_lookup.rst>`__)
 

--- a/tests/functional/baseline-simplified-rst/collections/index_module.rst
+++ b/tests/functional/baseline-simplified-rst/collections/index_module.rst
@@ -15,13 +15,13 @@ ns.col2
 ns2.col
 -------
 
-* `ns2.col.foo <ns2/col/foo_module.rst>`_ -- Do some foo \ :literal:`bar` (of module `ns2.col.foo <foo_module.rst>`__)\ 
+* `ns2.col.foo <ns2/col/foo_module.rst>`_ -- Do some foo :literal:`bar` (of module `ns2.col.foo <foo_module.rst>`__)
 * `ns2.col.foo2 <ns2/col/foo2_module.rst>`_ -- Another foo
 * `ns2.col.sub.foo3 <ns2/col/sub.foo3_module.rst>`_ -- A sub-foo
 
 ns2.flatcol
 -----------
 
-* `ns2.flatcol.foo <ns2/flatcol/foo_module.rst>`_ -- Do some foo \ :literal:`bar` (of module `ns2.flatcol.foo <foo_module.rst>`__)\ 
+* `ns2.flatcol.foo <ns2/flatcol/foo_module.rst>`_ -- Do some foo :literal:`bar` (of module `ns2.flatcol.foo <foo_module.rst>`__)
 * `ns2.flatcol.foo2 <ns2/flatcol/foo2_module.rst>`_ -- Another foo
 

--- a/tests/functional/baseline-simplified-rst/collections/index_shell.rst
+++ b/tests/functional/baseline-simplified-rst/collections/index_shell.rst
@@ -7,5 +7,5 @@ Index of all Shell Plugins
 ns2.col
 -------
 
-* `ns2.col.foo <ns2/col/foo_shell.rst>`_ -- Foo shell \ :literal:`bar` (of shell plugin `ns2.col.foo <foo_shell.rst>`__)\ 
+* `ns2.col.foo <ns2/col/foo_shell.rst>`_ -- Foo shell :literal:`bar` (of shell plugin `ns2.col.foo <foo_shell.rst>`__)
 

--- a/tests/functional/baseline-simplified-rst/collections/index_test.rst
+++ b/tests/functional/baseline-simplified-rst/collections/index_test.rst
@@ -8,5 +8,5 @@ ns2.col
 -------
 
 * `ns2.col.bar <ns2/col/bar_test.rst>`_ -- Is something a bar
-* `ns2.col.foo <ns2/col/foo_test.rst>`_ -- Is something a foo \ :literal:`bar` (of test plugin `ns2.col.foo <foo_test.rst>`__)\ 
+* `ns2.col.foo <ns2/col/foo_test.rst>`_ -- Is something a foo :literal:`bar` (of test plugin `ns2.col.foo <foo_test.rst>`__)
 

--- a/tests/functional/baseline-simplified-rst/collections/index_vars.rst
+++ b/tests/functional/baseline-simplified-rst/collections/index_vars.rst
@@ -7,5 +7,5 @@ Index of all Vars Plugins
 ns2.col
 -------
 
-* `ns2.col.foo <ns2/col/foo_vars.rst>`_ -- Load foo \ :literal:`bar` (of vars plugin `ns2.col.foo <foo_vars.rst>`__)\ 
+* `ns2.col.foo <ns2/col/foo_vars.rst>`_ -- Load foo :literal:`bar` (of vars plugin `ns2.col.foo <foo_vars.rst>`__)
 

--- a/tests/functional/baseline-simplified-rst/collections/ns/col2/foo2_module.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns/col2/foo2_module.rst
@@ -25,17 +25,16 @@ Synopsis
 --------
 
 - Does some foo on the remote host.
-- A broken reference \ :ref:`asdfasdfoobarTHISDOESNOTEXIST <asdfasdfoobarTHISDOESNOTEXIST>`\ .
-- The option \ :literal:`foo` (`link <#parameter-foo>`_)\  exists, but \ :literal:`foobar` (`link <#parameter-foobar>`_)\  does not.
-- The return value \ :literal:`bar` (`link <#return-bar>`_)\  exists, but \ :literal:`barbaz` (`link <#return-barbaz>`_)\  does not.
-- Again existing: \ :literal:`foo=1` (of module `ns.col2.foo <foo_module.rst>`__)\ , \ :literal:`bar=2` (of module `ns.col2.foo <foo_module.rst>`__)\ 
-- Again not existing: \ :literal:`foobar=1` (of module `ns.col2.foo <foo_module.rst>`__)\ , \ :literal:`barbaz=2` (of module `ns.col2.foo <foo_module.rst>`__)\ 
-- \ :literal:`\ `\  \ :emphasis:`\ `\  \ :strong:`\ `\  \ :literal:`\ `\    \ :ref:`\  <>`\  \ :literal:`\ `\  \ :literal:`` (`link <#parameter->`_)\  \ :literal:`` (`link <#return->`_)\  \ :literal:``\ 
+- A broken reference :ref:`asdfasdfoobarTHISDOESNOTEXIST <asdfasdfoobarTHISDOESNOTEXIST>`.
+- The option :literal:`foo` (`link <#parameter-foo>`_) exists, but :literal:`foobar` (`link <#parameter-foobar>`_) does not.
+- The return value :literal:`bar` (`link <#return-bar>`_) exists, but :literal:`barbaz` (`link <#return-barbaz>`_) does not.
+- Again existing: :literal:`foo=1` (of module `ns.col2.foo <foo_module.rst>`__)\ , :literal:`bar=2` (of module `ns.col2.foo <foo_module.rst>`__)
+- Again not existing: :literal:`foobar=1` (of module `ns.col2.foo <foo_module.rst>`__)\ , :literal:`barbaz=2` (of module `ns.col2.foo <foo_module.rst>`__)
+- :literal:`\ ` :emphasis:`\ ` :strong:`\ ` :literal:`\ `   :ref:`\  <>` :literal:`\ ` :literal:`` (`link <#parameter->`_) :literal:`` (`link <#return->`_) :literal:``
 - Foo bar baz. Bamm - Bar baz
   bam bum.
   Bumm - Foo bar
   baz bam!
-
 
 
 
@@ -192,22 +191,20 @@ Attributes
 
 
 
-
   * - .. _ansible_collections.ns.col2.foo2_module__attribute-platform:
 
       **platform**
 
     - Platform:posix
 
-      The module \ :strong:`ERROR while parsing`\ : While parsing "M(boo)" at index 12: Module name "boo" is not a FQCN\  is not using an FQCN.
+      The module :strong:`ERROR while parsing`\ : While parsing "M(boo)" at index 12: Module name "boo" is not a FQCN is not using an FQCN.
 
-      Sometimes our markup is \ :strong:`ERROR while parsing`\ : While parsing "B(broken." at index 25: Cannot find closing ")" after last parameter\ 
+      Sometimes our markup is :strong:`ERROR while parsing`\ : While parsing "B(broken." at index 25: Cannot find closing ")" after last parameter
 
       Foo bar baz. Bamm - Bar baz
       bam bum.
       Bumm - Foo bar
       baz bam!
-
 
 
     - 
@@ -223,7 +220,6 @@ Notes
   bam bum.
   Bumm - Foo bar
   baz bam!
-
 
 See Also
 --------
@@ -255,7 +251,6 @@ See Also
   bam bum.
   Bumm - Foo bar
   baz bam!
-
 
 Examples
 --------

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo2_module.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo2_module.rst
@@ -23,8 +23,8 @@ Synopsis
 --------
 
 - Foo bar.
-- See \ :literal:`foo\_param\_1` (of role `ns2.col.foo <foo_role.rst>`__, entrypoint main)\  for a random role parameter reference. And \ :literal:`foo\_param\_2=42` (of role `ns2.col.foo <foo_role.rst>`__, entrypoint main)\  for one with a value.
-- Reference using alias - \ :literal:`bar` (of module `ns2.col.foo\_redirect <foo_redirect_module.rst>`__)\  and \ :literal:`baz` (of module `ns2.col.foo\_redirect <foo_redirect_module.rst>`__)\ .
+- See :literal:`foo\_param\_1` (of role `ns2.col.foo <foo_role.rst>`__, entrypoint main) for a random role parameter reference. And :literal:`foo\_param\_2=42` (of role `ns2.col.foo <foo_role.rst>`__, entrypoint main) for one with a value.
+- Reference using alias - :literal:`bar` (of module `ns2.col.foo\_redirect <foo_redirect_module.rst>`__) and :literal:`baz` (of module `ns2.col.foo\_redirect <foo_redirect_module.rst>`__).
 
 
 
@@ -85,7 +85,7 @@ Attributes
 
 
     - 
-      Use \ :literal:`group/ns2.col.foo\_group`\  or \ :literal:`group/ns2.col.bar\_group`\  in \ :literal:`module\_defaults`\  to set defaults for this module.
+      Use :literal:`group/ns2.col.foo\_group` or :literal:`group/ns2.col.bar\_group` in :literal:`module\_defaults` to set defaults for this module.
 
 
 

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_become.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_become.rst
@@ -1,8 +1,8 @@
 
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
-ns2.col.foo become -- Use foo \ :literal:`bar` (`link <#parameter-bar>`_)\ 
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo become -- Use foo :literal:`bar` (`link <#parameter-bar>`_)
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 This become plugin is part of the `ns2.col collection <https://galaxy.ansible.com/ui/repo/published/ns2/col/>`_ (version 2.1.0).
 
@@ -24,11 +24,9 @@ DEPRECATED
 :Why: Just some text.
       This one has more than one line.
       And one more.
-
 :Alternative: I don't know
               of any
               alternative.
-
 
 Synopsis
 --------

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_cache.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_cache.rst
@@ -1,8 +1,8 @@
 
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
-ns2.col.foo cache -- Foo files \ :literal:`bar` (`link <#parameter-bar>`_)\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo cache -- Foo files :literal:`bar` (`link <#parameter-bar>`_)
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 This cache plugin is part of the `ns2.col collection <https://galaxy.ansible.com/ui/repo/published/ns2/col/>`_ (version 2.1.0).
 

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_callback.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_callback.rst
@@ -1,8 +1,8 @@
 
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
-ns2.col.foo callback -- Foo output \ :literal:`bar` (`link <#parameter-bar>`_)\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo callback -- Foo output :literal:`bar` (`link <#parameter-bar>`_)
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 This callback plugin is part of the `ns2.col collection <https://galaxy.ansible.com/ui/repo/published/ns2/col/>`_ (version 2.1.0).
 

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_connection.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_connection.rst
@@ -1,8 +1,8 @@
 
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
-ns2.col.foo connection -- Foo connection \ :literal:`bar` (`link <#parameter-bar>`_)\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo connection -- Foo connection :literal:`bar` (`link <#parameter-bar>`_)
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 This connection plugin is part of the `ns2.col collection <https://galaxy.ansible.com/ui/repo/published/ns2/col/>`_ (version 2.1.0).
 
@@ -23,7 +23,7 @@ New in ns2.col 1.2.0
 Synopsis
 --------
 
-- This is for the \ :literal:`foo`\  connection.
+- This is for the :literal:`foo` connection.
 
 
 
@@ -106,8 +106,8 @@ Parameters
 Notes
 -----
 
-- Some note. \ :strong:`Something in bold`\ . \ :literal:`And in code`\ . \ :emphasis:`And in italics`\ . An URL: \ `https://example.org <https://example.org>`__\ .
-- And another one. \ `A link <https://example.com>`__\ .
+- Some note. :strong:`Something in bold`. :literal:`And in code`. :emphasis:`And in italics`. An URL: \ `https://example.org <https://example.org>`__.
+- And another one. \ `A link <https://example.com>`__.
 
 
 

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_filter.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_filter.rst
@@ -1,8 +1,8 @@
 
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
-ns2.col.foo filter -- The foo filter \ :literal:`bar` (`link <#parameter-bar>`_)\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo filter -- The foo filter :literal:`bar` (`link <#parameter-bar>`_)
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 This filter plugin is part of the `ns2.col collection <https://galaxy.ansible.com/ui/repo/published/ns2/col/>`_ (version 2.1.0).
 

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_inventory.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_inventory.rst
@@ -1,8 +1,8 @@
 
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
-ns2.col.foo inventory -- The foo inventory \ :literal:`bar` (`link <#parameter-bar>`_)\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo inventory -- The foo inventory :literal:`bar` (`link <#parameter-bar>`_)
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 This inventory plugin is part of the `ns2.col collection <https://galaxy.ansible.com/ui/repo/published/ns2/col/>`_ (version 2.1.0).
 

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_lookup.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_lookup.rst
@@ -1,8 +1,8 @@
 
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
-ns2.col.foo lookup -- Look up some foo \ :literal:`bar` (`link <#parameter-bar>`_)\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo lookup -- Look up some foo :literal:`bar` (`link <#parameter-bar>`_)
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 This lookup plugin is part of the `ns2.col collection <https://galaxy.ansible.com/ui/repo/published/ns2/col/>`_ (version 2.1.0).
 

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_module.rst
@@ -1,8 +1,8 @@
 
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
-ns2.col.foo module -- Do some foo \ :literal:`bar` (`link <#parameter-bar>`_)\ 
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo module -- Do some foo :literal:`bar` (`link <#parameter-bar>`_)
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 This module is part of the `ns2.col collection <https://galaxy.ansible.com/ui/repo/published/ns2/col/>`_ (version 2.1.0).
 
@@ -27,7 +27,7 @@ Synopsis
 
 - Does some foo on the remote host.
 - Whether foo is magic or not has not yet been determined.
-- \ :literal:`FOOBAR1`\ , \ :literal:`FOOBAR2`\ , \ :literal:`FOOBAR3`\ , \ :literal:`FOOBAR4`\ .
+- :literal:`FOOBAR1`\ , :literal:`FOOBAR2`\ , :literal:`FOOBAR3`\ , :literal:`FOOBAR4`.
 
 
 Aliases: foo_redirect
@@ -230,7 +230,7 @@ Attributes
 
 
     - 
-      Use \ :literal:`group/ns2.col.foo\_group`\  in \ :literal:`module\_defaults`\  to set defaults for this module.
+      Use :literal:`group/ns2.col.foo\_group` in :literal:`module\_defaults` to set defaults for this module.
 
 
 
@@ -282,7 +282,7 @@ See Also
   Another foo.
 * \ `ns2.col.foo <foo_lookup.rst>`__\  lookup plugin
 
-  Look up some foo \ :literal:`bar` (`link <#parameter-bar>`_)\ .
+  Look up some foo :literal:`bar` (`link <#parameter-bar>`_).
 * \ `ansible.builtin.service <service_module.rst>`__\ 
 
   The service module.

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_role.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_role.rst
@@ -29,17 +29,15 @@ DEPRECATED
 :Why: Just some text.
       This one has more than one line.
       And one more.
-
 :Alternative: I don't know
               of any
               alternative.
-
 
 Synopsis
 ^^^^^^^^
 
 - This is the foo role.
-- If you set \ :literal:`foo\_param\_1` (`link <#parameter-main--foo_param_1>`_)\  while \ :literal:`foo\_param\_2=3` (`link <#parameter-main--foo_param_2>`_)\ , this might behave funny.
+- If you set :literal:`foo\_param\_1` (`link <#parameter-main--foo_param_1>`_) while :literal:`foo\_param\_2=3` (`link <#parameter-main--foo_param_2>`_)\ , this might behave funny.
 
 
 Parameters

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_shell.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_shell.rst
@@ -1,8 +1,8 @@
 
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
-ns2.col.foo shell -- Foo shell \ :literal:`bar` (`link <#parameter-bar>`_)\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo shell -- Foo shell :literal:`bar` (`link <#parameter-bar>`_)
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 This shell plugin is part of the `ns2.col collection <https://galaxy.ansible.com/ui/repo/published/ns2/col/>`_ (version 2.1.0).
 

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_test.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_test.rst
@@ -1,8 +1,8 @@
 
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
-ns2.col.foo test -- Is something a foo \ :literal:`bar` (`link <#parameter-bar>`_)\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo test -- Is something a foo :literal:`bar` (`link <#parameter-bar>`_)
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 This test plugin is part of the `ns2.col collection <https://galaxy.ansible.com/ui/repo/published/ns2/col/>`_ (version 2.1.0).
 

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_vars.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_vars.rst
@@ -1,8 +1,8 @@
 
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
-ns2.col.foo vars -- Load foo \ :literal:`bar` (`link <#parameter-bar>`_)\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo vars -- Load foo :literal:`bar` (`link <#parameter-bar>`_)
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 This vars plugin is part of the `ns2.col collection <https://galaxy.ansible.com/ui/repo/published/ns2/col/>`_ (version 2.1.0).
 

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/index.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/index.rst
@@ -15,9 +15,7 @@ Description
 -----------
 
 This is a description.
-
 With multiple paragraphs.
-
 
 **Author:**
 
@@ -66,7 +64,7 @@ These are the plugins in the ns2.col collection:
 Modules
 ~~~~~~~
 
-* `foo module <foo_module.rst>`_ -- Do some foo \ :literal:`bar` (of module `ns2.col.foo <foo_module.rst>`__)\ 
+* `foo module <foo_module.rst>`_ -- Do some foo :literal:`bar` (of module `ns2.col.foo <foo_module.rst>`__)
 * `foo2 module <foo2_module.rst>`_ -- Another foo
 * `sub.foo3 module <sub.foo3_module.rst>`_ -- A sub-foo
 
@@ -74,19 +72,19 @@ Modules
 Become Plugins
 ~~~~~~~~~~~~~~
 
-* `foo become <foo_become.rst>`_ -- Use foo \ :literal:`bar` (of become plugin `ns2.col.foo <foo_become.rst>`__)\ 
+* `foo become <foo_become.rst>`_ -- Use foo :literal:`bar` (of become plugin `ns2.col.foo <foo_become.rst>`__)
 
 
 Cache Plugins
 ~~~~~~~~~~~~~
 
-* `foo cache <foo_cache.rst>`_ -- Foo files \ :literal:`bar` (of cache plugin `ns2.col.foo <foo_cache.rst>`__)\ 
+* `foo cache <foo_cache.rst>`_ -- Foo files :literal:`bar` (of cache plugin `ns2.col.foo <foo_cache.rst>`__)
 
 
 Callback Plugins
 ~~~~~~~~~~~~~~~~
 
-* `foo callback <foo_callback.rst>`_ -- Foo output \ :literal:`bar` (of callback plugin `ns2.col.foo <foo_callback.rst>`__)\ 
+* `foo callback <foo_callback.rst>`_ -- Foo output :literal:`bar` (of callback plugin `ns2.col.foo <foo_callback.rst>`__)
 
 
 Cliconf Plugins
@@ -98,32 +96,32 @@ Cliconf Plugins
 Connection Plugins
 ~~~~~~~~~~~~~~~~~~
 
-* `foo connection <foo_connection.rst>`_ -- Foo connection \ :literal:`bar` (of connection plugin `ns2.col.foo <foo_connection.rst>`__)\ 
+* `foo connection <foo_connection.rst>`_ -- Foo connection :literal:`bar` (of connection plugin `ns2.col.foo <foo_connection.rst>`__)
 
 
 Filter Plugins
 ~~~~~~~~~~~~~~
 
 * `bar filter <bar_filter.rst>`_ -- The bar filter
-* `foo filter <foo_filter.rst>`_ -- The foo filter \ :literal:`bar` (of filter plugin `ns2.col.foo <foo_filter.rst>`__)\ 
+* `foo filter <foo_filter.rst>`_ -- The foo filter :literal:`bar` (of filter plugin `ns2.col.foo <foo_filter.rst>`__)
 
 
 Inventory Plugins
 ~~~~~~~~~~~~~~~~~
 
-* `foo inventory <foo_inventory.rst>`_ -- The foo inventory \ :literal:`bar` (of inventory plugin `ns2.col.foo <foo_inventory.rst>`__)\ 
+* `foo inventory <foo_inventory.rst>`_ -- The foo inventory :literal:`bar` (of inventory plugin `ns2.col.foo <foo_inventory.rst>`__)
 
 
 Lookup Plugins
 ~~~~~~~~~~~~~~
 
-* `foo lookup <foo_lookup.rst>`_ -- Look up some foo \ :literal:`bar` (of lookup plugin `ns2.col.foo <foo_lookup.rst>`__)\ 
+* `foo lookup <foo_lookup.rst>`_ -- Look up some foo :literal:`bar` (of lookup plugin `ns2.col.foo <foo_lookup.rst>`__)
 
 
 Shell Plugins
 ~~~~~~~~~~~~~
 
-* `foo shell <foo_shell.rst>`_ -- Foo shell \ :literal:`bar` (of shell plugin `ns2.col.foo <foo_shell.rst>`__)\ 
+* `foo shell <foo_shell.rst>`_ -- Foo shell :literal:`bar` (of shell plugin `ns2.col.foo <foo_shell.rst>`__)
 
 
 Strategy Plugins
@@ -136,13 +134,13 @@ Test Plugins
 ~~~~~~~~~~~~
 
 * `bar test <bar_test.rst>`_ -- Is something a bar
-* `foo test <foo_test.rst>`_ -- Is something a foo \ :literal:`bar` (of test plugin `ns2.col.foo <foo_test.rst>`__)\ 
+* `foo test <foo_test.rst>`_ -- Is something a foo :literal:`bar` (of test plugin `ns2.col.foo <foo_test.rst>`__)
 
 
 Vars Plugins
 ~~~~~~~~~~~~
 
-* `foo vars <foo_vars.rst>`_ -- Load foo \ :literal:`bar` (of vars plugin `ns2.col.foo <foo_vars.rst>`__)\ 
+* `foo vars <foo_vars.rst>`_ -- Load foo :literal:`bar` (of vars plugin `ns2.col.foo <foo_vars.rst>`__)
 
 
 Role Index

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/sub.foo3_module.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/sub.foo3_module.rst
@@ -23,7 +23,7 @@ Synopsis
 --------
 
 - Foo sub bar.
-- See \ :literal:`foo\_param\_1` (of role `ns2.col.foo <foo_role.rst>`__, entrypoint main)\  for a random role parameter reference. And \ :literal:`foo\_param\_2=42` (of role `ns2.col.foo <foo_role.rst>`__, entrypoint main)\  for one with a value.
+- See :literal:`foo\_param\_1` (of role `ns2.col.foo <foo_role.rst>`__, entrypoint main) for a random role parameter reference. And :literal:`foo\_param\_2=42` (of role `ns2.col.foo <foo_role.rst>`__, entrypoint main) for one with a value.
 
 
 
@@ -84,7 +84,7 @@ Attributes
 
 
     - 
-      Use \ :literal:`group/ns2.col.foo\_group`\  or \ :literal:`group/ns2.col.bar\_group`\  in \ :literal:`module\_defaults`\  to set defaults for this module.
+      Use :literal:`group/ns2.col.foo\_group` or :literal:`group/ns2.col.bar\_group` in :literal:`module\_defaults` to set defaults for this module.
 
 
 

--- a/tests/functional/baseline-simplified-rst/collections/ns2/flatcol/foo2_module.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/flatcol/foo2_module.rst
@@ -23,7 +23,7 @@ Synopsis
 --------
 
 - Foo bar.
-- See \ :literal:`foo\_param\_1` (of role `ns2.flatcol.foo <foo_role.rst>`__, entrypoint main)\  for a random role parameter reference. And \ :literal:`foo\_param\_2=42` (of role `ns2.flatcol.foo <foo_role.rst>`__, entrypoint main)\  for one with a value.
+- See :literal:`foo\_param\_1` (of role `ns2.flatcol.foo <foo_role.rst>`__, entrypoint main) for a random role parameter reference. And :literal:`foo\_param\_2=42` (of role `ns2.flatcol.foo <foo_role.rst>`__, entrypoint main) for one with a value.
 
 
 

--- a/tests/functional/baseline-simplified-rst/collections/ns2/flatcol/foo_module.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/flatcol/foo_module.rst
@@ -1,8 +1,8 @@
 
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
-ns2.flatcol.foo module -- Do some foo \ :literal:`bar` (`link <#parameter-bar>`_)\ 
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.flatcol.foo module -- Do some foo :literal:`bar` (`link <#parameter-bar>`_)
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 This module is part of the `ns2.flatcol collection <https://galaxy.ansible.com/ui/repo/published/ns2/flatcol/>`_.
 

--- a/tests/functional/baseline-simplified-rst/collections/ns2/flatcol/index.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/flatcol/index.rst
@@ -43,7 +43,7 @@ These are the plugins in the ns2.flatcol collection:
 Modules
 ~~~~~~~
 
-* `foo module <foo_module.rst>`_ -- Do some foo \ :literal:`bar` (of module `ns2.flatcol.foo <foo_module.rst>`__)\ 
+* `foo module <foo_module.rst>`_ -- Do some foo :literal:`bar` (of module `ns2.flatcol.foo <foo_module.rst>`__)
 * `foo2 module <foo2_module.rst>`_ -- Another foo
 
 

--- a/tests/functional/baseline-squash-hierarchy/bar_filter.rst
+++ b/tests/functional/baseline-squash-hierarchy/bar_filter.rst
@@ -281,16 +281,16 @@ example: ``input | ns2.col.bar(key1=value1, key2=value2, ...)``
       :ansible-option-choices:`Choices:`
 
       - :ansible-option-choices-entry:`"a"`\ :
-        Whatever \ :literal:`a`\  is.
+        Whatever :literal:`a` is.
 
       - :ansible-option-choices-entry:`"b"`\ :
-        What is \ :literal:`b`\ ? I don't know.
+        What is :literal:`b`\ ? I don't know.
 
       - :ansible-option-choices-entry:`"cde"`\ :
         This is some more unknown. There are rumors this is related to the alphabet.
 
       - :ansible-option-choices-entry-default:`"foo"` :ansible-option-choices-default-mark:`(default)`\ :
-        Our default value, the glorious \ :literal:`foo`\ .
+        Our default value, the glorious :literal:`foo`.
 
         Even has two paragraphs.
 

--- a/tests/functional/baseline-squash-hierarchy/bar_test.rst
+++ b/tests/functional/baseline-squash-hierarchy/bar_test.rst
@@ -189,7 +189,7 @@ Return Value
 
         <div class="ansible-option-cell">
 
-      Returns \ :literal:`true`\  if the path is a bar, \ :literal:`false`\  if it is not a bar.
+      Returns :literal:`true` if the path is a bar, :literal:`false` if it is not a bar.
 
 
       .. rst-class:: ansible-option-line

--- a/tests/functional/baseline-squash-hierarchy/foo2_module.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo2_module.rst
@@ -49,8 +49,8 @@ Synopsis
 .. Description
 
 - Foo bar.
-- See \ :ansopt:`ns2.col.foo#role:main:foo\_param\_1`\  for a random role parameter reference. And \ :ansopt:`ns2.col.foo#role:main:foo\_param\_2=42`\  for one with a value.
-- Reference using alias - \ :ansopt:`ns2.col.foo\_redirect#module:bar`\  and \ :ansopt:`ns2.col.foo\_redirect#module:baz`\ .
+- See :ansopt:`ns2.col.foo#role:main:foo\_param\_1` for a random role parameter reference. And :ansopt:`ns2.col.foo#role:main:foo\_param\_2=42` for one with a value.
+- Reference using alias - :ansopt:`ns2.col.foo\_redirect#module:bar` and :ansopt:`ns2.col.foo\_redirect#module:baz`.
 
 
 .. Aliases
@@ -108,7 +108,7 @@ Parameters
 
       Some bar.
 
-      See \ :ansopt:`ns2.col.foo#role:main:foo\_param\_1`\  for a random role parameter reference. And \ :ansopt:`ns2.col.foo#role:main:foo\_param\_2=42`\  for one with a value.
+      See :ansopt:`ns2.col.foo#role:main:foo\_param\_1` for a random role parameter reference. And :ansopt:`ns2.col.foo#role:main:foo\_param\_2=42` for one with a value.
 
 
       .. raw:: html
@@ -168,7 +168,7 @@ Attributes
 
         <div class="ansible-option-cell">
 
-      Use \ :literal:`group/ns2.col.foo\_group`\  or \ :literal:`group/ns2.col.bar\_group`\  in \ :literal:`module\_defaults`\  to set defaults for this module.
+      Use :literal:`group/ns2.col.foo\_group` or :literal:`group/ns2.col.bar\_group` in :literal:`module\_defaults` to set defaults for this module.
 
 
       .. raw:: html
@@ -373,9 +373,9 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
 
       Some bar.
 
-      Referencing myself as \ :ansretval:`ns2.col.foo2#module:bar`\ .
+      Referencing myself as :ansretval:`ns2.col.foo2#module:bar`.
 
-      Do not confuse with \ :ansopt:`ns2.col.foo2#module:bar`\ .
+      Do not confuse with :ansopt:`ns2.col.foo2#module:bar`.
 
 
       .. rst-class:: ansible-option-line

--- a/tests/functional/baseline-squash-hierarchy/foo_become.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_become.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo become -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo become -- Use foo :ansopt:`ns2.col.foo#become:bar`
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -48,11 +48,9 @@ DEPRECATED
 :Why: Just some text.
       This one has more than one line.
       And one more.
-
 :Alternative: I don't know
               of any
               alternative.
-
 
 Synopsis
 --------
@@ -118,11 +116,9 @@ Parameters
       This one has more than one line though.
       One more.
 
-
       Alternative: nothing
       relevant
       I know of
-
 
 
 
@@ -135,11 +131,11 @@ Parameters
 
         <div class="ansible-option-cell">
 
-      Bar. \ :strong:`BAR!`\ 
+      Bar. :strong:`BAR!`
 
-      Totally unrelated to \ :ansopt:`ns2.col.foo#become:become\_user`\ . Even with \ :ansopt:`ns2.col.foo#become:become\_user=foo`\ .
+      Totally unrelated to :ansopt:`ns2.col.foo#become:become\_user`. Even with :ansopt:`ns2.col.foo#become:become\_user=foo`.
 
-      Might not be compatible when \ :ansopt:`ns2.col.foo#become:become\_user`\  is \ :ansval:`bar`\ , though.
+      Might not be compatible when :ansopt:`ns2.col.foo#become:become\_user` is :ansval:`bar`\ , though.
 
 
       .. raw:: html

--- a/tests/functional/baseline-squash-hierarchy/foo_cache.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_cache.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo cache -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo cache -- Foo files :ansopt:`ns2.col.foo#cache:bar`
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-squash-hierarchy/foo_callback.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_callback.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo callback -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo callback -- Foo output :ansopt:`ns2.col.foo#callback:bar`
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-squash-hierarchy/foo_connection.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_connection.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo connection -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo connection -- Foo connection :ansopt:`ns2.col.foo#connection:bar`
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -51,7 +51,7 @@ Synopsis
 
 .. Description
 
-- This is for the \ :literal:`foo`\  connection.
+- This is for the :literal:`foo` connection.
 
 
 .. Aliases
@@ -183,8 +183,8 @@ Notes
 -----
 
 .. note::
-   - Some note. \ :strong:`Something in bold`\ . \ :literal:`And in code`\ . \ :emphasis:`And in italics`\ . An URL: \ `https://example.org <https://example.org>`__\ .
-   - And another one. \ `A link <https://example.com>`__\ .
+   - Some note. :strong:`Something in bold`. :literal:`And in code`. :emphasis:`And in italics`. An URL: \ `https://example.org <https://example.org>`__.
+   - And another one. \ `A link <https://example.com>`__.
 
 .. Seealso
 

--- a/tests/functional/baseline-squash-hierarchy/foo_filter.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_filter.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo filter -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo filter -- The foo filter :ansopt:`ns2.col.foo#filter:bar`
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-squash-hierarchy/foo_inventory.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_inventory.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo inventory -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo inventory -- The foo inventory :ansopt:`ns2.col.foo#inventory:bar`
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-squash-hierarchy/foo_lookup.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_lookup.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo lookup -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo lookup -- Look up some foo :ansopt:`ns2.col.foo#lookup:bar`
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-squash-hierarchy/foo_module.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_module.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo module -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo module -- Do some foo :ansopt:`ns2.col.foo#module:bar`
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -55,7 +55,7 @@ Synopsis
 
 - Does some foo on the remote host.
 - Whether foo is magic or not has not yet been determined.
-- \ :ansenvvarref:`FOOBAR1`\ , \ :ansenvvarref:`FOOBAR2`\ , \ :ansenvvar:`FOOBAR3`\ , \ :ansenvvar:`FOOBAR4`\ .
+- :ansenvvarref:`FOOBAR1`\ , :ansenvvarref:`FOOBAR2`\ , :ansenvvar:`FOOBAR3`\ , :ansenvvar:`FOOBAR4`.
 
 
 .. Aliases
@@ -126,9 +126,9 @@ Parameters
 
       A bar.
 
-      Independent from \ :ansopt:`ns2.col.foo#module:foo`\ .
+      Independent from :ansopt:`ns2.col.foo#module:foo`.
 
-      Do not confuse with \ :ansretval:`ns2.col.foo#module:bar`\ .
+      Do not confuse with :ansretval:`ns2.col.foo#module:bar`.
 
 
       .. raw:: html
@@ -204,7 +204,7 @@ Parameters
 
       The 'pkg\_info' option was added in version 2.13.
 
-      Aliases were added in 2.18, to support using \ :literal:`auto={{ansible\_facts['pkg\_mgr']}}`\ 
+      Aliases were added in 2.18, to support using :literal:`auto={{ansible\_facts['pkg\_mgr']}}`
 
 
       .. rst-class:: ansible-option-line
@@ -215,10 +215,10 @@ Parameters
         Alpine Linux package manager
 
       - :ansible-option-choices-entry:`"apt"`\ :
-        For DEB based distros, \ :literal:`python-apt`\  package must be installed on targeted hosts
+        For DEB based distros, :literal:`python-apt` package must be installed on targeted hosts
 
       - :ansible-option-choices-entry-default:`"auto"` :ansible-option-choices-default-mark:`(default)`\ :
-        Depending on \ :ansopt:`strategy`\ , will match the first or all package managers provided, in order
+        Depending on :ansopt:`strategy`\ , will match the first or all package managers provided, in order
 
       - :ansible-option-choices-entry:`"dnf"`\ :
         Alias to rpm
@@ -245,7 +245,7 @@ Parameters
         Alias to pkg
 
       - :ansible-option-choices-entry:`"portage"`\ :
-        Handles ebuild packages, it requires the \ :literal:`qlist`\  utility, which is part of 'app-portage/portage-utils'
+        Handles ebuild packages, it requires the :literal:`qlist` utility, which is part of 'app-portage/portage-utils'
 
       - :ansible-option-choices-entry:`"rpm"`\ :
         For RPM based distros, requires RPM Python bindings, not installed by default on Suse (python3-rpm)
@@ -342,7 +342,7 @@ Parameters
 
       Whatever.
 
-      Also required when \ :ansopt:`ns2.col.foo#module:subfoo`\  is specified when \ :ansopt:`ns2.col.foo#module:foo=bar`\  or \ :ansval:`baz`\ .
+      Also required when :ansopt:`ns2.col.foo#module:subfoo` is specified when :ansopt:`ns2.col.foo#module:foo=bar` or :ansval:`baz`.
 
 
       .. raw:: html
@@ -403,7 +403,7 @@ Attributes
 
         <div class="ansible-option-cell">
 
-      Use \ :literal:`group/ns2.col.foo\_group`\  in \ :literal:`module\_defaults`\  to set defaults for this module.
+      Use :literal:`group/ns2.col.foo\_group` in :literal:`module\_defaults` to set defaults for this module.
 
 
       .. raw:: html
@@ -551,7 +551,7 @@ See Also
    \ :ref:`ns2.col.foo2 <ansible_collections.ns2.col.foo2_module>`\ 
        Another foo.
    \ :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>`\  lookup plugin
-       Look up some foo \ :ansopt:`ns2.col.foo#module:bar`\ .
+       Look up some foo :ansopt:`ns2.col.foo#module:bar`.
    \ :ref:`ansible.builtin.service <ansible_collections.ansible.builtin.service_module>`\ 
        The service module.
    \ :ref:`ansible.builtin.ssh <ansible_collections.ansible.builtin.ssh_connection>`\  connection plugin
@@ -627,9 +627,9 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
 
       Some bar.
 
-      Referencing myself as \ :ansretval:`ns2.col.foo#module:bar`\ .
+      Referencing myself as :ansretval:`ns2.col.foo#module:bar`.
 
-      Do not confuse with \ :ansopt:`ns2.col.foo#module:bar`\ .
+      Do not confuse with :ansopt:`ns2.col.foo#module:bar`.
 
 
       .. rst-class:: ansible-option-line

--- a/tests/functional/baseline-squash-hierarchy/foo_role.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_role.rst
@@ -55,11 +55,9 @@ DEPRECATED
 :Why: Just some text.
       This one has more than one line.
       And one more.
-
 :Alternative: I don't know
               of any
               alternative.
-
 
 Synopsis
 ^^^^^^^^
@@ -67,7 +65,7 @@ Synopsis
 .. Description
 
 - This is the foo role.
-- If you set \ :ansopt:`ns2.col.foo#role:main:foo\_param\_1`\  while \ :ansopt:`ns2.col.foo#role:main:foo\_param\_2=3`\ , this might behave funny.
+- If you set :ansopt:`ns2.col.foo#role:main:foo\_param\_1` while :ansopt:`ns2.col.foo#role:main:foo\_param\_2=3`\ , this might behave funny.
 
 .. Requirements
 
@@ -120,7 +118,7 @@ Parameters
 
       A string parameter
 
-      If you set \ :ansopt:`ns2.col.foo#role:main:foo\_param\_1`\  while \ :ansopt:`ns2.col.foo#role:main:foo\_param\_2=3`\ , this might behave funny.
+      If you set :ansopt:`ns2.col.foo#role:main:foo\_param\_1` while :ansopt:`ns2.col.foo#role:main:foo\_param\_2=3`\ , this might behave funny.
 
 
       .. raw:: html

--- a/tests/functional/baseline-squash-hierarchy/foo_shell.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_shell.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo shell -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo shell -- Foo shell :ansopt:`ns2.col.foo#shell:bar`
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-squash-hierarchy/foo_test.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_test.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo test -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo test -- Is something a foo :ansopt:`ns2.col.foo#test:bar`
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-squash-hierarchy/foo_vars.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_vars.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo vars -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo vars -- Load foo :ansopt:`ns2.col.foo#vars:bar`
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-squash-hierarchy/index.rst
+++ b/tests/functional/baseline-squash-hierarchy/index.rst
@@ -19,9 +19,7 @@ Description
 -----------
 
 This is a description.
-
 With multiple paragraphs.
-
 
 **Author:**
 
@@ -92,7 +90,7 @@ These are the plugins in the ns2.col collection:
 Modules
 ~~~~~~~
 
-* :ansplugin:`foo module <ns2.col.foo#module>` -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
+* :ansplugin:`foo module <ns2.col.foo#module>` -- Do some foo :ansopt:`ns2.col.foo#module:bar`
 * :ansplugin:`foo2 module <ns2.col.foo2#module>` -- Another foo
 * :ansplugin:`sub.foo3 module <ns2.col.sub.foo3#module>` -- A sub-foo
 
@@ -108,7 +106,7 @@ Modules
 Become Plugins
 ~~~~~~~~~~~~~~
 
-* :ansplugin:`foo become <ns2.col.foo#become>` -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
+* :ansplugin:`foo become <ns2.col.foo#become>` -- Use foo :ansopt:`ns2.col.foo#become:bar`
 
 .. toctree::
     :maxdepth: 1
@@ -120,7 +118,7 @@ Become Plugins
 Cache Plugins
 ~~~~~~~~~~~~~
 
-* :ansplugin:`foo cache <ns2.col.foo#cache>` -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
+* :ansplugin:`foo cache <ns2.col.foo#cache>` -- Foo files :ansopt:`ns2.col.foo#cache:bar`
 
 .. toctree::
     :maxdepth: 1
@@ -132,7 +130,7 @@ Cache Plugins
 Callback Plugins
 ~~~~~~~~~~~~~~~~
 
-* :ansplugin:`foo callback <ns2.col.foo#callback>` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
+* :ansplugin:`foo callback <ns2.col.foo#callback>` -- Foo output :ansopt:`ns2.col.foo#callback:bar`
 
 .. toctree::
     :maxdepth: 1
@@ -156,7 +154,7 @@ Cliconf Plugins
 Connection Plugins
 ~~~~~~~~~~~~~~~~~~
 
-* :ansplugin:`foo connection <ns2.col.foo#connection>` -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
+* :ansplugin:`foo connection <ns2.col.foo#connection>` -- Foo connection :ansopt:`ns2.col.foo#connection:bar`
 
 .. toctree::
     :maxdepth: 1
@@ -169,7 +167,7 @@ Filter Plugins
 ~~~~~~~~~~~~~~
 
 * :ansplugin:`bar filter <ns2.col.bar#filter>` -- The bar filter
-* :ansplugin:`foo filter <ns2.col.foo#filter>` -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
+* :ansplugin:`foo filter <ns2.col.foo#filter>` -- The foo filter :ansopt:`ns2.col.foo#filter:bar`
 
 .. toctree::
     :maxdepth: 1
@@ -182,7 +180,7 @@ Filter Plugins
 Inventory Plugins
 ~~~~~~~~~~~~~~~~~
 
-* :ansplugin:`foo inventory <ns2.col.foo#inventory>` -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
+* :ansplugin:`foo inventory <ns2.col.foo#inventory>` -- The foo inventory :ansopt:`ns2.col.foo#inventory:bar`
 
 .. toctree::
     :maxdepth: 1
@@ -194,7 +192,7 @@ Inventory Plugins
 Lookup Plugins
 ~~~~~~~~~~~~~~
 
-* :ansplugin:`foo lookup <ns2.col.foo#lookup>` -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
+* :ansplugin:`foo lookup <ns2.col.foo#lookup>` -- Look up some foo :ansopt:`ns2.col.foo#lookup:bar`
 
 .. toctree::
     :maxdepth: 1
@@ -206,7 +204,7 @@ Lookup Plugins
 Shell Plugins
 ~~~~~~~~~~~~~
 
-* :ansplugin:`foo shell <ns2.col.foo#shell>` -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
+* :ansplugin:`foo shell <ns2.col.foo#shell>` -- Foo shell :ansopt:`ns2.col.foo#shell:bar`
 
 .. toctree::
     :maxdepth: 1
@@ -231,7 +229,7 @@ Test Plugins
 ~~~~~~~~~~~~
 
 * :ansplugin:`bar test <ns2.col.bar#test>` -- Is something a bar
-* :ansplugin:`foo test <ns2.col.foo#test>` -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
+* :ansplugin:`foo test <ns2.col.foo#test>` -- Is something a foo :ansopt:`ns2.col.foo#test:bar`
 
 .. toctree::
     :maxdepth: 1
@@ -244,7 +242,7 @@ Test Plugins
 Vars Plugins
 ~~~~~~~~~~~~
 
-* :ansplugin:`foo vars <ns2.col.foo#vars>` -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
+* :ansplugin:`foo vars <ns2.col.foo#vars>` -- Load foo :ansopt:`ns2.col.foo#vars:bar`
 
 .. toctree::
     :maxdepth: 1

--- a/tests/functional/baseline-squash-hierarchy/sub.foo3_module.rst
+++ b/tests/functional/baseline-squash-hierarchy/sub.foo3_module.rst
@@ -49,7 +49,7 @@ Synopsis
 .. Description
 
 - Foo sub bar.
-- See \ :ansopt:`ns2.col.foo#role:main:foo\_param\_1`\  for a random role parameter reference. And \ :ansopt:`ns2.col.foo#role:main:foo\_param\_2=42`\  for one with a value.
+- See :ansopt:`ns2.col.foo#role:main:foo\_param\_1` for a random role parameter reference. And :ansopt:`ns2.col.foo#role:main:foo\_param\_2=42` for one with a value.
 
 
 .. Aliases
@@ -107,7 +107,7 @@ Parameters
 
       Some bar.
 
-      See \ :ansopt:`ns2.col.foo#role:main:foo\_param\_1`\  for a random role parameter reference. And \ :ansopt:`ns2.col.foo#role:main:foo\_param\_2=42`\  for one with a value.
+      See :ansopt:`ns2.col.foo#role:main:foo\_param\_1` for a random role parameter reference. And :ansopt:`ns2.col.foo#role:main:foo\_param\_2=42` for one with a value.
 
 
       .. raw:: html
@@ -167,7 +167,7 @@ Attributes
 
         <div class="ansible-option-cell">
 
-      Use \ :literal:`group/ns2.col.foo\_group`\  or \ :literal:`group/ns2.col.bar\_group`\  in \ :literal:`module\_defaults`\  to set defaults for this module.
+      Use :literal:`group/ns2.col.foo\_group` or :literal:`group/ns2.col.bar\_group` in :literal:`module\_defaults` to set defaults for this module.
 
 
       .. raw:: html
@@ -372,9 +372,9 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
 
       Some bar.
 
-      Referencing myself as \ :ansretval:`ns2.col.sub.foo3#module:bar`\ .
+      Referencing myself as :ansretval:`ns2.col.sub.foo3#module:bar`.
 
-      Do not confuse with \ :ansopt:`ns2.col.sub.foo3#module:bar`\ .
+      Do not confuse with :ansopt:`ns2.col.sub.foo3#module:bar`.
 
 
       .. rst-class:: ansible-option-line

--- a/tests/functional/baseline-use-html-blobs/collections/callback_index_stdout.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/callback_index_stdout.rst
@@ -14,5 +14,5 @@ See :ref:`list_of_callback_plugins` for the list of *all* callback plugins.
 ns2.col
 -------
 
-* :ansplugin:`ns2.col.foo#callback` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
+* :ansplugin:`ns2.col.foo#callback` -- Foo output :ansopt:`ns2.col.foo#callback:bar`
 

--- a/tests/functional/baseline-use-html-blobs/collections/index_become.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_become.rst
@@ -12,5 +12,5 @@ Index of all Become Plugins
 ns2.col
 -------
 
-* :ansplugin:`ns2.col.foo#become` -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
+* :ansplugin:`ns2.col.foo#become` -- Use foo :ansopt:`ns2.col.foo#become:bar`
 

--- a/tests/functional/baseline-use-html-blobs/collections/index_cache.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_cache.rst
@@ -12,5 +12,5 @@ Index of all Cache Plugins
 ns2.col
 -------
 
-* :ansplugin:`ns2.col.foo#cache` -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
+* :ansplugin:`ns2.col.foo#cache` -- Foo files :ansopt:`ns2.col.foo#cache:bar`
 

--- a/tests/functional/baseline-use-html-blobs/collections/index_callback.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_callback.rst
@@ -20,5 +20,5 @@ Index of all Callback Plugins
 ns2.col
 -------
 
-* :ansplugin:`ns2.col.foo#callback` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
+* :ansplugin:`ns2.col.foo#callback` -- Foo output :ansopt:`ns2.col.foo#callback:bar`
 

--- a/tests/functional/baseline-use-html-blobs/collections/index_connection.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_connection.rst
@@ -12,5 +12,5 @@ Index of all Connection Plugins
 ns2.col
 -------
 
-* :ansplugin:`ns2.col.foo#connection` -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
+* :ansplugin:`ns2.col.foo#connection` -- Foo connection :ansopt:`ns2.col.foo#connection:bar`
 

--- a/tests/functional/baseline-use-html-blobs/collections/index_filter.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_filter.rst
@@ -13,5 +13,5 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.bar#filter` -- The bar filter
-* :ansplugin:`ns2.col.foo#filter` -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
+* :ansplugin:`ns2.col.foo#filter` -- The foo filter :ansopt:`ns2.col.foo#filter:bar`
 

--- a/tests/functional/baseline-use-html-blobs/collections/index_inventory.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_inventory.rst
@@ -12,5 +12,5 @@ Index of all Inventory Plugins
 ns2.col
 -------
 
-* :ansplugin:`ns2.col.foo#inventory` -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
+* :ansplugin:`ns2.col.foo#inventory` -- The foo inventory :ansopt:`ns2.col.foo#inventory:bar`
 

--- a/tests/functional/baseline-use-html-blobs/collections/index_lookup.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_lookup.rst
@@ -12,5 +12,5 @@ Index of all Lookup Plugins
 ns2.col
 -------
 
-* :ansplugin:`ns2.col.foo#lookup` -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
+* :ansplugin:`ns2.col.foo#lookup` -- Look up some foo :ansopt:`ns2.col.foo#lookup:bar`
 

--- a/tests/functional/baseline-use-html-blobs/collections/index_module.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_module.rst
@@ -12,7 +12,7 @@ Index of all Modules
 ns2.col
 -------
 
-* :ansplugin:`ns2.col.foo#module` -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
+* :ansplugin:`ns2.col.foo#module` -- Do some foo :ansopt:`ns2.col.foo#module:bar`
 * :ansplugin:`ns2.col.foo2#module` -- Another foo
 * :ansplugin:`ns2.col.sub.foo3#module` -- A sub-foo
 

--- a/tests/functional/baseline-use-html-blobs/collections/index_shell.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_shell.rst
@@ -12,5 +12,5 @@ Index of all Shell Plugins
 ns2.col
 -------
 
-* :ansplugin:`ns2.col.foo#shell` -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
+* :ansplugin:`ns2.col.foo#shell` -- Foo shell :ansopt:`ns2.col.foo#shell:bar`
 

--- a/tests/functional/baseline-use-html-blobs/collections/index_test.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_test.rst
@@ -13,5 +13,5 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.bar#test` -- Is something a bar
-* :ansplugin:`ns2.col.foo#test` -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
+* :ansplugin:`ns2.col.foo#test` -- Is something a foo :ansopt:`ns2.col.foo#test:bar`
 

--- a/tests/functional/baseline-use-html-blobs/collections/index_vars.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_vars.rst
@@ -12,5 +12,5 @@ Index of all Vars Plugins
 ns2.col
 -------
 
-* :ansplugin:`ns2.col.foo#vars` -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
+* :ansplugin:`ns2.col.foo#vars` -- Load foo :ansopt:`ns2.col.foo#vars:bar`
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo2_module.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo2_module.rst
@@ -49,8 +49,8 @@ Synopsis
 .. Description
 
 - Foo bar.
-- See \ :ansopt:`ns2.col.foo#role:main:foo\_param\_1`\  for a random role parameter reference. And \ :ansopt:`ns2.col.foo#role:main:foo\_param\_2=42`\  for one with a value.
-- Reference using alias - \ :ansopt:`ns2.col.foo\_redirect#module:bar`\  and \ :ansopt:`ns2.col.foo\_redirect#module:baz`\ .
+- See :ansopt:`ns2.col.foo#role:main:foo\_param\_1` for a random role parameter reference. And :ansopt:`ns2.col.foo#role:main:foo\_param\_2=42` for one with a value.
+- Reference using alias - :ansopt:`ns2.col.foo\_redirect#module:bar` and :ansopt:`ns2.col.foo\_redirect#module:baz`.
 
 
 .. Aliases
@@ -149,7 +149,7 @@ Attributes
 
         <div class="ansible-option-cell">
 
-      Use \ :literal:`group/ns2.col.foo\_group`\  or \ :literal:`group/ns2.col.bar\_group`\  in \ :literal:`module\_defaults`\  to set defaults for this module.
+      Use :literal:`group/ns2.col.foo\_group` or :literal:`group/ns2.col.bar\_group` in :literal:`module\_defaults` to set defaults for this module.
 
 
       .. raw:: html

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_become.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_become.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo become -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo become -- Use foo :ansopt:`ns2.col.foo#become:bar`
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -48,11 +48,9 @@ DEPRECATED
 :Why: Just some text.
       This one has more than one line.
       And one more.
-
 :Alternative: I don't know
               of any
               alternative.
-
 
 Synopsis
 --------

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_cache.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_cache.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo cache -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo cache -- Foo files :ansopt:`ns2.col.foo#cache:bar`
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_callback.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_callback.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo callback -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo callback -- Foo output :ansopt:`ns2.col.foo#callback:bar`
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_connection.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_connection.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo connection -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo connection -- Foo connection :ansopt:`ns2.col.foo#connection:bar`
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -51,7 +51,7 @@ Synopsis
 
 .. Description
 
-- This is for the \ :literal:`foo`\  connection.
+- This is for the :literal:`foo` connection.
 
 
 .. Aliases
@@ -145,8 +145,8 @@ Notes
 -----
 
 .. note::
-   - Some note. \ :strong:`Something in bold`\ . \ :literal:`And in code`\ . \ :emphasis:`And in italics`\ . An URL: \ `https://example.org <https://example.org>`__\ .
-   - And another one. \ `A link <https://example.com>`__\ .
+   - Some note. :strong:`Something in bold`. :literal:`And in code`. :emphasis:`And in italics`. An URL: \ `https://example.org <https://example.org>`__.
+   - And another one. \ `A link <https://example.com>`__.
 
 .. Seealso
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_filter.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_filter.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo filter -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo filter -- The foo filter :ansopt:`ns2.col.foo#filter:bar`
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_inventory.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_inventory.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo inventory -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo inventory -- The foo inventory :ansopt:`ns2.col.foo#inventory:bar`
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_lookup.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_lookup.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo lookup -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo lookup -- Look up some foo :ansopt:`ns2.col.foo#lookup:bar`
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_module.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo module -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo module -- Do some foo :ansopt:`ns2.col.foo#module:bar`
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -55,7 +55,7 @@ Synopsis
 
 - Does some foo on the remote host.
 - Whether foo is magic or not has not yet been determined.
-- \ :ansenvvarref:`FOOBAR1`\ , \ :ansenvvarref:`FOOBAR2`\ , \ :ansenvvar:`FOOBAR3`\ , \ :ansenvvar:`FOOBAR4`\ .
+- :ansenvvarref:`FOOBAR1`\ , :ansenvvarref:`FOOBAR2`\ , :ansenvvar:`FOOBAR3`\ , :ansenvvar:`FOOBAR4`.
 
 
 .. Aliases
@@ -295,7 +295,7 @@ Attributes
 
         <div class="ansible-option-cell">
 
-      Use \ :literal:`group/ns2.col.foo\_group`\  in \ :literal:`module\_defaults`\  to set defaults for this module.
+      Use :literal:`group/ns2.col.foo\_group` in :literal:`module\_defaults` to set defaults for this module.
 
 
       .. raw:: html
@@ -443,7 +443,7 @@ See Also
    \ :ref:`ns2.col.foo2 <ansible_collections.ns2.col.foo2_module>`\ 
        Another foo.
    \ :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>`\  lookup plugin
-       Look up some foo \ :ansopt:`ns2.col.foo#module:bar`\ .
+       Look up some foo :ansopt:`ns2.col.foo#module:bar`.
    \ :ref:`ansible.builtin.service <ansible_collections.ansible.builtin.service_module>`\ 
        The service module.
    \ :ref:`ansible.builtin.ssh <ansible_collections.ansible.builtin.ssh_connection>`\  connection plugin

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_role.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_role.rst
@@ -55,11 +55,9 @@ DEPRECATED
 :Why: Just some text.
       This one has more than one line.
       And one more.
-
 :Alternative: I don't know
               of any
               alternative.
-
 
 Synopsis
 ^^^^^^^^
@@ -67,7 +65,7 @@ Synopsis
 .. Description
 
 - This is the foo role.
-- If you set \ :ansopt:`ns2.col.foo#role:main:foo\_param\_1`\  while \ :ansopt:`ns2.col.foo#role:main:foo\_param\_2=3`\ , this might behave funny.
+- If you set :ansopt:`ns2.col.foo#role:main:foo\_param\_1` while :ansopt:`ns2.col.foo#role:main:foo\_param\_2=3`\ , this might behave funny.
 
 .. Requirements
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_shell.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_shell.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo shell -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo shell -- Foo shell :ansopt:`ns2.col.foo#shell:bar`
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_test.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_test.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo test -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo test -- Is something a foo :ansopt:`ns2.col.foo#test:bar`
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_vars.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_vars.rst
@@ -18,8 +18,8 @@
 
 .. Title
 
-ns2.col.foo vars -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ns2.col.foo vars -- Load foo :ansopt:`ns2.col.foo#vars:bar`
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/index.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/index.rst
@@ -19,9 +19,7 @@ Description
 -----------
 
 This is a description.
-
 With multiple paragraphs.
-
 
 **Author:**
 
@@ -92,7 +90,7 @@ These are the plugins in the ns2.col collection:
 Modules
 ~~~~~~~
 
-* :ansplugin:`foo module <ns2.col.foo#module>` -- Do some foo \ :ansopt:`ns2.col.foo#module:bar`\ 
+* :ansplugin:`foo module <ns2.col.foo#module>` -- Do some foo :ansopt:`ns2.col.foo#module:bar`
 * :ansplugin:`foo2 module <ns2.col.foo2#module>` -- Another foo
 * :ansplugin:`sub.foo3 module <ns2.col.sub.foo3#module>` -- A sub-foo
 
@@ -108,7 +106,7 @@ Modules
 Become Plugins
 ~~~~~~~~~~~~~~
 
-* :ansplugin:`foo become <ns2.col.foo#become>` -- Use foo \ :ansopt:`ns2.col.foo#become:bar`\ 
+* :ansplugin:`foo become <ns2.col.foo#become>` -- Use foo :ansopt:`ns2.col.foo#become:bar`
 
 .. toctree::
     :maxdepth: 1
@@ -120,7 +118,7 @@ Become Plugins
 Cache Plugins
 ~~~~~~~~~~~~~
 
-* :ansplugin:`foo cache <ns2.col.foo#cache>` -- Foo files \ :ansopt:`ns2.col.foo#cache:bar`\ 
+* :ansplugin:`foo cache <ns2.col.foo#cache>` -- Foo files :ansopt:`ns2.col.foo#cache:bar`
 
 .. toctree::
     :maxdepth: 1
@@ -132,7 +130,7 @@ Cache Plugins
 Callback Plugins
 ~~~~~~~~~~~~~~~~
 
-* :ansplugin:`foo callback <ns2.col.foo#callback>` -- Foo output \ :ansopt:`ns2.col.foo#callback:bar`\ 
+* :ansplugin:`foo callback <ns2.col.foo#callback>` -- Foo output :ansopt:`ns2.col.foo#callback:bar`
 
 .. toctree::
     :maxdepth: 1
@@ -156,7 +154,7 @@ Cliconf Plugins
 Connection Plugins
 ~~~~~~~~~~~~~~~~~~
 
-* :ansplugin:`foo connection <ns2.col.foo#connection>` -- Foo connection \ :ansopt:`ns2.col.foo#connection:bar`\ 
+* :ansplugin:`foo connection <ns2.col.foo#connection>` -- Foo connection :ansopt:`ns2.col.foo#connection:bar`
 
 .. toctree::
     :maxdepth: 1
@@ -169,7 +167,7 @@ Filter Plugins
 ~~~~~~~~~~~~~~
 
 * :ansplugin:`bar filter <ns2.col.bar#filter>` -- The bar filter
-* :ansplugin:`foo filter <ns2.col.foo#filter>` -- The foo filter \ :ansopt:`ns2.col.foo#filter:bar`\ 
+* :ansplugin:`foo filter <ns2.col.foo#filter>` -- The foo filter :ansopt:`ns2.col.foo#filter:bar`
 
 .. toctree::
     :maxdepth: 1
@@ -182,7 +180,7 @@ Filter Plugins
 Inventory Plugins
 ~~~~~~~~~~~~~~~~~
 
-* :ansplugin:`foo inventory <ns2.col.foo#inventory>` -- The foo inventory \ :ansopt:`ns2.col.foo#inventory:bar`\ 
+* :ansplugin:`foo inventory <ns2.col.foo#inventory>` -- The foo inventory :ansopt:`ns2.col.foo#inventory:bar`
 
 .. toctree::
     :maxdepth: 1
@@ -194,7 +192,7 @@ Inventory Plugins
 Lookup Plugins
 ~~~~~~~~~~~~~~
 
-* :ansplugin:`foo lookup <ns2.col.foo#lookup>` -- Look up some foo \ :ansopt:`ns2.col.foo#lookup:bar`\ 
+* :ansplugin:`foo lookup <ns2.col.foo#lookup>` -- Look up some foo :ansopt:`ns2.col.foo#lookup:bar`
 
 .. toctree::
     :maxdepth: 1
@@ -206,7 +204,7 @@ Lookup Plugins
 Shell Plugins
 ~~~~~~~~~~~~~
 
-* :ansplugin:`foo shell <ns2.col.foo#shell>` -- Foo shell \ :ansopt:`ns2.col.foo#shell:bar`\ 
+* :ansplugin:`foo shell <ns2.col.foo#shell>` -- Foo shell :ansopt:`ns2.col.foo#shell:bar`
 
 .. toctree::
     :maxdepth: 1
@@ -231,7 +229,7 @@ Test Plugins
 ~~~~~~~~~~~~
 
 * :ansplugin:`bar test <ns2.col.bar#test>` -- Is something a bar
-* :ansplugin:`foo test <ns2.col.foo#test>` -- Is something a foo \ :ansopt:`ns2.col.foo#test:bar`\ 
+* :ansplugin:`foo test <ns2.col.foo#test>` -- Is something a foo :ansopt:`ns2.col.foo#test:bar`
 
 .. toctree::
     :maxdepth: 1
@@ -244,7 +242,7 @@ Test Plugins
 Vars Plugins
 ~~~~~~~~~~~~
 
-* :ansplugin:`foo vars <ns2.col.foo#vars>` -- Load foo \ :ansopt:`ns2.col.foo#vars:bar`\ 
+* :ansplugin:`foo vars <ns2.col.foo#vars>` -- Load foo :ansopt:`ns2.col.foo#vars:bar`
 
 .. toctree::
     :maxdepth: 1

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/sub.foo3_module.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/sub.foo3_module.rst
@@ -49,7 +49,7 @@ Synopsis
 .. Description
 
 - Foo sub bar.
-- See \ :ansopt:`ns2.col.foo#role:main:foo\_param\_1`\  for a random role parameter reference. And \ :ansopt:`ns2.col.foo#role:main:foo\_param\_2=42`\  for one with a value.
+- See :ansopt:`ns2.col.foo#role:main:foo\_param\_1` for a random role parameter reference. And :ansopt:`ns2.col.foo#role:main:foo\_param\_2=42` for one with a value.
 
 
 .. Aliases
@@ -148,7 +148,7 @@ Attributes
 
         <div class="ansible-option-cell">
 
-      Use \ :literal:`group/ns2.col.foo\_group`\  or \ :literal:`group/ns2.col.bar\_group`\  in \ :literal:`module\_defaults`\  to set defaults for this module.
+      Use :literal:`group/ns2.col.foo\_group` or :literal:`group/ns2.col.bar\_group` in :literal:`module\_defaults` to set defaults for this module.
 
 
       .. raw:: html

--- a/tests/units/markup/test_markup.py
+++ b/tests/units/markup/test_markup.py
@@ -18,22 +18,22 @@ RST_IFY_DATA = {
     "no-op": "no-op",
     "no-op Z(test)": "no-op Z(test)",
     # Simple cases of all substitutions
-    "I(italic)": r"\ :emphasis:`italic`\ ",
-    "B(bold)": r"\ :strong:`bold`\ ",
-    "M(ansible.builtin.yum)": r"\ :ref:`ansible.builtin.yum"
-    r" <ansible_collections.ansible.builtin.yum_module>`\ ",
-    "U(https://docs.ansible.com)": r"\ `https://docs.ansible.com <https://docs.ansible.com>`__\ ",
-    "L(the user guide,https://docs.ansible.com/user-guide.html)": r"\ `the user guide"
-    r" <https://docs.ansible.com/user-guide.html>`__\ ",
-    "R(the user guide,user-guide)": r"\ :ref:`the user guide <user-guide>`\ ",
-    "C(/usr/bin/file)": r"\ :literal:`/usr/bin/file`\ ",
-    "HORIZONTALLINE": "\n\n.. raw:: html\n\n  <hr>\n\n",
+    "I(italic)": r":emphasis:`italic`",
+    "B(bold)": r":strong:`bold`",
+    "M(ansible.builtin.yum)": r":ref:`ansible.builtin.yum"
+    r" <ansible_collections.ansible.builtin.yum_module>`",
+    "U(https://docs.ansible.com)": r"`https://docs.ansible.com <https://docs.ansible.com>`__",
+    "L(the user guide,https://docs.ansible.com/user-guide.html)": r"`the user guide"
+    r" <https://docs.ansible.com/user-guide.html>`__",
+    "R(the user guide,user-guide)": r":ref:`the user guide <user-guide>`",
+    "C(/usr/bin/file)": r":literal:`/usr/bin/file`",
+    "HORIZONTALLINE": ".. raw:: html\n\n  <hr>",
     # Multiple substitutions
-    "The M(ansible.builtin.yum) module B(MUST) be given the C(package) parameter.  See the R(looping docs,using-loops) for more info": r"The \ :ref:`ansible.builtin.yum <ansible_collections.ansible.builtin.yum_module>`\  module \ :strong:`MUST`\  be given the \ :literal:`package`\  parameter.  See the \ :ref:`looping docs <using-loops>`\  for more info",
+    "The M(ansible.builtin.yum) module B(MUST) be given the C(package) parameter.  See the R(looping docs,using-loops) for more info": r"The :ref:`ansible.builtin.yum <ansible_collections.ansible.builtin.yum_module>` module :strong:`MUST` be given the :literal:`package` parameter.  See the :ref:`looping docs <using-loops>` for more info",
     # Problem cases
     "IBM(International Business Machines)": "IBM(International Business Machines)",
-    "L(the user guide, https://docs.ansible.com/)": r"\ `the user guide <https://docs.ansible.com/>`__\ ",
-    "R(the user guide, user-guide)": r"\ :ref:`the user guide <user-guide>`\ ",
+    "L(the user guide, https://docs.ansible.com/)": r"`the user guide <https://docs.ansible.com/>`__",
+    "R(the user guide, user-guide)": r":ref:`the user guide <user-guide>`",
 }
 
 

--- a/tests/units/test_jinja2.py
+++ b/tests/units/test_jinja2.py
@@ -20,22 +20,22 @@ RST_IFY_DATA = {
     "no-op": "no-op",
     "no-op Z(test)": "no-op Z(test)",
     # Simple cases of all substitutions
-    "I(italic)": r"\ :emphasis:`italic`\ ",
-    "B(bold)": r"\ :strong:`bold`\ ",
-    "M(ansible.builtin.yum)": r"\ :ref:`ansible.builtin.yum"
-    r" <ansible_collections.ansible.builtin.yum_module>`\ ",
-    "U(https://docs.ansible.com)": r"\ `https://docs.ansible.com <https://docs.ansible.com>`__\ ",
-    "L(the user guide,https://docs.ansible.com/user-guide.html)": r"\ `the user guide"
-    r" <https://docs.ansible.com/user-guide.html>`__\ ",
-    "R(the user guide,user-guide)": r"\ :ref:`the user guide <user-guide>`\ ",
-    "C(/usr/bin/file)": r"\ :literal:`/usr/bin/file`\ ",
-    "HORIZONTALLINE": "\n\n.. raw:: html\n\n  <hr>\n\n",
+    "I(italic)": r":emphasis:`italic`",
+    "B(bold)": r":strong:`bold`",
+    "M(ansible.builtin.yum)": r":ref:`ansible.builtin.yum"
+    r" <ansible_collections.ansible.builtin.yum_module>`",
+    "U(https://docs.ansible.com)": r"`https://docs.ansible.com <https://docs.ansible.com>`__",
+    "L(the user guide,https://docs.ansible.com/user-guide.html)": r"`the user guide"
+    r" <https://docs.ansible.com/user-guide.html>`__",
+    "R(the user guide,user-guide)": r":ref:`the user guide <user-guide>`",
+    "C(/usr/bin/file)": r":literal:`/usr/bin/file`",
+    "HORIZONTALLINE": ".. raw:: html\n\n  <hr>",
     # Multiple substitutions
-    "The M(ansible.builtin.yum) module B(MUST) be given the C(package) parameter.  See the R(looping docs,using-loops) for more info": r"The \ :ref:`ansible.builtin.yum <ansible_collections.ansible.builtin.yum_module>`\  module \ :strong:`MUST`\  be given the \ :literal:`package`\  parameter.  See the \ :ref:`looping docs <using-loops>`\  for more info",
+    "The M(ansible.builtin.yum) module B(MUST) be given the C(package) parameter.  See the R(looping docs,using-loops) for more info": r"The :ref:`ansible.builtin.yum <ansible_collections.ansible.builtin.yum_module>` module :strong:`MUST` be given the :literal:`package` parameter.  See the :ref:`looping docs <using-loops>` for more info",
     # Problem cases
     "IBM(International Business Machines)": "IBM(International Business Machines)",
-    "L(the user guide, https://docs.ansible.com/)": r"\ `the user guide <https://docs.ansible.com/>`__\ ",
-    "R(the user guide, user-guide)": r"\ :ref:`the user guide <user-guide>`\ ",
+    "L(the user guide, https://docs.ansible.com/)": r"`the user guide <https://docs.ansible.com/>`__",
+    "R(the user guide, user-guide)": r":ref:`the user guide <user-guide>`",
 }
 
 


### PR DESCRIPTION
Fixes the baseline for https://github.com/ansible-community/antsibull-docs-parser/pull/56.

It also fixes a bug when escaping the title of the list of collections in a namespace, due to https://github.com/ansible-community/antsibull-docs-parser/pull/56 removing initial spaces. The filter was applied only to the last string in the concatenation, which started with a whitespace. This caused the word `Namespace` to be directly added to the namespace.