### PR TITLE
Remove superfluous whitespace or escaped spaces from templates

### DIFF
--- a/changelogs/fragments/313-whitespace.yml
+++ b/changelogs/fragments/313-whitespace.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Remove superfluous whitespace or escaped spaces from templates (https://github.com/ansible-community/antsibull-docs/pull/313)."

--- a/src/antsibull_docs/data/docsite/ansible-docsite/plugin.rst.j2
+++ b/src/antsibull_docs/data/docsite/ansible-docsite/plugin.rst.j2
@@ -327,13 +327,13 @@ See Also
 
 .. Examples
 
-{% if examples -%}
+{% if examples and examples | trim -%}
 Examples
 --------
 
 .. code-block:: @{ examples_format | rst_format(for_sphinx=true) }@
 
-@{ examples | indent(4, True) }@
+@{ examples | sanitize_whitespace | indent(4, True) }@
 
 {% endif %}
 

--- a/src/antsibull_docs/data/docsite/ansible-docsite/role.rst.j2
+++ b/src/antsibull_docs/data/docsite/ansible-docsite/role.rst.j2
@@ -189,13 +189,13 @@ See Also
 {%     endfor %}
 {%   endif %}
 
-{%   if ep_doc['examples'] -%}
+{%   if ep_doc['examples'] and ep_doc['examples'] | trim -%}
 Examples
 --------
 
 .. code-block:: @{ ep_doc['examples_format'] | rst_format(for_sphinx=true) }@
 
-@{     ep_doc['examples'] | indent(4, True) }@
+@{     ep_doc['examples'] | sanitize_whitespace | indent(4, True) }@
 
 {%   endif %}
 

--- a/src/antsibull_docs/data/docsite/simplified-rst/macros/attributes.rst.j2
+++ b/src/antsibull_docs/data/docsite/simplified-rst/macros/attributes.rst.j2
@@ -49,7 +49,7 @@
 {%   endfor %}
 
 {#   description #}
-    - 
+    -
 {% for desc in data['description'] %}
       @{ desc | rst_ify(role_entrypoint=role_entrypoint) | rst_indent(6) }@
 

--- a/src/antsibull_docs/data/docsite/simplified-rst/plugin.rst.j2
+++ b/src/antsibull_docs/data/docsite/simplified-rst/plugin.rst.j2
@@ -256,13 +256,13 @@ See Also
 {% endfor %}
 {% endif %}
 
-{% if examples -%}
+{% if examples and examples | trim -%}
 Examples
 --------
 
 .. code-block:: @{ examples_format | rst_format }@
 
-@{ examples | indent(4, True) }@
+@{ examples | sanitize_whitespace | indent(4, True) }@
 
 {% endif %}
 

--- a/src/antsibull_docs/data/docsite/simplified-rst/role.rst.j2
+++ b/src/antsibull_docs/data/docsite/simplified-rst/role.rst.j2
@@ -146,13 +146,13 @@ See Also
 {%     endfor %}
 {%   endif %}
 
-{%   if ep_doc['examples'] -%}
+{%   if ep_doc['examples'] and ep_doc['examples'] | trim -%}
 Examples
 --------
 
 .. code-block:: @{ ep_doc['examples_format'] | rst_format }@
 
-@{     ep_doc['examples'] | indent(4, True) }@
+@{     ep_doc['examples'] | sanitize_whitespace | indent(4, True) }@
 
 {%   endif %}
 

--- a/src/antsibull_docs/jinja2/environment.py
+++ b/src/antsibull_docs/jinja2/environment.py
@@ -37,6 +37,7 @@ from .filters import (
     rst_format,
     rst_indent,
     rst_xline,
+    sanitize_whitespace,
     suboption_depth,
     to_ini_value,
     to_json,
@@ -46,14 +47,14 @@ from .tests import still_relevant, test_list
 
 def reference_plugin_rst(plugin_name: str, plugin_type: str) -> str:
     fqcn = f"{plugin_name}"
-    return f"\\ :ref:`{rst_escape(fqcn)} <{get_plugin_ref(fqcn, plugin_type)}>`\\ "
+    return f":ref:`{rst_escape(fqcn)} <{get_plugin_ref(fqcn, plugin_type)}>`"
 
 
 def reference_plugin_rst_simplified(plugin_name: str, plugin_type: str) -> str:
     fqcn = f"{plugin_name}"
-    # TODO: return f"\\ {fqcn}\\ " for other collections
+    # TODO: return fqcn for other collections
     name = plugin_name.split(".", 2)[2]
-    return f"\\ `{rst_escape(fqcn)} <{name}_{plugin_type}.rst>`__\\ "
+    return f"`{rst_escape(fqcn)} <{name}_{plugin_type}.rst>`__"
 
 
 def make_reference_plugin_rst(output_format: OutputFormat):
@@ -171,6 +172,7 @@ def doc_environment(
     env.filters["suboption_depth"] = suboption_depth
     env.filters["rst_format"] = rst_format
     env.filters["rst_indent"] = rst_indent
+    env.filters["sanitize_whitespace"] = sanitize_whitespace
     if collection_url is not None:
         env.filters["collection_url"] = collection_url
     if collection_install is not None:

--- a/src/antsibull_docs/jinja2/filters.py
+++ b/src/antsibull_docs/jinja2/filters.py
@@ -21,6 +21,7 @@ from jinja2.utils import pass_context
 from ..markup.htmlify import html_ify as html_ify_impl
 from ..markup.rstify import get_rst_formatter_link_provider
 from ..markup.rstify import rst_ify as rst_ify_impl
+from ..utils.text import sanitize_whitespace as _sanitize_whitespace
 from . import OutputFormat
 
 mlog = log.fields(mod=__name__)
@@ -98,7 +99,7 @@ def massage_author_name(value):
     """remove email addresses from the given string, and remove `(!UNKNOWN)`"""
     value = _EMAIL_ADDRESS.sub("", value)
     value = value.replace("(!UNKNOWN)", "")
-    return value
+    return value.strip()
 
 
 def extract_options_from_list(
@@ -288,3 +289,9 @@ def rst_indent(
             )
 
     return indent + rv if first else rv
+
+
+def sanitize_whitespace(text: str) -> str:
+    if not isinstance(text, str):
+        raise ValueError("sanitize_whitespace can only be applied to strings")
+    return _sanitize_whitespace(text)

--- a/src/antsibull_docs/utils/text.py
+++ b/src/antsibull_docs/utils/text.py
@@ -1,0 +1,59 @@
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2024, Ansible Project
+"""
+Text utils.
+"""
+
+import typing as t
+
+
+def count_leading_whitespace(
+    line: str, *, max_count: t.Optional[int] = None
+) -> t.Optional[int]:
+    """
+    Count the number of leading whitespace for the given line.
+
+    If ``max_count`` is given, will not return numbers greater than ``max_count``.
+    If the line completely consists out of whitespace, ``None`` is returned.
+    """
+    length = len(line)
+    to_check = length
+    if max_count is not None and max_count < to_check:
+        to_check = max_count
+    count = 0
+    while count < to_check and line[count] in " \t":
+        count += 1
+    if count == length:
+        return None
+    return count
+
+
+def sanitize_whitespace(content: str) -> str:
+    # Split into lines and remove trailing whitespace
+    lines = [line.rstrip(" \t") for line in content.splitlines()]
+
+    # Remove starting and trailing empty lines
+    start = 0
+    end = len(lines)
+    while start < end and lines[start] == "":
+        start += 1
+    while start < end and lines[end - 1] == "":
+        end -= 1
+    lines = lines[start:end]
+
+    # Remove common leading whitespace
+    common_whitespace = None
+    for line in lines:
+        whitespace = count_leading_whitespace(line, max_count=common_whitespace)
+        if whitespace is not None:
+            if common_whitespace is None or common_whitespace > whitespace:
+                common_whitespace = whitespace
+                if common_whitespace == 0:
+                    break
+    if common_whitespace is not None and common_whitespace > 0:
+        lines = [line[common_whitespace:] for line in lines]
+
+    # Re-combine the result
+    return "\n".join(lines)

--- a/tests/functional/baseline-default/collections/ns/col2/bar_role.rst
+++ b/tests/functional/baseline-default/collections/ns/col2/bar_role.rst
@@ -115,11 +115,11 @@ See Also
 
 .. seealso::
 
-   \ :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_module>`\ 
+   :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_module>`
        The official documentation on the **ns2.col.foo** module.
-   \ :ref:`ns2.col.foobarbaz <ansible_collections.ns2.col.foobarbaz_module>`\ 
+   :ref:`ns2.col.foobarbaz <ansible_collections.ns2.col.foobarbaz_module>`
        The official documentation on the **ns2.col.foobarbaz** module.
-   \ :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>`\  lookup plugin
+   :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>` lookup plugin
        The official documentation on the **ns2.col.foo** lookup plugin.
 
 

--- a/tests/functional/baseline-default/collections/ns/col2/foo2_module.rst
+++ b/tests/functional/baseline-default/collections/ns/col2/foo2_module.rst
@@ -474,21 +474,21 @@ See Also
 
 .. seealso::
 
-   \ :ref:`ns.col2.foo3 <ansible_collections.ns.col2.foo3_module>`\ 
+   :ref:`ns.col2.foo3 <ansible_collections.ns.col2.foo3_module>`
        Foo III.
-   \ :ref:`ns.col2.foobarbaz <ansible_collections.ns.col2.foobarbaz_module>`\ 
+   :ref:`ns.col2.foobarbaz <ansible_collections.ns.col2.foobarbaz_module>`
        The official documentation on the **ns.col2.foobarbaz** module.
-   \ :ref:`ns.col2.foo4 <ansible_collections.ns.col2.foo4_module>`\  module plugin
+   :ref:`ns.col2.foo4 <ansible_collections.ns.col2.foo4_module>` module plugin
        Markup reference linting test.
-   \ :ref:`ns.col2.foobarbaz <ansible_collections.ns.col2.foobarbaz_inventory>`\  inventory plugin
+   :ref:`ns.col2.foobarbaz <ansible_collections.ns.col2.foobarbaz_inventory>` inventory plugin
        The official documentation on the **ns.col2.foobarbaz** inventory plugin.
-   \ :ref:`ansible.builtin.service <ansible_collections.ansible.builtin.service_module>`\ 
+   :ref:`ansible.builtin.service <ansible_collections.ansible.builtin.service_module>`
        The service module.
-   \ :ref:`ansible.builtin.foobarbaz <ansible_collections.ansible.builtin.foobarbaz_module>`\ 
+   :ref:`ansible.builtin.foobarbaz <ansible_collections.ansible.builtin.foobarbaz_module>`
        A non-existing module.
-   \ :ref:`ansible.builtin.linear <ansible_collections.ansible.builtin.linear_strategy>`\  strategy plugin
+   :ref:`ansible.builtin.linear <ansible_collections.ansible.builtin.linear_strategy>` strategy plugin
        The linear strategy plugin.
-   \ :ref:`ansible.builtin.foobarbaz <ansible_collections.ansible.builtin.foobarbaz_strategy>`\  strategy plugin
+   :ref:`ansible.builtin.foobarbaz <ansible_collections.ansible.builtin.foobarbaz_strategy>` strategy plugin
        Foo bar baz. Bamm - Bar baz
        bam bum.
        Bumm - Foo bar
@@ -501,9 +501,7 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     name: This is YAML.
-
 
 
 

--- a/tests/functional/baseline-default/collections/ns/col2/foo3_module.rst
+++ b/tests/functional/baseline-default/collections/ns/col2/foo3_module.rst
@@ -394,9 +394,7 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     This is not YAML.
-
 
 
 

--- a/tests/functional/baseline-default/collections/ns2/col/bar_filter.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/bar_filter.rst
@@ -323,9 +323,7 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     {'a': 1} | ns2.col.bar({'b': 2}, baz='cde')
-
 
 
 

--- a/tests/functional/baseline-default/collections/ns2/col/bar_test.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/bar_test.rst
@@ -142,7 +142,6 @@ Examples
 
 
 
-
 .. Facts
 
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo2_module.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo2_module.rst
@@ -316,11 +316,9 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     - name: Do some foo
       ns2.col.foo2:
         bar: foo
-
 
 
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_become.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_become.rst
@@ -352,7 +352,7 @@ Status
 Authors
 ~~~~~~~
 
-- Nobody 
+- Nobody
 
 
 .. hint::

--- a/tests/functional/baseline-default/collections/ns2/col/foo_cliconf.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_cliconf.rst
@@ -91,7 +91,7 @@ Synopsis
 Authors
 ~~~~~~~
 
-- Felix Fontein (@felixfontein) 
+- Felix Fontein (@felixfontein)
 
 
 .. hint::

--- a/tests/functional/baseline-default/collections/ns2/col/foo_filter.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_filter.rst
@@ -231,9 +231,7 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     some_var: "{{ 'foo' | ns2.col.foo }}"
-
 
 
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_inventory.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_inventory.rst
@@ -134,10 +134,8 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     foo:
         bar!
-
 
 
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_lookup.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_lookup.rst
@@ -199,11 +199,9 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     - name: Look up bar
       ansible.builtin.debug:
         msg: "{{ lookup('ns2.col.foo', 'bar') }}"
-
 
 
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_module.rst
@@ -548,13 +548,13 @@ See Also
 
 .. seealso::
 
-   \ :ref:`ns2.col.foo2 <ansible_collections.ns2.col.foo2_module>`\ 
+   :ref:`ns2.col.foo2 <ansible_collections.ns2.col.foo2_module>`
        Another foo.
-   \ :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>`\  lookup plugin
+   :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>` lookup plugin
        Look up some foo :ansopt:`ns2.col.foo#module:bar`.
-   \ :ref:`ansible.builtin.service <ansible_collections.ansible.builtin.service_module>`\ 
+   :ref:`ansible.builtin.service <ansible_collections.ansible.builtin.service_module>`
        The service module.
-   \ :ref:`ansible.builtin.ssh <ansible_collections.ansible.builtin.ssh_connection>`\  connection plugin
+   :ref:`ansible.builtin.ssh <ansible_collections.ansible.builtin.ssh_connection>` connection plugin
        The ssh connection plugin.
 
 .. Examples
@@ -564,7 +564,6 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     - name: Do some foo
       ns2.col.foo:
         foo: '{{ foo }}'
@@ -574,7 +573,6 @@ Examples
           - 3
         subfoo:
           foo: hoo!
-
 
 
 

--- a/tests/functional/baseline-default/collections/ns2/col/foo_role.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_role.rst
@@ -280,7 +280,7 @@ See Also
 
 .. seealso::
 
-   \ :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_module>`\ 
+   :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_module>`
        The official documentation on the **ns2.col.foo** module.
 
 Examples

--- a/tests/functional/baseline-default/collections/ns2/col/foo_test.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_test.rst
@@ -191,9 +191,7 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     some_var: "{{ {'a': 1} is ns2.col.foo }}"
-
 
 
 

--- a/tests/functional/baseline-default/collections/ns2/col/sub.foo3_module.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/sub.foo3_module.rst
@@ -315,11 +315,9 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     - name: Do some foobar
       ns2.col.sub.foo3:
         bar: baz
-
 
 
 

--- a/tests/functional/baseline-default/collections/ns2/flatcol/foo2_module.rst
+++ b/tests/functional/baseline-default/collections/ns2/flatcol/foo2_module.rst
@@ -131,11 +131,9 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     - name: Do some foo
       ns2.flatcol.foo2:
         bar: foo
-
 
 
 

--- a/tests/functional/baseline-default/collections/ns2/flatcol/foo_module.rst
+++ b/tests/functional/baseline-default/collections/ns2/flatcol/foo_module.rst
@@ -274,7 +274,6 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     - name: Do some foo
       ns2.flatcol.foo:
         foo: '{{ foo }}'
@@ -284,7 +283,6 @@ Examples
           - 3
         subfoo:
           foo: hoo!
-
 
 
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/bar_role.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/bar_role.rst
@@ -115,11 +115,11 @@ See Also
 
 .. seealso::
 
-   \ :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_module>`\ 
+   :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_module>`
        The official documentation on the **ns2.col.foo** module.
-   \ :ref:`ns2.col.foobarbaz <ansible_collections.ns2.col.foobarbaz_module>`\ 
+   :ref:`ns2.col.foobarbaz <ansible_collections.ns2.col.foobarbaz_module>`
        The official documentation on the **ns2.col.foobarbaz** module.
-   \ :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>`\  lookup plugin
+   :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>` lookup plugin
        The official documentation on the **ns2.col.foo** lookup plugin.
 
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/foo2_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/foo2_module.rst
@@ -474,21 +474,21 @@ See Also
 
 .. seealso::
 
-   \ :ref:`ns.col2.foo3 <ansible_collections.ns.col2.foo3_module>`\ 
+   :ref:`ns.col2.foo3 <ansible_collections.ns.col2.foo3_module>`
        Foo III.
-   \ :ref:`ns.col2.foobarbaz <ansible_collections.ns.col2.foobarbaz_module>`\ 
+   :ref:`ns.col2.foobarbaz <ansible_collections.ns.col2.foobarbaz_module>`
        The official documentation on the **ns.col2.foobarbaz** module.
-   \ :ref:`ns.col2.foo4 <ansible_collections.ns.col2.foo4_module>`\  module plugin
+   :ref:`ns.col2.foo4 <ansible_collections.ns.col2.foo4_module>` module plugin
        Markup reference linting test.
-   \ :ref:`ns.col2.foobarbaz <ansible_collections.ns.col2.foobarbaz_inventory>`\  inventory plugin
+   :ref:`ns.col2.foobarbaz <ansible_collections.ns.col2.foobarbaz_inventory>` inventory plugin
        The official documentation on the **ns.col2.foobarbaz** inventory plugin.
-   \ :ref:`ansible.builtin.service <ansible_collections.ansible.builtin.service_module>`\ 
+   :ref:`ansible.builtin.service <ansible_collections.ansible.builtin.service_module>`
        The service module.
-   \ :ref:`ansible.builtin.foobarbaz <ansible_collections.ansible.builtin.foobarbaz_module>`\ 
+   :ref:`ansible.builtin.foobarbaz <ansible_collections.ansible.builtin.foobarbaz_module>`
        A non-existing module.
-   \ :ref:`ansible.builtin.linear <ansible_collections.ansible.builtin.linear_strategy>`\  strategy plugin
+   :ref:`ansible.builtin.linear <ansible_collections.ansible.builtin.linear_strategy>` strategy plugin
        The linear strategy plugin.
-   \ :ref:`ansible.builtin.foobarbaz <ansible_collections.ansible.builtin.foobarbaz_strategy>`\  strategy plugin
+   :ref:`ansible.builtin.foobarbaz <ansible_collections.ansible.builtin.foobarbaz_strategy>` strategy plugin
        Foo bar baz. Bamm - Bar baz
        bam bum.
        Bumm - Foo bar
@@ -501,9 +501,7 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     name: This is YAML.
-
 
 
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/foo3_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/foo3_module.rst
@@ -394,9 +394,7 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     This is not YAML.
-
 
 
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/bar_filter.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/bar_filter.rst
@@ -323,9 +323,7 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     {'a': 1} | ns2.col.bar({'b': 2}, baz='cde')
-
 
 
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/bar_test.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/bar_test.rst
@@ -142,7 +142,6 @@ Examples
 
 
 
-
 .. Facts
 
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo2_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo2_module.rst
@@ -316,11 +316,9 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     - name: Do some foo
       ns2.col.foo2:
         bar: foo
-
 
 
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_become.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_become.rst
@@ -352,7 +352,7 @@ Status
 Authors
 ~~~~~~~
 
-- Nobody 
+- Nobody
 
 
 .. hint::

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_cliconf.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_cliconf.rst
@@ -91,7 +91,7 @@ Synopsis
 Authors
 ~~~~~~~
 
-- Felix Fontein (@felixfontein) 
+- Felix Fontein (@felixfontein)
 
 
 .. hint::

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_filter.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_filter.rst
@@ -231,9 +231,7 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     some_var: "{{ 'foo' | ns2.col.foo }}"
-
 
 
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_inventory.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_inventory.rst
@@ -134,10 +134,8 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     foo:
         bar!
-
 
 
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_lookup.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_lookup.rst
@@ -199,11 +199,9 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     - name: Look up bar
       ansible.builtin.debug:
         msg: "{{ lookup('ns2.col.foo', 'bar') }}"
-
 
 
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_module.rst
@@ -548,13 +548,13 @@ See Also
 
 .. seealso::
 
-   \ :ref:`ns2.col.foo2 <ansible_collections.ns2.col.foo2_module>`\ 
+   :ref:`ns2.col.foo2 <ansible_collections.ns2.col.foo2_module>`
        Another foo.
-   \ :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>`\  lookup plugin
+   :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>` lookup plugin
        Look up some foo :ansopt:`ns2.col.foo#module:bar`.
-   \ :ref:`ansible.builtin.service <ansible_collections.ansible.builtin.service_module>`\ 
+   :ref:`ansible.builtin.service <ansible_collections.ansible.builtin.service_module>`
        The service module.
-   \ :ref:`ansible.builtin.ssh <ansible_collections.ansible.builtin.ssh_connection>`\  connection plugin
+   :ref:`ansible.builtin.ssh <ansible_collections.ansible.builtin.ssh_connection>` connection plugin
        The ssh connection plugin.
 
 .. Examples
@@ -564,7 +564,6 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     - name: Do some foo
       ns2.col.foo:
         foo: '{{ foo }}'
@@ -574,7 +573,6 @@ Examples
           - 3
         subfoo:
           foo: hoo!
-
 
 
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_role.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_role.rst
@@ -280,7 +280,7 @@ See Also
 
 .. seealso::
 
-   \ :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_module>`\ 
+   :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_module>`
        The official documentation on the **ns2.col.foo** module.
 
 Examples

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_test.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_test.rst
@@ -191,9 +191,7 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     some_var: "{{ {'a': 1} is ns2.col.foo }}"
-
 
 
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/sub.foo3_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/sub.foo3_module.rst
@@ -315,11 +315,9 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     - name: Do some foobar
       ns2.col.sub.foo3:
         bar: baz
-
 
 
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/flatcol/foo2_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/flatcol/foo2_module.rst
@@ -131,11 +131,9 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     - name: Do some foo
       ns2.flatcol.foo2:
         bar: foo
-
 
 
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/flatcol/foo_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/flatcol/foo_module.rst
@@ -274,7 +274,6 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     - name: Do some foo
       ns2.flatcol.foo:
         foo: '{{ foo }}'
@@ -284,7 +283,6 @@ Examples
           - 3
         subfoo:
           foo: hoo!
-
 
 
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/bar_filter.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/bar_filter.rst
@@ -323,9 +323,7 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     {'a': 1} | ns2.col.bar({'b': 2}, baz='cde')
-
 
 
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/bar_test.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/bar_test.rst
@@ -142,7 +142,6 @@ Examples
 
 
 
-
 .. Facts
 
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo2_module.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo2_module.rst
@@ -316,11 +316,9 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     - name: Do some foo
       ns2.col.foo2:
         bar: foo
-
 
 
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_become.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_become.rst
@@ -352,7 +352,7 @@ Status
 Authors
 ~~~~~~~
 
-- Nobody 
+- Nobody
 
 
 .. hint::

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_cliconf.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_cliconf.rst
@@ -91,7 +91,7 @@ Synopsis
 Authors
 ~~~~~~~
 
-- Felix Fontein (@felixfontein) 
+- Felix Fontein (@felixfontein)
 
 
 .. hint::

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_filter.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_filter.rst
@@ -231,9 +231,7 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     some_var: "{{ 'foo' | ns2.col.foo }}"
-
 
 
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_inventory.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_inventory.rst
@@ -134,10 +134,8 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     foo:
         bar!
-
 
 
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_lookup.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_lookup.rst
@@ -199,11 +199,9 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     - name: Look up bar
       ansible.builtin.debug:
         msg: "{{ lookup('ns2.col.foo', 'bar') }}"
-
 
 
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_module.rst
@@ -548,13 +548,13 @@ See Also
 
 .. seealso::
 
-   \ :ref:`ns2.col.foo2 <ansible_collections.ns2.col.foo2_module>`\ 
+   :ref:`ns2.col.foo2 <ansible_collections.ns2.col.foo2_module>`
        Another foo.
-   \ :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>`\  lookup plugin
+   :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>` lookup plugin
        Look up some foo :ansopt:`ns2.col.foo#module:bar`.
-   \ :ref:`ansible.builtin.service <ansible_collections.ansible.builtin.service_module>`\ 
+   :ref:`ansible.builtin.service <ansible_collections.ansible.builtin.service_module>`
        The service module.
-   \ :ref:`ansible.builtin.ssh <ansible_collections.ansible.builtin.ssh_connection>`\  connection plugin
+   :ref:`ansible.builtin.ssh <ansible_collections.ansible.builtin.ssh_connection>` connection plugin
        The ssh connection plugin.
 
 .. Examples
@@ -564,7 +564,6 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     - name: Do some foo
       ns2.col.foo:
         foo: '{{ foo }}'
@@ -574,7 +573,6 @@ Examples
           - 3
         subfoo:
           foo: hoo!
-
 
 
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_role.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_role.rst
@@ -280,7 +280,7 @@ See Also
 
 .. seealso::
 
-   \ :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_module>`\ 
+   :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_module>`
        The official documentation on the **ns2.col.foo** module.
 
 Examples

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_test.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_test.rst
@@ -191,9 +191,7 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     some_var: "{{ {'a': 1} is ns2.col.foo }}"
-
 
 
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/sub.foo3_module.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/sub.foo3_module.rst
@@ -315,11 +315,9 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     - name: Do some foobar
       ns2.col.sub.foo3:
         bar: baz
-
 
 
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/flatcol/foo2_module.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/flatcol/foo2_module.rst
@@ -131,11 +131,9 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     - name: Do some foo
       ns2.flatcol.foo2:
         bar: foo
-
 
 
 

--- a/tests/functional/baseline-no-indexes/collections/ns2/flatcol/foo_module.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/flatcol/foo_module.rst
@@ -274,7 +274,6 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     - name: Do some foo
       ns2.flatcol.foo:
         foo: '{{ foo }}'
@@ -284,7 +283,6 @@ Examples
           - 3
         subfoo:
           foo: hoo!
-
 
 
 

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/bar_filter.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/bar_filter.rst
@@ -195,9 +195,7 @@ Examples
 
 .. code-block:: yaml
 
-    
     {'a': 1} | ns2.col.bar({'b': 2}, baz='cde')
-
 
 
 

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/bar_test.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/bar_test.rst
@@ -81,7 +81,6 @@ Examples
 
 
 
-
 Return Value
 ------------
 

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo2_module.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo2_module.rst
@@ -84,7 +84,7 @@ Attributes
     - Action groups: \ns2.col.bar\_group, ns2.col.foo\_group
 
 
-    - 
+    -
       Use :literal:`group/ns2.col.foo\_group` or :literal:`group/ns2.col.bar\_group` in :literal:`module\_defaults` to set defaults for this module.
 
 
@@ -97,7 +97,7 @@ Attributes
 
 
 
-    - 
+    -
       Can run in check\_mode and return changed status prediction without modifying target
 
 
@@ -110,7 +110,7 @@ Attributes
 
 
 
-    - 
+    -
       Will return details on what has changed (or possibly needs changing in check\_mode), when in diff mode
 
 
@@ -122,7 +122,7 @@ Attributes
     - Platform:posix
 
 
-    - 
+    -
       Target OS/families that can be operated against
 
 
@@ -135,11 +135,9 @@ Examples
 
 .. code-block:: yaml
 
-    
     - name: Do some foo
       ns2.col.foo2:
         bar: foo
-
 
 
 

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_become.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_become.rst
@@ -211,7 +211,7 @@ Status
 Authors
 ~~~~~~~
 
-- Nobody 
+- Nobody
 
 
 .. hint::

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_cliconf.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_cliconf.rst
@@ -43,7 +43,7 @@ Synopsis
 Authors
 ~~~~~~~
 
-- Felix Fontein (@felixfontein) 
+- Felix Fontein (@felixfontein)
 
 
 .. hint::

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_filter.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_filter.rst
@@ -127,9 +127,7 @@ Examples
 
 .. code-block:: yaml
 
-    
     some_var: "{{ 'foo' | ns2.col.foo }}"
-
 
 
 

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_inventory.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_inventory.rst
@@ -72,10 +72,8 @@ Examples
 
 .. code-block:: yaml
 
-    
     foo:
         bar!
-
 
 
 

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_lookup.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_lookup.rst
@@ -116,11 +116,9 @@ Examples
 
 .. code-block:: yaml
 
-    
     - name: Look up bar
       ansible.builtin.debug:
         msg: "{{ lookup('ns2.col.foo', 'bar') }}"
-
 
 
 

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_module.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_module.rst
@@ -229,7 +229,7 @@ Attributes
     - Action group: \ns2.col.foo\_group
 
 
-    - 
+    -
       Use :literal:`group/ns2.col.foo\_group` in :literal:`module\_defaults` to set defaults for this module.
 
 
@@ -242,7 +242,7 @@ Attributes
 
 
 
-    - 
+    -
       Can run in check\_mode and return changed status prediction without modifying target
 
 
@@ -255,7 +255,7 @@ Attributes
 
 
 
-    - 
+    -
       Will return details on what has changed (or possibly needs changing in check\_mode), when in diff mode
 
 
@@ -267,7 +267,7 @@ Attributes
     - Platform:posix
 
 
-    - 
+    -
       Target OS/families that can be operated against
 
 
@@ -277,16 +277,16 @@ Attributes
 See Also
 --------
 
-* \ `ns2.col.foo2 <foo2_module.rst>`__\ 
+* `ns2.col.foo2 <foo2_module.rst>`__
 
   Another foo.
-* \ `ns2.col.foo <foo_lookup.rst>`__\  lookup plugin
+* `ns2.col.foo <foo_lookup.rst>`__ lookup plugin
 
   Look up some foo :literal:`bar` (`link <#parameter-bar>`_).
-* \ `ansible.builtin.service <service_module.rst>`__\ 
+* `ansible.builtin.service <service_module.rst>`__
 
   The service module.
-* \ `ansible.builtin.ssh <ssh_connection.rst>`__\  connection plugin
+* `ansible.builtin.ssh <ssh_connection.rst>`__ connection plugin
 
   The ssh connection plugin.
 
@@ -295,7 +295,6 @@ Examples
 
 .. code-block:: yaml
 
-    
     - name: Do some foo
       ns2.col.foo:
         foo: '{{ foo }}'
@@ -305,7 +304,6 @@ Examples
           - 3
         subfoo:
           foo: hoo!
-
 
 
 

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_role.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_role.rst
@@ -108,7 +108,7 @@ Attributes
 
 
 
-    - 
+    -
       Can run in check\_mode and return changed status prediction without modifying target
 
 
@@ -120,7 +120,7 @@ Attributes
     - Platforms:Linux, macOS, FreeBSD
 
 
-    - 
+    -
       The supported platforms
 
 
@@ -130,7 +130,7 @@ Attributes
 See Also
 ^^^^^^^^
 
-* \ `ns2.col.foo <foo_module.rst>`__\ 
+* `ns2.col.foo <foo_module.rst>`__
 
   The official documentation on the **ns2.col.foo** module.
 

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_test.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_test.rst
@@ -110,9 +110,7 @@ Examples
 
 .. code-block:: yaml
 
-    
     some_var: "{{ {'a': 1} is ns2.col.foo }}"
-
 
 
 

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/sub.foo3_module.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/sub.foo3_module.rst
@@ -83,7 +83,7 @@ Attributes
     - Action groups: \ns2.col.bar\_group, ns2.col.foo\_group
 
 
-    - 
+    -
       Use :literal:`group/ns2.col.foo\_group` or :literal:`group/ns2.col.bar\_group` in :literal:`module\_defaults` to set defaults for this module.
 
 
@@ -96,7 +96,7 @@ Attributes
 
 
 
-    - 
+    -
       Can run in check\_mode and return changed status prediction without modifying target
 
 
@@ -109,7 +109,7 @@ Attributes
 
 
 
-    - 
+    -
       Will return details on what has changed (or possibly needs changing in check\_mode), when in diff mode
 
 
@@ -121,7 +121,7 @@ Attributes
     - Platform:posix
 
 
-    - 
+    -
       Target OS/families that can be operated against
 
 
@@ -134,11 +134,9 @@ Examples
 
 .. code-block:: yaml
 
-    
     - name: Do some foobar
       ns2.col.sub.foo3:
         bar: baz
-
 
 
 

--- a/tests/functional/baseline-simplified-rst/collections/ns/col2/bar_role.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns/col2/bar_role.rst
@@ -60,13 +60,13 @@ Synopsis
 See Also
 ^^^^^^^^
 
-* \ `ns2.col.foo <foo_module.rst>`__\ 
+* `ns2.col.foo <foo_module.rst>`__
 
   The official documentation on the **ns2.col.foo** module.
-* \ `ns2.col.foobarbaz <foobarbaz_module.rst>`__\ 
+* `ns2.col.foobarbaz <foobarbaz_module.rst>`__
 
   The official documentation on the **ns2.col.foobarbaz** module.
-* \ `ns2.col.foo <foo_lookup.rst>`__\  lookup plugin
+* `ns2.col.foo <foo_lookup.rst>`__ lookup plugin
 
   The official documentation on the **ns2.col.foo** lookup plugin.
 

--- a/tests/functional/baseline-simplified-rst/collections/ns/col2/foo2_module.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns/col2/foo2_module.rst
@@ -168,7 +168,7 @@ Attributes
 
 
 
-    - 
+    -
       Can run in check\_mode and return changed status prediction without modifying target
 
 
@@ -181,7 +181,7 @@ Attributes
 
 
 
-    - 
+    -
       Will return details on what has changed (or possibly needs changing in check\_mode), when in diff mode
 
       Foo bar baz. Bamm - Bar baz
@@ -207,7 +207,7 @@ Attributes
       baz bam!
 
 
-    - 
+    -
       Target OS/families that can be operated against
 
 
@@ -224,28 +224,28 @@ Notes
 See Also
 --------
 
-* \ `ns.col2.foo3 <foo3_module.rst>`__\ 
+* `ns.col2.foo3 <foo3_module.rst>`__
 
   Foo III.
-* \ `ns.col2.foobarbaz <foobarbaz_module.rst>`__\ 
+* `ns.col2.foobarbaz <foobarbaz_module.rst>`__
 
   The official documentation on the **ns.col2.foobarbaz** module.
-* \ `ns.col2.foo4 <foo4_module.rst>`__\  module plugin
+* `ns.col2.foo4 <foo4_module.rst>`__ module plugin
 
   Markup reference linting test.
-* \ `ns.col2.foobarbaz <foobarbaz_inventory.rst>`__\  inventory plugin
+* `ns.col2.foobarbaz <foobarbaz_inventory.rst>`__ inventory plugin
 
   The official documentation on the **ns.col2.foobarbaz** inventory plugin.
-* \ `ansible.builtin.service <service_module.rst>`__\ 
+* `ansible.builtin.service <service_module.rst>`__
 
   The service module.
-* \ `ansible.builtin.foobarbaz <foobarbaz_module.rst>`__\ 
+* `ansible.builtin.foobarbaz <foobarbaz_module.rst>`__
 
   A non-existing module.
-* \ `ansible.builtin.linear <linear_strategy.rst>`__\  strategy plugin
+* `ansible.builtin.linear <linear_strategy.rst>`__ strategy plugin
 
   The linear strategy plugin.
-* \ `ansible.builtin.foobarbaz <foobarbaz_strategy.rst>`__\  strategy plugin
+* `ansible.builtin.foobarbaz <foobarbaz_strategy.rst>`__ strategy plugin
 
   Foo bar baz. Bamm - Bar baz
   bam bum.
@@ -257,9 +257,7 @@ Examples
 
 .. code-block:: yaml
 
-    
     name: This is YAML.
-
 
 
 

--- a/tests/functional/baseline-simplified-rst/collections/ns/col2/foo3_module.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns/col2/foo3_module.rst
@@ -137,7 +137,7 @@ Attributes
 
 
 
-    - 
+    -
       Can run in check\_mode and return changed status prediction without modifying target
 
 
@@ -150,7 +150,7 @@ Attributes
 
 
 
-    - 
+    -
       Will return details on what has changed (or possibly needs changing in check\_mode), when in diff mode
 
 
@@ -162,7 +162,7 @@ Attributes
     - Platform:posix
 
 
-    - 
+    -
       Target OS/families that can be operated against
 
 
@@ -175,9 +175,7 @@ Examples
 
 .. code-block:: yaml
 
-    
     This is not YAML.
-
 
 
 

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/bar_filter.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/bar_filter.rst
@@ -195,9 +195,7 @@ Examples
 
 .. code-block:: yaml
 
-    
     {'a': 1} | ns2.col.bar({'b': 2}, baz='cde')
-
 
 
 

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/bar_test.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/bar_test.rst
@@ -81,7 +81,6 @@ Examples
 
 
 
-
 Return Value
 ------------
 

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo2_module.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo2_module.rst
@@ -84,7 +84,7 @@ Attributes
     - Action groups: \ns2.col.bar\_group, ns2.col.foo\_group
 
 
-    - 
+    -
       Use :literal:`group/ns2.col.foo\_group` or :literal:`group/ns2.col.bar\_group` in :literal:`module\_defaults` to set defaults for this module.
 
 
@@ -97,7 +97,7 @@ Attributes
 
 
 
-    - 
+    -
       Can run in check\_mode and return changed status prediction without modifying target
 
 
@@ -110,7 +110,7 @@ Attributes
 
 
 
-    - 
+    -
       Will return details on what has changed (or possibly needs changing in check\_mode), when in diff mode
 
 
@@ -122,7 +122,7 @@ Attributes
     - Platform:posix
 
 
-    - 
+    -
       Target OS/families that can be operated against
 
 
@@ -135,11 +135,9 @@ Examples
 
 .. code-block:: yaml
 
-    
     - name: Do some foo
       ns2.col.foo2:
         bar: foo
-
 
 
 

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_become.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_become.rst
@@ -211,7 +211,7 @@ Status
 Authors
 ~~~~~~~
 
-- Nobody 
+- Nobody
 
 
 .. hint::

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_cliconf.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_cliconf.rst
@@ -43,7 +43,7 @@ Synopsis
 Authors
 ~~~~~~~
 
-- Felix Fontein (@felixfontein) 
+- Felix Fontein (@felixfontein)
 
 
 .. hint::

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_filter.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_filter.rst
@@ -127,9 +127,7 @@ Examples
 
 .. code-block:: yaml
 
-    
     some_var: "{{ 'foo' | ns2.col.foo }}"
-
 
 
 

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_inventory.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_inventory.rst
@@ -72,10 +72,8 @@ Examples
 
 .. code-block:: yaml
 
-    
     foo:
         bar!
-
 
 
 

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_lookup.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_lookup.rst
@@ -116,11 +116,9 @@ Examples
 
 .. code-block:: yaml
 
-    
     - name: Look up bar
       ansible.builtin.debug:
         msg: "{{ lookup('ns2.col.foo', 'bar') }}"
-
 
 
 

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_module.rst
@@ -229,7 +229,7 @@ Attributes
     - Action group: \ns2.col.foo\_group
 
 
-    - 
+    -
       Use :literal:`group/ns2.col.foo\_group` in :literal:`module\_defaults` to set defaults for this module.
 
 
@@ -242,7 +242,7 @@ Attributes
 
 
 
-    - 
+    -
       Can run in check\_mode and return changed status prediction without modifying target
 
 
@@ -255,7 +255,7 @@ Attributes
 
 
 
-    - 
+    -
       Will return details on what has changed (or possibly needs changing in check\_mode), when in diff mode
 
 
@@ -267,7 +267,7 @@ Attributes
     - Platform:posix
 
 
-    - 
+    -
       Target OS/families that can be operated against
 
 
@@ -277,16 +277,16 @@ Attributes
 See Also
 --------
 
-* \ `ns2.col.foo2 <foo2_module.rst>`__\ 
+* `ns2.col.foo2 <foo2_module.rst>`__
 
   Another foo.
-* \ `ns2.col.foo <foo_lookup.rst>`__\  lookup plugin
+* `ns2.col.foo <foo_lookup.rst>`__ lookup plugin
 
   Look up some foo :literal:`bar` (`link <#parameter-bar>`_).
-* \ `ansible.builtin.service <service_module.rst>`__\ 
+* `ansible.builtin.service <service_module.rst>`__
 
   The service module.
-* \ `ansible.builtin.ssh <ssh_connection.rst>`__\  connection plugin
+* `ansible.builtin.ssh <ssh_connection.rst>`__ connection plugin
 
   The ssh connection plugin.
 
@@ -295,7 +295,6 @@ Examples
 
 .. code-block:: yaml
 
-    
     - name: Do some foo
       ns2.col.foo:
         foo: '{{ foo }}'
@@ -305,7 +304,6 @@ Examples
           - 3
         subfoo:
           foo: hoo!
-
 
 
 

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_role.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_role.rst
@@ -108,7 +108,7 @@ Attributes
 
 
 
-    - 
+    -
       Can run in check\_mode and return changed status prediction without modifying target
 
 
@@ -120,7 +120,7 @@ Attributes
     - Platforms:Linux, macOS, FreeBSD
 
 
-    - 
+    -
       The supported platforms
 
 
@@ -130,7 +130,7 @@ Attributes
 See Also
 ^^^^^^^^
 
-* \ `ns2.col.foo <foo_module.rst>`__\ 
+* `ns2.col.foo <foo_module.rst>`__
 
   The official documentation on the **ns2.col.foo** module.
 

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_test.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_test.rst
@@ -110,9 +110,7 @@ Examples
 
 .. code-block:: yaml
 
-    
     some_var: "{{ {'a': 1} is ns2.col.foo }}"
-
 
 
 

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/sub.foo3_module.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/sub.foo3_module.rst
@@ -83,7 +83,7 @@ Attributes
     - Action groups: \ns2.col.bar\_group, ns2.col.foo\_group
 
 
-    - 
+    -
       Use :literal:`group/ns2.col.foo\_group` or :literal:`group/ns2.col.bar\_group` in :literal:`module\_defaults` to set defaults for this module.
 
 
@@ -96,7 +96,7 @@ Attributes
 
 
 
-    - 
+    -
       Can run in check\_mode and return changed status prediction without modifying target
 
 
@@ -109,7 +109,7 @@ Attributes
 
 
 
-    - 
+    -
       Will return details on what has changed (or possibly needs changing in check\_mode), when in diff mode
 
 
@@ -121,7 +121,7 @@ Attributes
     - Platform:posix
 
 
-    - 
+    -
       Target OS/families that can be operated against
 
 
@@ -134,11 +134,9 @@ Examples
 
 .. code-block:: yaml
 
-    
     - name: Do some foobar
       ns2.col.sub.foo3:
         bar: baz
-
 
 
 

--- a/tests/functional/baseline-simplified-rst/collections/ns2/flatcol/foo2_module.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/flatcol/foo2_module.rst
@@ -72,11 +72,9 @@ Examples
 
 .. code-block:: yaml
 
-    
     - name: Do some foo
       ns2.flatcol.foo2:
         bar: foo
-
 
 
 

--- a/tests/functional/baseline-simplified-rst/collections/ns2/flatcol/foo_module.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/flatcol/foo_module.rst
@@ -131,7 +131,6 @@ Examples
 
 .. code-block:: yaml
 
-    
     - name: Do some foo
       ns2.flatcol.foo:
         foo: '{{ foo }}'
@@ -141,7 +140,6 @@ Examples
           - 3
         subfoo:
           foo: hoo!
-
 
 
 

--- a/tests/functional/baseline-squash-hierarchy/bar_filter.rst
+++ b/tests/functional/baseline-squash-hierarchy/bar_filter.rst
@@ -323,9 +323,7 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     {'a': 1} | ns2.col.bar({'b': 2}, baz='cde')
-
 
 
 

--- a/tests/functional/baseline-squash-hierarchy/bar_test.rst
+++ b/tests/functional/baseline-squash-hierarchy/bar_test.rst
@@ -142,7 +142,6 @@ Examples
 
 
 
-
 .. Facts
 
 

--- a/tests/functional/baseline-squash-hierarchy/foo2_module.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo2_module.rst
@@ -316,11 +316,9 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     - name: Do some foo
       ns2.col.foo2:
         bar: foo
-
 
 
 

--- a/tests/functional/baseline-squash-hierarchy/foo_become.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_become.rst
@@ -352,7 +352,7 @@ Status
 Authors
 ~~~~~~~
 
-- Nobody 
+- Nobody
 
 
 .. hint::

--- a/tests/functional/baseline-squash-hierarchy/foo_cliconf.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_cliconf.rst
@@ -91,7 +91,7 @@ Synopsis
 Authors
 ~~~~~~~
 
-- Felix Fontein (@felixfontein) 
+- Felix Fontein (@felixfontein)
 
 
 .. hint::

--- a/tests/functional/baseline-squash-hierarchy/foo_filter.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_filter.rst
@@ -231,9 +231,7 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     some_var: "{{ 'foo' | ns2.col.foo }}"
-
 
 
 

--- a/tests/functional/baseline-squash-hierarchy/foo_inventory.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_inventory.rst
@@ -134,10 +134,8 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     foo:
         bar!
-
 
 
 

--- a/tests/functional/baseline-squash-hierarchy/foo_lookup.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_lookup.rst
@@ -199,11 +199,9 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     - name: Look up bar
       ansible.builtin.debug:
         msg: "{{ lookup('ns2.col.foo', 'bar') }}"
-
 
 
 

--- a/tests/functional/baseline-squash-hierarchy/foo_module.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_module.rst
@@ -548,13 +548,13 @@ See Also
 
 .. seealso::
 
-   \ :ref:`ns2.col.foo2 <ansible_collections.ns2.col.foo2_module>`\ 
+   :ref:`ns2.col.foo2 <ansible_collections.ns2.col.foo2_module>`
        Another foo.
-   \ :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>`\  lookup plugin
+   :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>` lookup plugin
        Look up some foo :ansopt:`ns2.col.foo#module:bar`.
-   \ :ref:`ansible.builtin.service <ansible_collections.ansible.builtin.service_module>`\ 
+   :ref:`ansible.builtin.service <ansible_collections.ansible.builtin.service_module>`
        The service module.
-   \ :ref:`ansible.builtin.ssh <ansible_collections.ansible.builtin.ssh_connection>`\  connection plugin
+   :ref:`ansible.builtin.ssh <ansible_collections.ansible.builtin.ssh_connection>` connection plugin
        The ssh connection plugin.
 
 .. Examples
@@ -564,7 +564,6 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     - name: Do some foo
       ns2.col.foo:
         foo: '{{ foo }}'
@@ -574,7 +573,6 @@ Examples
           - 3
         subfoo:
           foo: hoo!
-
 
 
 

--- a/tests/functional/baseline-squash-hierarchy/foo_role.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_role.rst
@@ -280,7 +280,7 @@ See Also
 
 .. seealso::
 
-   \ :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_module>`\ 
+   :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_module>`
        The official documentation on the **ns2.col.foo** module.
 
 Examples

--- a/tests/functional/baseline-squash-hierarchy/foo_test.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_test.rst
@@ -191,9 +191,7 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     some_var: "{{ {'a': 1} is ns2.col.foo }}"
-
 
 
 

--- a/tests/functional/baseline-squash-hierarchy/sub.foo3_module.rst
+++ b/tests/functional/baseline-squash-hierarchy/sub.foo3_module.rst
@@ -315,11 +315,9 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     - name: Do some foobar
       ns2.col.sub.foo3:
         bar: baz
-
 
 
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/bar_filter.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/bar_filter.rst
@@ -242,9 +242,7 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     {'a': 1} | ns2.col.bar({'b': 2}, baz='cde')
-
 
 
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/bar_test.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/bar_test.rst
@@ -122,7 +122,6 @@ Examples
 
 
 
-
 .. Facts
 
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo2_module.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo2_module.rst
@@ -297,11 +297,9 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     - name: Do some foo
       ns2.col.foo2:
         bar: foo
-
 
 
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_become.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_become.rst
@@ -261,7 +261,7 @@ Status
 Authors
 ~~~~~~~
 
-- Nobody 
+- Nobody
 
 
 .. hint::

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_cliconf.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_cliconf.rst
@@ -91,7 +91,7 @@ Synopsis
 Authors
 ~~~~~~~
 
-- Felix Fontein (@felixfontein) 
+- Felix Fontein (@felixfontein)
 
 
 .. hint::

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_filter.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_filter.rst
@@ -171,9 +171,7 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     some_var: "{{ 'foo' | ns2.col.foo }}"
-
 
 
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_inventory.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_inventory.rst
@@ -114,10 +114,8 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     foo:
         bar!
-
 
 
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_lookup.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_lookup.rst
@@ -161,11 +161,9 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     - name: Look up bar
       ansible.builtin.debug:
         msg: "{{ lookup('ns2.col.foo', 'bar') }}"
-
 
 
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_module.rst
@@ -440,13 +440,13 @@ See Also
 
 .. seealso::
 
-   \ :ref:`ns2.col.foo2 <ansible_collections.ns2.col.foo2_module>`\ 
+   :ref:`ns2.col.foo2 <ansible_collections.ns2.col.foo2_module>`
        Another foo.
-   \ :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>`\  lookup plugin
+   :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_lookup>` lookup plugin
        Look up some foo :ansopt:`ns2.col.foo#module:bar`.
-   \ :ref:`ansible.builtin.service <ansible_collections.ansible.builtin.service_module>`\ 
+   :ref:`ansible.builtin.service <ansible_collections.ansible.builtin.service_module>`
        The service module.
-   \ :ref:`ansible.builtin.ssh <ansible_collections.ansible.builtin.ssh_connection>`\  connection plugin
+   :ref:`ansible.builtin.ssh <ansible_collections.ansible.builtin.ssh_connection>` connection plugin
        The ssh connection plugin.
 
 .. Examples
@@ -456,7 +456,6 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     - name: Do some foo
       ns2.col.foo:
         foo: '{{ foo }}'
@@ -466,7 +465,6 @@ Examples
           - 3
         subfoo:
           foo: hoo!
-
 
 
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_role.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_role.rst
@@ -233,7 +233,7 @@ See Also
 
 .. seealso::
 
-   \ :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_module>`\ 
+   :ref:`ns2.col.foo <ansible_collections.ns2.col.foo_module>`
        The official documentation on the **ns2.col.foo** module.
 
 Examples

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_test.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_test.rst
@@ -152,9 +152,7 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     some_var: "{{ {'a': 1} is ns2.col.foo }}"
-
 
 
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/sub.foo3_module.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/sub.foo3_module.rst
@@ -296,11 +296,9 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
     - name: Do some foobar
       ns2.col.sub.foo3:
         bar: baz
-
 
 
 

--- a/tests/units/test_jinja2.py
+++ b/tests/units/test_jinja2.py
@@ -66,9 +66,9 @@ def test_move_first(input, move_to_beginning, expected):
 
 MASSAGE_AUTHOR_NAME = [
     ("", ""),
-    ("John Doe (@johndoe) <john.doe@gmail.com>", "John Doe (@johndoe) "),
-    ("John Doe (@johndoe) john+doe@gmail.com", "John Doe (@johndoe) "),
-    ("John Doe (@johndoe) (john-doe@gmail.com)", "John Doe (@johndoe) "),
+    ("John Doe (@johndoe) <john.doe@gmail.com>", "John Doe (@johndoe)"),
+    ("John Doe (@johndoe) john+doe@gmail.com", "John Doe (@johndoe)"),
+    ("John Doe (@johndoe) (john-doe@gmail.com)", "John Doe (@johndoe)"),
     ("John Doe (@johndoe, john.doe@gmail.com)", "John Doe (@johndoe, )"),
 ]
 

--- a/tests/units/utils/test_text.py
+++ b/tests/units/utils/test_text.py
@@ -1,0 +1,98 @@
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2024, Ansible Project
+
+from __future__ import annotations
+
+import pytest
+
+from antsibull_docs.utils.text import count_leading_whitespace, sanitize_whitespace
+
+
+@pytest.mark.parametrize(
+    "line, max_count, expected",
+    [
+        (
+            "",
+            None,
+            None,
+        ),
+        (
+            " \t ",
+            None,
+            None,
+        ),
+        (
+            " test ",
+            None,
+            1,
+        ),
+        (
+            "none   ",
+            None,
+            0,
+        ),
+        (
+            "none   ",
+            1,
+            0,
+        ),
+        (
+            "    some ",
+            2,
+            2,
+        ),
+        (
+            "    some ",
+            10,
+            4,
+        ),
+    ],
+)
+def test_count_leading_whitespace(line, max_count, expected):
+    result = count_leading_whitespace(line, max_count=max_count)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "content, expected",
+    [
+        (
+            "",
+            "",
+        ),
+        (
+            r"""
+Test
+  Test
+""",
+            r"""Test
+  Test""",
+        ),
+        (
+            r"""
+
+      Test!
+  Test  
+    Test
+
+""",
+            r"""    Test!
+Test
+  Test""",
+        ),
+        (
+            """
+- name: Do some foo
+  ns2.flatcol.foo2:
+    bar: foo
+""",
+            """- name: Do some foo
+  ns2.flatcol.foo2:
+    bar: foo""",
+        ),
+    ],
+)
+def test_sanitize_whitespace(content, expected):
+    result = sanitize_whitespace(content)
+    assert result == expected


### PR DESCRIPTION
Improves the situation for #305.