### PR TITLE
Bump antsibull-docs-parser dependency to >= 1.1.0; use whitespace removal feature

### DIFF
--- a/changelogs/fragments/312-parser-dep.yml
+++ b/changelogs/fragments/312-parser-dep.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - "Bump minimal required version of dependency antsibull-docs-parser to 1.1.0
+     This allows to use a new whitespace-removal feature
+     (https://github.com/ansible-community/antsibull-docs/pull/312)."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "ansible-pygments",
     "antsibull-changelog >= 0.24.0",
     "antsibull-core >= 2.1.0, < 4.0.0",
-    "antsibull-docs-parser >= 1.0.2, < 2.0.0",
+    "antsibull-docs-parser >= 1.1.0, < 2.0.0",
     "asyncio-pool",
     "docutils",
     "jinja2 >= 3.0",

--- a/src/antsibull_docs/markup/htmlify.py
+++ b/src/antsibull_docs/markup/htmlify.py
@@ -15,7 +15,7 @@ from urllib.parse import quote
 from antsibull_docs_parser import dom
 from antsibull_docs_parser.format import LinkProvider
 from antsibull_docs_parser.html import to_html
-from antsibull_docs_parser.parser import Context, parse
+from antsibull_docs_parser.parser import Context, Whitespace, parse
 
 from ._counter import count as _count
 
@@ -60,7 +60,9 @@ def html_ify(
             fqcn=doc_plugin_fqcn, type=doc_plugin_type
         )
     context = Context(current_plugin=current_plugin, role_entrypoint=role_entrypoint)
-    paragraphs = parse(text, context, errors="message")
+    paragraphs = parse(
+        text, context, errors="message", whitespace=Whitespace.KEEP_SINGLE_NEWLINES
+    )
     link_provider = _HTMLLinkProvider()
     text = to_html(
         paragraphs,

--- a/src/antsibull_docs/markup/rstify.py
+++ b/src/antsibull_docs/markup/rstify.py
@@ -13,7 +13,7 @@ from collections.abc import Mapping
 
 from antsibull_docs_parser import dom
 from antsibull_docs_parser.format import Formatter, LinkProvider
-from antsibull_docs_parser.parser import Context, parse
+from antsibull_docs_parser.parser import Context, Whitespace, parse
 from antsibull_docs_parser.rst import AntsibullRSTFormatter as _AntsibullRSTFormatter
 from antsibull_docs_parser.rst import PlainRSTFormatter as _PlainRSTFormatter
 from antsibull_docs_parser.rst import rst_escape as _rst_escape
@@ -157,7 +157,9 @@ def rst_ify(
             fqcn=doc_plugin_fqcn, type=doc_plugin_type
         )
     context = Context(current_plugin=current_plugin, role_entrypoint=role_entrypoint)
-    paragraphs = parse(text, context, errors="message")
+    paragraphs = parse(
+        text, context, errors="message", whitespace=Whitespace.KEEP_SINGLE_NEWLINES
+    )
     text = to_rst(
         paragraphs,
         current_plugin=doc_current_plugin,

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_become.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_become.rst
@@ -65,12 +65,10 @@ Parameters
   <p>Removed in: version 4.0.0</p>
   <p>Why: Just some other text.
   This one has more than one line though.
-  One more.
-  </p>
+  One more.</p>
   <p>Alternative: nothing
   relevant
-  I know of
-  </p>
+  I know of</p>
 
     </td>
     <td valign="top">

--- a/tests/functional/baseline-simplified-rst/collections/ns/col2/foo2_module.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns/col2/foo2_module.rst
@@ -79,8 +79,7 @@ Parameters
       <p>Foo bar baz. Bamm - Bar baz
       bam bum.
       Bumm - Foo bar
-      baz bam!
-      </p>
+      baz bam!</p>
     </td>
   </tr>
   <tr>

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_become.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_become.rst
@@ -65,12 +65,10 @@ Parameters
   <p>Removed in: version 4.0.0</p>
   <p>Why: Just some other text.
   This one has more than one line though.
-  One more.
-  </p>
+  One more.</p>
   <p>Alternative: nothing
   relevant
-  I know of
-  </p>
+  I know of</p>
 
     </td>
     <td valign="top">

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_become.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_become.rst
@@ -97,12 +97,10 @@ Parameters
   <p>Removed in: version 4.0.0</p>
   <p>Why: Just some other text.
   This one has more than one line though.
-  One more.
-  </p>
+  One more.</p>
   <p>Alternative: nothing
   relevant
-  I know of
-  </p>
+  I know of</p>
 
     </div></td>
     <td><div class="ansible-option-cell">

--- a/tests/units/markup/test_markup.py
+++ b/tests/units/markup/test_markup.py
@@ -29,7 +29,7 @@ RST_IFY_DATA = {
     "C(/usr/bin/file)": r":literal:`/usr/bin/file`",
     "HORIZONTALLINE": ".. raw:: html\n\n  <hr>",
     # Multiple substitutions
-    "The M(ansible.builtin.yum) module B(MUST) be given the C(package) parameter.  See the R(looping docs,using-loops) for more info": r"The :ref:`ansible.builtin.yum <ansible_collections.ansible.builtin.yum_module>` module :strong:`MUST` be given the :literal:`package` parameter.  See the :ref:`looping docs <using-loops>` for more info",
+    "The M(ansible.builtin.yum) module B(MUST) be given the C(package) parameter.  See the R(looping docs,using-loops) for more info": r"The :ref:`ansible.builtin.yum <ansible_collections.ansible.builtin.yum_module>` module :strong:`MUST` be given the :literal:`package` parameter. See the :ref:`looping docs <using-loops>` for more info",
     # Problem cases
     "IBM(International Business Machines)": "IBM(International Business Machines)",
     "L(the user guide, https://docs.ansible.com/)": r"`the user guide <https://docs.ansible.com/>`__",

--- a/tests/units/test_jinja2.py
+++ b/tests/units/test_jinja2.py
@@ -31,7 +31,7 @@ RST_IFY_DATA = {
     "C(/usr/bin/file)": r":literal:`/usr/bin/file`",
     "HORIZONTALLINE": ".. raw:: html\n\n  <hr>",
     # Multiple substitutions
-    "The M(ansible.builtin.yum) module B(MUST) be given the C(package) parameter.  See the R(looping docs,using-loops) for more info": r"The :ref:`ansible.builtin.yum <ansible_collections.ansible.builtin.yum_module>` module :strong:`MUST` be given the :literal:`package` parameter.  See the :ref:`looping docs <using-loops>` for more info",
+    "The M(ansible.builtin.yum) module B(MUST) be given the C(package) parameter.  See the R(looping docs,using-loops) for more info": r"The :ref:`ansible.builtin.yum <ansible_collections.ansible.builtin.yum_module>` module :strong:`MUST` be given the :literal:`package` parameter. See the :ref:`looping docs <using-loops>` for more info",
     # Problem cases
     "IBM(International Business Machines)": "IBM(International Business Machines)",
     "L(the user guide, https://docs.ansible.com/)": r"`the user guide <https://docs.ansible.com/>`__",


### PR DESCRIPTION
This allows using https://github.com/ansible-community/antsibull-docs-parser/pull/54.

Once antsibull-docs-parser 1.1.0 is out a new antsibull-docs release should be made as soon as possible, due to the bug fixed in #311.

CI will likely fail since 1.1.0 hasn't been released.