### PR TITLE
Fix all remaining whitespace and newline issues.

### DIFF
--- a/changelogs/fragments/314-whitespace.yml
+++ b/changelogs/fragments/314-whitespace.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Remove trailing whitespace and leading and trailing empty lines from rendered templates, and ensure they end with a newline if not empty (https://github.com/ansible-community/antsibull-docs/pull/314)."

--- a/src/antsibull_docs/cli/doc_commands/sphinx_init.py
+++ b/src/antsibull_docs/cli/doc_commands/sphinx_init.py
@@ -18,6 +18,7 @@ import antsibull_docs
 
 from ... import app_context
 from ...jinja2.environment import doc_environment
+from ...utils.text import sanitize_whitespace
 
 mlog = log.fields(mod=__name__)
 
@@ -162,35 +163,36 @@ def site_init() -> int:
         source = filename.replace(".", "_").replace("/", "_") + ".j2"
         template = env.get_template(source)
 
-        content = (
-            template.render(
-                dest_dir=dest_dir,
-                collection_version=collection_version,
-                use_current=use_current,
-                squash_hierarchy=squash_hierarchy,
-                collections=collections,
-                lenient=lenient,
-                fail_on_error=fail_on_error,
-                use_html_blobs=use_html_blobs,
-                breadcrumbs=breadcrumbs,
-                indexes=indexes,
-                sphinx_theme=sphinx_theme,
-                sphinx_theme_package=sphinx_theme_package,
-                collection_url=collection_url,
-                collection_install=collection_install,
-                intersphinx=intersphinx_parts,
-                project=project,
-                conf_copyright=conf_copyright,
-                title=title,
-                html_short_title=html_short_title,
-                extra_conf=extra_conf,
-                extra_html_context=extra_html_context,
-                extra_html_theme_options=extra_html_theme_options,
-                output_format=output_format,
-                antsibull_docs_version=antsibull_docs.__version__,
-                add_antsibull_docs_version=add_antsibull_docs_version,
-            )
-            + "\n"
+        content = template.render(
+            dest_dir=dest_dir,
+            collection_version=collection_version,
+            use_current=use_current,
+            squash_hierarchy=squash_hierarchy,
+            collections=collections,
+            lenient=lenient,
+            fail_on_error=fail_on_error,
+            use_html_blobs=use_html_blobs,
+            breadcrumbs=breadcrumbs,
+            indexes=indexes,
+            sphinx_theme=sphinx_theme,
+            sphinx_theme_package=sphinx_theme_package,
+            collection_url=collection_url,
+            collection_install=collection_install,
+            intersphinx=intersphinx_parts,
+            project=project,
+            conf_copyright=conf_copyright,
+            title=title,
+            html_short_title=html_short_title,
+            extra_conf=extra_conf,
+            extra_html_context=extra_html_context,
+            extra_html_theme_options=extra_html_theme_options,
+            output_format=output_format,
+            antsibull_docs_version=antsibull_docs.__version__,
+            add_antsibull_docs_version=add_antsibull_docs_version,
+        )
+
+        content = sanitize_whitespace(
+            content, trailing_newline=True, remove_common_leading_whitespace=False
         )
 
         destination = os.path.join(dest_dir, filename)

--- a/src/antsibull_docs/jinja2/filters.py
+++ b/src/antsibull_docs/jinja2/filters.py
@@ -294,4 +294,4 @@ def rst_indent(
 def sanitize_whitespace(text: str) -> str:
     if not isinstance(text, str):
         raise ValueError("sanitize_whitespace can only be applied to strings")
-    return _sanitize_whitespace(text)
+    return _sanitize_whitespace(text, trailing_newline=False)

--- a/src/antsibull_docs/utils/text.py
+++ b/src/antsibull_docs/utils/text.py
@@ -30,7 +30,13 @@ def count_leading_whitespace(
     return count
 
 
-def sanitize_whitespace(content: str) -> str:
+def sanitize_whitespace(
+    content: str,
+    /,
+    *,
+    trailing_newline: bool = True,
+    remove_common_leading_whitespace: bool = True,
+) -> str:
     # Split into lines and remove trailing whitespace
     lines = [line.rstrip(" \t") for line in content.splitlines()]
 
@@ -44,16 +50,20 @@ def sanitize_whitespace(content: str) -> str:
     lines = lines[start:end]
 
     # Remove common leading whitespace
-    common_whitespace = None
-    for line in lines:
-        whitespace = count_leading_whitespace(line, max_count=common_whitespace)
-        if whitespace is not None:
-            if common_whitespace is None or common_whitespace > whitespace:
-                common_whitespace = whitespace
-                if common_whitespace == 0:
-                    break
-    if common_whitespace is not None and common_whitespace > 0:
-        lines = [line[common_whitespace:] for line in lines]
+    if remove_common_leading_whitespace:
+        common_whitespace = None
+        for line in lines:
+            whitespace = count_leading_whitespace(line, max_count=common_whitespace)
+            if whitespace is not None:
+                if common_whitespace is None or common_whitespace > whitespace:
+                    common_whitespace = whitespace
+                    if common_whitespace == 0:
+                        break
+        if common_whitespace is not None and common_whitespace > 0:
+            lines = [line[common_whitespace:] for line in lines]
+
+    if trailing_newline and lines:
+        lines.append("")
 
     # Re-combine the result
     return "\n".join(lines)

--- a/src/antsibull_docs/write_docs/__init__.py
+++ b/src/antsibull_docs/write_docs/__init__.py
@@ -15,6 +15,8 @@ from jinja2 import Template
 
 import antsibull_docs
 
+from ..utils.text import sanitize_whitespace as _sanitize_whitespace
+
 mlog = log.fields(mod=__name__)
 
 #: Mapping of plugins to nonfatal errors.  This is the type to use when accepting the plugin.
@@ -31,13 +33,24 @@ PluginCollectionInfoT = Mapping[str, Mapping[str, Mapping[str, str]]]
 
 
 def _render_template(
-    _template: Template, _name: str, /, add_version: bool, **kwargs
+    _template: Template,
+    _name: str,
+    /,
+    *,
+    add_version: bool,
+    sanitize_whitespace: bool = True,
+    **kwargs,
 ) -> str:
     try:
-        return _template.render(
+        result = _template.render(
             antsibull_docs_version=antsibull_docs.__version__ if add_version else None,
             **kwargs,
         )
+        if sanitize_whitespace:
+            result = _sanitize_whitespace(
+                result, trailing_newline=True, remove_common_leading_whitespace=False
+            )
+        return result
     except Exception as exc:
         raise RuntimeError(f"Error while rendering {_name}") from exc
 

--- a/tests/functional/baseline-default/collections/callback_index_stdout.rst
+++ b/tests/functional/baseline-default/collections/callback_index_stdout.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -15,4 +14,3 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.foo#callback` -- Foo output :ansopt:`ns2.col.foo#callback:bar`
-

--- a/tests/functional/baseline-default/collections/environment_variables.rst
+++ b/tests/functional/baseline-default/collections/environment_variables.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::

--- a/tests/functional/baseline-default/collections/index.rst
+++ b/tests/functional/baseline-default/collections/index.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::

--- a/tests/functional/baseline-default/collections/index_become.rst
+++ b/tests/functional/baseline-default/collections/index_become.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -13,4 +12,3 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.foo#become` -- Use foo :ansopt:`ns2.col.foo#become:bar`
-

--- a/tests/functional/baseline-default/collections/index_cache.rst
+++ b/tests/functional/baseline-default/collections/index_cache.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -13,4 +12,3 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.foo#cache` -- Foo files :ansopt:`ns2.col.foo#cache:bar`
-

--- a/tests/functional/baseline-default/collections/index_callback.rst
+++ b/tests/functional/baseline-default/collections/index_callback.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -21,4 +20,3 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.foo#callback` -- Foo output :ansopt:`ns2.col.foo#callback:bar`
-

--- a/tests/functional/baseline-default/collections/index_cliconf.rst
+++ b/tests/functional/baseline-default/collections/index_cliconf.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -13,4 +12,3 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.foo#cliconf` -- Foo router CLI config
-

--- a/tests/functional/baseline-default/collections/index_connection.rst
+++ b/tests/functional/baseline-default/collections/index_connection.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -13,4 +12,3 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.foo#connection` -- Foo connection :ansopt:`ns2.col.foo#connection:bar`
-

--- a/tests/functional/baseline-default/collections/index_filter.rst
+++ b/tests/functional/baseline-default/collections/index_filter.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -14,4 +13,3 @@ ns2.col
 
 * :ansplugin:`ns2.col.bar#filter` -- The bar filter
 * :ansplugin:`ns2.col.foo#filter` -- The foo filter :ansopt:`ns2.col.foo#filter:bar`
-

--- a/tests/functional/baseline-default/collections/index_inventory.rst
+++ b/tests/functional/baseline-default/collections/index_inventory.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -13,4 +12,3 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.foo#inventory` -- The foo inventory :ansopt:`ns2.col.foo#inventory:bar`
-

--- a/tests/functional/baseline-default/collections/index_lookup.rst
+++ b/tests/functional/baseline-default/collections/index_lookup.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -13,4 +12,3 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.foo#lookup` -- Look up some foo :ansopt:`ns2.col.foo#lookup:bar`
-

--- a/tests/functional/baseline-default/collections/index_module.rst
+++ b/tests/functional/baseline-default/collections/index_module.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -12,7 +11,7 @@ Index of all Modules
 ns.col2
 -------
 
-* :ansplugin:`ns.col2.foo#module` -- 
+* :ansplugin:`ns.col2.foo#module` --
 * :ansplugin:`ns.col2.foo2#module` -- Foo two
 * :ansplugin:`ns.col2.foo3#module` -- Foo III
 * :ansplugin:`ns.col2.foo4#module` -- Markup reference linting test
@@ -29,4 +28,3 @@ ns2.flatcol
 
 * :ansplugin:`ns2.flatcol.foo#module` -- Do some foo :ansopt:`ns2.flatcol.foo#module:bar`
 * :ansplugin:`ns2.flatcol.foo2#module` -- Another foo
-

--- a/tests/functional/baseline-default/collections/index_role.rst
+++ b/tests/functional/baseline-default/collections/index_role.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -18,4 +17,3 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.foo#role` -- Foo role
-

--- a/tests/functional/baseline-default/collections/index_shell.rst
+++ b/tests/functional/baseline-default/collections/index_shell.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -13,4 +12,3 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.foo#shell` -- Foo shell :ansopt:`ns2.col.foo#shell:bar`
-

--- a/tests/functional/baseline-default/collections/index_strategy.rst
+++ b/tests/functional/baseline-default/collections/index_strategy.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -13,4 +12,3 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.foo#strategy` -- Executes tasks in foo
-

--- a/tests/functional/baseline-default/collections/index_test.rst
+++ b/tests/functional/baseline-default/collections/index_test.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -14,4 +13,3 @@ ns2.col
 
 * :ansplugin:`ns2.col.bar#test` -- Is something a bar
 * :ansplugin:`ns2.col.foo#test` -- Is something a foo :ansopt:`ns2.col.foo#test:bar`
-

--- a/tests/functional/baseline-default/collections/index_vars.rst
+++ b/tests/functional/baseline-default/collections/index_vars.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -13,4 +12,3 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.foo#vars` -- Load foo :ansopt:`ns2.col.foo#vars:bar`
-

--- a/tests/functional/baseline-default/collections/ns/col1/index.rst
+++ b/tests/functional/baseline-default/collections/ns/col1/index.rst
@@ -1,5 +1,3 @@
-
-
 .. meta::
   :antsibull-docs: <ANTSIBULL_DOCS_VERSION>
 

--- a/tests/functional/baseline-default/collections/ns/col2/bar_role.rst
+++ b/tests/functional/baseline-default/collections/ns/col2/bar_role.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -134,4 +133,3 @@ Authors
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-default/collections/ns/col2/foo2_module.rst
+++ b/tests/functional/baseline-default/collections/ns/col2/foo2_module.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -204,7 +203,7 @@ Parameters
       .. raw:: html
 
         </div>
-    
+
   * - .. raw:: html
 
         <div class="ansible-option-indent"></div><div class="ansible-option-cell">
@@ -587,4 +586,3 @@ Authors
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-default/collections/ns/col2/foo3_module.rst
+++ b/tests/functional/baseline-default/collections/ns/col2/foo3_module.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -187,7 +186,7 @@ Parameters
       .. raw:: html
 
         </div>
-    
+
   * - .. raw:: html
 
         <div class="ansible-option-indent"></div><div class="ansible-option-cell">
@@ -432,4 +431,3 @@ The errors were:
           string does not match regex "^(any|bits|bool|bytes|complex|dict|float|int|json|jsonarg|list|path|sid|str|pathspec|pathlist)$" (type=value_error.str.regex; pattern=^(any|bits|bool|bytes|complex|dict|float|int|json|jsonarg|list|path|sid|str|pathspec|pathlist)$)
         return -> baz
           value is not a valid dict (type=type_error.dict)
-

--- a/tests/functional/baseline-default/collections/ns/col2/foo4_module.rst
+++ b/tests/functional/baseline-default/collections/ns/col2/foo4_module.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -369,4 +368,3 @@ Authors
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-default/collections/ns/col2/foo_module.rst
+++ b/tests/functional/baseline-default/collections/ns/col2/foo_module.rst
@@ -1,4 +1,3 @@
-
 .. Document meta section
 
 :orphan:

--- a/tests/functional/baseline-default/collections/ns/col2/index.rst
+++ b/tests/functional/baseline-default/collections/ns/col2/index.rst
@@ -1,5 +1,3 @@
-
-
 .. meta::
   :antsibull-docs: <ANTSIBULL_DOCS_VERSION>
 
@@ -42,7 +40,7 @@ These are the plugins in the ns.col2 collection:
 Modules
 ~~~~~~~
 
-* :ansplugin:`foo module <ns.col2.foo#module>` -- 
+* :ansplugin:`foo module <ns.col2.foo#module>` --
 * :ansplugin:`foo2 module <ns.col2.foo2#module>` -- Foo two
 * :ansplugin:`foo3 module <ns.col2.foo3#module>` -- Foo III
 * :ansplugin:`foo4 module <ns.col2.foo4#module>` -- Markup reference linting test

--- a/tests/functional/baseline-default/collections/ns/index.rst
+++ b/tests/functional/baseline-default/collections/ns/index.rst
@@ -1,5 +1,3 @@
-
-
 .. meta::
   :antsibull-docs: <ANTSIBULL_DOCS_VERSION>
 

--- a/tests/functional/baseline-default/collections/ns2/col/bar_filter.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/bar_filter.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -420,4 +419,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-default/collections/ns2/col/bar_test.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/bar_test.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -240,4 +239,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-default/collections/ns2/col/foo2_module.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo2_module.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -428,4 +427,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-default/collections/ns2/col/foo_become.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_become.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -382,4 +381,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-default/collections/ns2/col/foo_cache.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_cache.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -227,4 +226,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-default/collections/ns2/col/foo_callback.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_callback.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -176,4 +175,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-default/collections/ns2/col/foo_cliconf.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_cliconf.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -121,4 +120,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-default/collections/ns2/col/foo_connection.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_connection.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -237,4 +236,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-default/collections/ns2/col/foo_filter.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_filter.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -328,4 +327,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-default/collections/ns2/col/foo_inventory.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_inventory.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -178,4 +177,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-default/collections/ns2/col/foo_lookup.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_lookup.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -303,4 +302,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-default/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_module.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -302,7 +301,7 @@ Parameters
       .. raw:: html
 
         </div>
-    
+
   * - .. raw:: html
 
         <div class="ansible-option-indent"></div><div class="ansible-option-cell">
@@ -683,4 +682,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-default/collections/ns2/col/foo_redirect_module.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_redirect_module.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:

--- a/tests/functional/baseline-default/collections/ns2/col/foo_role.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_role.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -326,4 +325,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-default/collections/ns2/col/foo_shell.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_shell.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -233,4 +232,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-default/collections/ns2/col/foo_strategy.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_strategy.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -124,4 +123,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-default/collections/ns2/col/foo_test.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_test.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -293,4 +292,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-default/collections/ns2/col/foo_vars.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/foo_vars.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -237,4 +236,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-default/collections/ns2/col/index.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/index.rst
@@ -1,5 +1,3 @@
-
-
 .. meta::
   :antsibull-docs: <ANTSIBULL_DOCS_VERSION>
 

--- a/tests/functional/baseline-default/collections/ns2/col/is_bar_test.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/is_bar_test.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:

--- a/tests/functional/baseline-default/collections/ns2/col/sub.foo3_module.rst
+++ b/tests/functional/baseline-default/collections/ns2/col/sub.foo3_module.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -427,4 +426,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-default/collections/ns2/flatcol/foo2_module.rst
+++ b/tests/functional/baseline-default/collections/ns2/flatcol/foo2_module.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -234,4 +233,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-default/collections/ns2/flatcol/foo_module.rst
+++ b/tests/functional/baseline-default/collections/ns2/flatcol/foo_module.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -197,7 +196,7 @@ Parameters
       .. raw:: html
 
         </div>
-    
+
   * - .. raw:: html
 
         <div class="ansible-option-indent"></div><div class="ansible-option-cell">
@@ -384,4 +383,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-default/collections/ns2/flatcol/index.rst
+++ b/tests/functional/baseline-default/collections/ns2/flatcol/index.rst
@@ -1,5 +1,3 @@
-
-
 .. meta::
   :antsibull-docs: <ANTSIBULL_DOCS_VERSION>
 

--- a/tests/functional/baseline-default/collections/ns2/index.rst
+++ b/tests/functional/baseline-default/collections/ns2/index.rst
@@ -1,5 +1,3 @@
-
-
 .. meta::
   :antsibull-docs: <ANTSIBULL_DOCS_VERSION>
 

--- a/tests/functional/baseline-no-breadcrumbs/collections/callback_index_stdout.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/callback_index_stdout.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -15,4 +14,3 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.foo#callback` -- Foo output :ansopt:`ns2.col.foo#callback:bar`
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/environment_variables.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/environment_variables.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::

--- a/tests/functional/baseline-no-breadcrumbs/collections/index.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -15,4 +14,3 @@ These are the collections documented here.
 * :ref:`ns.col2 <plugins_in_ns.col2>`
 * :ref:`ns2.col <plugins_in_ns2.col>`
 * :ref:`ns2.flatcol <plugins_in_ns2.flatcol>`
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_become.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_become.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -13,4 +12,3 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.foo#become` -- Use foo :ansopt:`ns2.col.foo#become:bar`
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_cache.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_cache.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -13,4 +12,3 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.foo#cache` -- Foo files :ansopt:`ns2.col.foo#cache:bar`
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_callback.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_callback.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -21,4 +20,3 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.foo#callback` -- Foo output :ansopt:`ns2.col.foo#callback:bar`
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_cliconf.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_cliconf.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -13,4 +12,3 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.foo#cliconf` -- Foo router CLI config
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_connection.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_connection.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -13,4 +12,3 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.foo#connection` -- Foo connection :ansopt:`ns2.col.foo#connection:bar`
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_filter.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_filter.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -14,4 +13,3 @@ ns2.col
 
 * :ansplugin:`ns2.col.bar#filter` -- The bar filter
 * :ansplugin:`ns2.col.foo#filter` -- The foo filter :ansopt:`ns2.col.foo#filter:bar`
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_inventory.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_inventory.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -13,4 +12,3 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.foo#inventory` -- The foo inventory :ansopt:`ns2.col.foo#inventory:bar`
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_lookup.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_lookup.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -13,4 +12,3 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.foo#lookup` -- Look up some foo :ansopt:`ns2.col.foo#lookup:bar`
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_module.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -12,7 +11,7 @@ Index of all Modules
 ns.col2
 -------
 
-* :ansplugin:`ns.col2.foo#module` -- 
+* :ansplugin:`ns.col2.foo#module` --
 * :ansplugin:`ns.col2.foo2#module` -- Foo two
 * :ansplugin:`ns.col2.foo3#module` -- Foo III
 * :ansplugin:`ns.col2.foo4#module` -- Markup reference linting test
@@ -29,4 +28,3 @@ ns2.flatcol
 
 * :ansplugin:`ns2.flatcol.foo#module` -- Do some foo :ansopt:`ns2.flatcol.foo#module:bar`
 * :ansplugin:`ns2.flatcol.foo2#module` -- Another foo
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_role.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_role.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -18,4 +17,3 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.foo#role` -- Foo role
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_shell.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_shell.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -13,4 +12,3 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.foo#shell` -- Foo shell :ansopt:`ns2.col.foo#shell:bar`
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_strategy.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_strategy.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -13,4 +12,3 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.foo#strategy` -- Executes tasks in foo
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_test.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_test.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -14,4 +13,3 @@ ns2.col
 
 * :ansplugin:`ns2.col.bar#test` -- Is something a bar
 * :ansplugin:`ns2.col.foo#test` -- Is something a foo :ansopt:`ns2.col.foo#test:bar`
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/index_vars.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/index_vars.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -13,4 +12,3 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.foo#vars` -- Load foo :ansopt:`ns2.col.foo#vars:bar`
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns/col1/index.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns/col1/index.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/bar_role.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/bar_role.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -134,4 +133,3 @@ Authors
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/foo2_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/foo2_module.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -204,7 +203,7 @@ Parameters
       .. raw:: html
 
         </div>
-    
+
   * - .. raw:: html
 
         <div class="ansible-option-indent"></div><div class="ansible-option-cell">
@@ -587,4 +586,3 @@ Authors
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/foo3_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/foo3_module.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -187,7 +186,7 @@ Parameters
       .. raw:: html
 
         </div>
-    
+
   * - .. raw:: html
 
         <div class="ansible-option-indent"></div><div class="ansible-option-cell">
@@ -432,4 +431,3 @@ The errors were:
           string does not match regex "^(any|bits|bool|bytes|complex|dict|float|int|json|jsonarg|list|path|sid|str|pathspec|pathlist)$" (type=value_error.str.regex; pattern=^(any|bits|bool|bytes|complex|dict|float|int|json|jsonarg|list|path|sid|str|pathspec|pathlist)$)
         return -> baz
           value is not a valid dict (type=type_error.dict)
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/foo4_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/foo4_module.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -369,4 +368,3 @@ Authors
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/foo_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/foo_module.rst
@@ -1,4 +1,3 @@
-
 .. Document meta section
 
 :orphan:

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/index.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns/col2/index.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -43,7 +42,7 @@ These are the plugins in the ns.col2 collection:
 Modules
 ~~~~~~~
 
-* :ansplugin:`foo module <ns.col2.foo#module>` -- 
+* :ansplugin:`foo module <ns.col2.foo#module>` --
 * :ansplugin:`foo2 module <ns.col2.foo2#module>` -- Foo two
 * :ansplugin:`foo3 module <ns.col2.foo3#module>` -- Foo III
 * :ansplugin:`foo4 module <ns.col2.foo4#module>` -- Markup reference linting test

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns/index.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns/index.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -13,4 +12,3 @@ These are the collections documented here in the **ns** namespace.
 
 * :ref:`ns.col1 <plugins_in_ns.col1>`
 * :ref:`ns.col2 <plugins_in_ns.col2>`
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/bar_filter.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/bar_filter.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -420,4 +419,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/bar_test.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/bar_test.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -240,4 +239,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo2_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo2_module.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -428,4 +427,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_become.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_become.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -382,4 +381,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_cache.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_cache.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -227,4 +226,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_callback.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_callback.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -176,4 +175,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_cliconf.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_cliconf.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -121,4 +120,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_connection.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_connection.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -237,4 +236,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_filter.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_filter.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -328,4 +327,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_inventory.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_inventory.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -178,4 +177,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_lookup.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_lookup.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -303,4 +302,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_module.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -302,7 +301,7 @@ Parameters
       .. raw:: html
 
         </div>
-    
+
   * - .. raw:: html
 
         <div class="ansible-option-indent"></div><div class="ansible-option-cell">
@@ -683,4 +682,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_redirect_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_redirect_module.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_role.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_role.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -326,4 +325,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_shell.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_shell.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -233,4 +232,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_strategy.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_strategy.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -124,4 +123,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_test.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_test.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -293,4 +292,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_vars.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/foo_vars.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -237,4 +236,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/index.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/index.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/is_bar_test.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/is_bar_test.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/sub.foo3_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/col/sub.foo3_module.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -427,4 +426,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/flatcol/foo2_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/flatcol/foo2_module.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -234,4 +233,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/flatcol/foo_module.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/flatcol/foo_module.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -197,7 +196,7 @@ Parameters
       .. raw:: html
 
         </div>
-    
+
   * - .. raw:: html
 
         <div class="ansible-option-indent"></div><div class="ansible-option-cell">
@@ -384,4 +383,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/flatcol/index.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/flatcol/index.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::

--- a/tests/functional/baseline-no-breadcrumbs/collections/ns2/index.rst
+++ b/tests/functional/baseline-no-breadcrumbs/collections/ns2/index.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -13,4 +12,3 @@ These are the collections documented here in the **ns2** namespace.
 
 * :ref:`ns2.col <plugins_in_ns2.col>`
 * :ref:`ns2.flatcol <plugins_in_ns2.flatcol>`
-

--- a/tests/functional/baseline-no-indexes/collections/environment_variables.rst
+++ b/tests/functional/baseline-no-indexes/collections/environment_variables.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. _list_of_collection_env_vars:

--- a/tests/functional/baseline-no-indexes/collections/ns/col1/index.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns/col1/index.rst
@@ -1,6 +1,3 @@
-
-
-
 .. _plugins_in_ns.col1:
 
 Ns.Col1

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/bar_filter.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/bar_filter.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -417,4 +416,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/bar_test.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/bar_test.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -237,4 +236,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo2_module.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo2_module.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -425,4 +424,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_become.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_become.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -379,4 +378,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_cache.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_cache.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -224,4 +223,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_callback.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_callback.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -173,4 +172,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_cliconf.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_cliconf.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -118,4 +117,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_connection.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_connection.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -234,4 +233,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_filter.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_filter.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -325,4 +324,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_inventory.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_inventory.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -175,4 +174,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_lookup.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_lookup.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -300,4 +299,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_module.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -299,7 +298,7 @@ Parameters
       .. raw:: html
 
         </div>
-    
+
   * - .. raw:: html
 
         <div class="ansible-option-indent"></div><div class="ansible-option-cell">
@@ -680,4 +679,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_redirect_module.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_redirect_module.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_role.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_role.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -323,4 +322,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_shell.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_shell.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -230,4 +229,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_strategy.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_strategy.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -121,4 +120,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_test.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_test.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -290,4 +289,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/foo_vars.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/foo_vars.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -234,4 +233,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/index.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/index.rst
@@ -1,6 +1,3 @@
-
-
-
 .. _plugins_in_ns2.col:
 
 Ns2.Col

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/is_bar_test.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/is_bar_test.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:

--- a/tests/functional/baseline-no-indexes/collections/ns2/col/sub.foo3_module.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/col/sub.foo3_module.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -424,4 +423,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-indexes/collections/ns2/flatcol/foo2_module.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/flatcol/foo2_module.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -231,4 +230,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-indexes/collections/ns2/flatcol/foo_module.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/flatcol/foo_module.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -194,7 +193,7 @@ Parameters
       .. raw:: html
 
         </div>
-    
+
   * - .. raw:: html
 
         <div class="ansible-option-indent"></div><div class="ansible-option-cell">
@@ -381,4 +380,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-no-indexes/collections/ns2/flatcol/index.rst
+++ b/tests/functional/baseline-no-indexes/collections/ns2/flatcol/index.rst
@@ -1,6 +1,3 @@
-
-
-
 .. _plugins_in_ns2.flatcol:
 
 Ns2.Flatcol

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/bar_filter.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/bar_filter.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs
 
 ns2.col.bar filter -- The bar filter
@@ -244,4 +243,3 @@ Collection links
 * `Homepage <https://github.com/ansible-collections/community.crypto>`__
 * `Repository (Sources) <https://github.com/ansible-collections/community.internal\_test\_tools>`__
 * `Submit a bug report <https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&labels=&template=bug\_report.md>`__
-

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/bar_test.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/bar_test.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs
 
 ns2.col.bar test -- Is something a bar
@@ -130,4 +129,3 @@ Collection links
 * `Homepage <https://github.com/ansible-collections/community.crypto>`__
 * `Repository (Sources) <https://github.com/ansible-collections/community.internal\_test\_tools>`__
 * `Submit a bug report <https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&labels=&template=bug\_report.md>`__
-

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo2_module.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo2_module.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs
 
 ns2.col.foo2 module -- Another foo
@@ -193,4 +192,3 @@ Collection links
 * `Homepage <https://github.com/ansible-collections/community.crypto>`__
 * `Repository (Sources) <https://github.com/ansible-collections/community.internal\_test\_tools>`__
 * `Submit a bug report <https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&labels=&template=bug\_report.md>`__
-

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_become.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_become.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs
 
 ns2.col.foo become -- Use foo :literal:`bar` (`link <#parameter-bar>`_)
@@ -224,4 +223,3 @@ Collection links
 * `Homepage <https://github.com/ansible-collections/community.crypto>`__
 * `Repository (Sources) <https://github.com/ansible-collections/community.internal\_test\_tools>`__
 * `Submit a bug report <https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&labels=&template=bug\_report.md>`__
-

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_cache.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_cache.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs
 
 ns2.col.foo cache -- Foo files :literal:`bar` (`link <#parameter-bar>`_)
@@ -116,4 +115,3 @@ Collection links
 * `Homepage <https://github.com/ansible-collections/community.crypto>`__
 * `Repository (Sources) <https://github.com/ansible-collections/community.internal\_test\_tools>`__
 * `Submit a bug report <https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&labels=&template=bug\_report.md>`__
-

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_callback.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_callback.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs
 
 ns2.col.foo callback -- Foo output :literal:`bar` (`link <#parameter-bar>`_)
@@ -88,4 +87,3 @@ Collection links
 * `Homepage <https://github.com/ansible-collections/community.crypto>`__
 * `Repository (Sources) <https://github.com/ansible-collections/community.internal\_test\_tools>`__
 * `Submit a bug report <https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&labels=&template=bug\_report.md>`__
-

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_cliconf.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_cliconf.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs
 
 ns2.col.foo cliconf -- Foo router CLI config
@@ -56,4 +55,3 @@ Collection links
 * `Homepage <https://github.com/ansible-collections/community.crypto>`__
 * `Repository (Sources) <https://github.com/ansible-collections/community.internal\_test\_tools>`__
 * `Submit a bug report <https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&labels=&template=bug\_report.md>`__
-

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_connection.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_connection.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs
 
 ns2.col.foo connection -- Foo connection :literal:`bar` (`link <#parameter-bar>`_)
@@ -131,4 +130,3 @@ Collection links
 * `Homepage <https://github.com/ansible-collections/community.crypto>`__
 * `Repository (Sources) <https://github.com/ansible-collections/community.internal\_test\_tools>`__
 * `Submit a bug report <https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&labels=&template=bug\_report.md>`__
-

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_filter.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_filter.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs
 
 ns2.col.foo filter -- The foo filter :literal:`bar` (`link <#parameter-bar>`_)
@@ -176,4 +175,3 @@ Collection links
 * `Homepage <https://github.com/ansible-collections/community.crypto>`__
 * `Repository (Sources) <https://github.com/ansible-collections/community.internal\_test\_tools>`__
 * `Submit a bug report <https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&labels=&template=bug\_report.md>`__
-

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_inventory.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_inventory.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs
 
 ns2.col.foo inventory -- The foo inventory :literal:`bar` (`link <#parameter-bar>`_)
@@ -91,4 +90,3 @@ Collection links
 * `Homepage <https://github.com/ansible-collections/community.crypto>`__
 * `Repository (Sources) <https://github.com/ansible-collections/community.internal\_test\_tools>`__
 * `Submit a bug report <https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&labels=&template=bug\_report.md>`__
-

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_lookup.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_lookup.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs
 
 ns2.col.foo lookup -- Look up some foo :literal:`bar` (`link <#parameter-bar>`_)
@@ -173,4 +172,3 @@ Collection links
 * `Homepage <https://github.com/ansible-collections/community.crypto>`__
 * `Repository (Sources) <https://github.com/ansible-collections/community.internal\_test\_tools>`__
 * `Submit a bug report <https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&labels=&template=bug\_report.md>`__
-

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_module.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_module.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs
 
 ns2.col.foo module -- Do some foo :literal:`bar` (`link <#parameter-bar>`_)
@@ -360,4 +359,3 @@ Collection links
 * `Homepage <https://github.com/ansible-collections/community.crypto>`__
 * `Repository (Sources) <https://github.com/ansible-collections/community.internal\_test\_tools>`__
 * `Submit a bug report <https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&labels=&template=bug\_report.md>`__
-

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_redirect_module.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_redirect_module.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs
 
 ns2.col.foo_redirect module

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_role.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_role.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs
 
 ns2.col.foo role -- Foo role
@@ -162,4 +161,3 @@ Collection links
 * `Homepage <https://github.com/ansible-collections/community.crypto>`__
 * `Repository (Sources) <https://github.com/ansible-collections/community.internal\_test\_tools>`__
 * `Submit a bug report <https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&labels=&template=bug\_report.md>`__
-

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_shell.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_shell.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs
 
 ns2.col.foo shell -- Foo shell :literal:`bar` (`link <#parameter-bar>`_)
@@ -120,4 +119,3 @@ Collection links
 * `Homepage <https://github.com/ansible-collections/community.crypto>`__
 * `Repository (Sources) <https://github.com/ansible-collections/community.internal\_test\_tools>`__
 * `Submit a bug report <https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&labels=&template=bug\_report.md>`__
-

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_strategy.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_strategy.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs
 
 ns2.col.foo strategy -- Executes tasks in foo
@@ -57,4 +56,3 @@ Collection links
 * `Homepage <https://github.com/ansible-collections/community.crypto>`__
 * `Repository (Sources) <https://github.com/ansible-collections/community.internal\_test\_tools>`__
 * `Submit a bug report <https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&labels=&template=bug\_report.md>`__
-

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_test.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_test.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs
 
 ns2.col.foo test -- Is something a foo :literal:`bar` (`link <#parameter-bar>`_)
@@ -164,4 +163,3 @@ Collection links
 * `Homepage <https://github.com/ansible-collections/community.crypto>`__
 * `Repository (Sources) <https://github.com/ansible-collections/community.internal\_test\_tools>`__
 * `Submit a bug report <https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&labels=&template=bug\_report.md>`__
-

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_vars.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/foo_vars.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs
 
 ns2.col.foo vars -- Load foo :literal:`bar` (`link <#parameter-bar>`_)
@@ -123,4 +122,3 @@ Collection links
 * `Homepage <https://github.com/ansible-collections/community.crypto>`__
 * `Repository (Sources) <https://github.com/ansible-collections/community.internal\_test\_tools>`__
 * `Submit a bug report <https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&labels=&template=bug\_report.md>`__
-

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/index.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/index.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs
 
 
@@ -149,4 +148,3 @@ Role Index
 These are the roles in the ns2.col collection:
 
 * `foo role <foo_role.rst>`_ -- Foo role
-

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/is_bar_test.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/is_bar_test.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs
 
 ns2.col.is_bar test

--- a/tests/functional/baseline-simplified-rst-squash-hierarchy/sub.foo3_module.rst
+++ b/tests/functional/baseline-simplified-rst-squash-hierarchy/sub.foo3_module.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs
 
 ns2.col.sub.foo3 module -- A sub-foo
@@ -192,4 +191,3 @@ Collection links
 * `Homepage <https://github.com/ansible-collections/community.crypto>`__
 * `Repository (Sources) <https://github.com/ansible-collections/community.internal\_test\_tools>`__
 * `Submit a bug report <https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&labels=&template=bug\_report.md>`__
-

--- a/tests/functional/baseline-simplified-rst/collections/callback_index_stdout.rst
+++ b/tests/functional/baseline-simplified-rst/collections/callback_index_stdout.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 Index of all Stdout Callback Plugins
@@ -10,4 +9,3 @@ ns2.col
 -------
 
 * `ns2.col.foo <ns2/col/foo_callback.rst>`_ -- Foo output :literal:`bar` (of callback plugin `ns2.col.foo <foo_callback.rst>`__)
-

--- a/tests/functional/baseline-simplified-rst/collections/index.rst
+++ b/tests/functional/baseline-simplified-rst/collections/index.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 Collection Index

--- a/tests/functional/baseline-simplified-rst/collections/index_become.rst
+++ b/tests/functional/baseline-simplified-rst/collections/index_become.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 Index of all Become Plugins
@@ -8,4 +7,3 @@ ns2.col
 -------
 
 * `ns2.col.foo <ns2/col/foo_become.rst>`_ -- Use foo :literal:`bar` (of become plugin `ns2.col.foo <foo_become.rst>`__)
-

--- a/tests/functional/baseline-simplified-rst/collections/index_cache.rst
+++ b/tests/functional/baseline-simplified-rst/collections/index_cache.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 Index of all Cache Plugins
@@ -8,4 +7,3 @@ ns2.col
 -------
 
 * `ns2.col.foo <ns2/col/foo_cache.rst>`_ -- Foo files :literal:`bar` (of cache plugin `ns2.col.foo <foo_cache.rst>`__)
-

--- a/tests/functional/baseline-simplified-rst/collections/index_callback.rst
+++ b/tests/functional/baseline-simplified-rst/collections/index_callback.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 Index of all Callback Plugins
@@ -8,4 +7,3 @@ ns2.col
 -------
 
 * `ns2.col.foo <ns2/col/foo_callback.rst>`_ -- Foo output :literal:`bar` (of callback plugin `ns2.col.foo <foo_callback.rst>`__)
-

--- a/tests/functional/baseline-simplified-rst/collections/index_cliconf.rst
+++ b/tests/functional/baseline-simplified-rst/collections/index_cliconf.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 Index of all Cliconf Plugins
@@ -8,4 +7,3 @@ ns2.col
 -------
 
 * `ns2.col.foo <ns2/col/foo_cliconf.rst>`_ -- Foo router CLI config
-

--- a/tests/functional/baseline-simplified-rst/collections/index_connection.rst
+++ b/tests/functional/baseline-simplified-rst/collections/index_connection.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 Index of all Connection Plugins
@@ -8,4 +7,3 @@ ns2.col
 -------
 
 * `ns2.col.foo <ns2/col/foo_connection.rst>`_ -- Foo connection :literal:`bar` (of connection plugin `ns2.col.foo <foo_connection.rst>`__)
-

--- a/tests/functional/baseline-simplified-rst/collections/index_filter.rst
+++ b/tests/functional/baseline-simplified-rst/collections/index_filter.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 Index of all Filter Plugins
@@ -9,4 +8,3 @@ ns2.col
 
 * `ns2.col.bar <ns2/col/bar_filter.rst>`_ -- The bar filter
 * `ns2.col.foo <ns2/col/foo_filter.rst>`_ -- The foo filter :literal:`bar` (of filter plugin `ns2.col.foo <foo_filter.rst>`__)
-

--- a/tests/functional/baseline-simplified-rst/collections/index_inventory.rst
+++ b/tests/functional/baseline-simplified-rst/collections/index_inventory.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 Index of all Inventory Plugins
@@ -8,4 +7,3 @@ ns2.col
 -------
 
 * `ns2.col.foo <ns2/col/foo_inventory.rst>`_ -- The foo inventory :literal:`bar` (of inventory plugin `ns2.col.foo <foo_inventory.rst>`__)
-

--- a/tests/functional/baseline-simplified-rst/collections/index_lookup.rst
+++ b/tests/functional/baseline-simplified-rst/collections/index_lookup.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 Index of all Lookup Plugins
@@ -8,4 +7,3 @@ ns2.col
 -------
 
 * `ns2.col.foo <ns2/col/foo_lookup.rst>`_ -- Look up some foo :literal:`bar` (of lookup plugin `ns2.col.foo <foo_lookup.rst>`__)
-

--- a/tests/functional/baseline-simplified-rst/collections/index_module.rst
+++ b/tests/functional/baseline-simplified-rst/collections/index_module.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 Index of all Modules
@@ -7,7 +6,7 @@ Index of all Modules
 ns.col2
 -------
 
-* `ns.col2.foo <ns/col2/foo_module.rst>`_ -- 
+* `ns.col2.foo <ns/col2/foo_module.rst>`_ --
 * `ns.col2.foo2 <ns/col2/foo2_module.rst>`_ -- Foo two
 * `ns.col2.foo3 <ns/col2/foo3_module.rst>`_ -- Foo III
 * `ns.col2.foo4 <ns/col2/foo4_module.rst>`_ -- Markup reference linting test
@@ -24,4 +23,3 @@ ns2.flatcol
 
 * `ns2.flatcol.foo <ns2/flatcol/foo_module.rst>`_ -- Do some foo :literal:`bar` (of module `ns2.flatcol.foo <foo_module.rst>`__)
 * `ns2.flatcol.foo2 <ns2/flatcol/foo2_module.rst>`_ -- Another foo
-

--- a/tests/functional/baseline-simplified-rst/collections/index_role.rst
+++ b/tests/functional/baseline-simplified-rst/collections/index_role.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 Index of all Roles
@@ -13,4 +12,3 @@ ns2.col
 -------
 
 * `ns2.col.foo <ns2/col/foo_role.rst>`_ -- Foo role
-

--- a/tests/functional/baseline-simplified-rst/collections/index_shell.rst
+++ b/tests/functional/baseline-simplified-rst/collections/index_shell.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 Index of all Shell Plugins
@@ -8,4 +7,3 @@ ns2.col
 -------
 
 * `ns2.col.foo <ns2/col/foo_shell.rst>`_ -- Foo shell :literal:`bar` (of shell plugin `ns2.col.foo <foo_shell.rst>`__)
-

--- a/tests/functional/baseline-simplified-rst/collections/index_strategy.rst
+++ b/tests/functional/baseline-simplified-rst/collections/index_strategy.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 Index of all Strategy Plugins
@@ -8,4 +7,3 @@ ns2.col
 -------
 
 * `ns2.col.foo <ns2/col/foo_strategy.rst>`_ -- Executes tasks in foo
-

--- a/tests/functional/baseline-simplified-rst/collections/index_test.rst
+++ b/tests/functional/baseline-simplified-rst/collections/index_test.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 Index of all Test Plugins
@@ -9,4 +8,3 @@ ns2.col
 
 * `ns2.col.bar <ns2/col/bar_test.rst>`_ -- Is something a bar
 * `ns2.col.foo <ns2/col/foo_test.rst>`_ -- Is something a foo :literal:`bar` (of test plugin `ns2.col.foo <foo_test.rst>`__)
-

--- a/tests/functional/baseline-simplified-rst/collections/index_vars.rst
+++ b/tests/functional/baseline-simplified-rst/collections/index_vars.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 Index of all Vars Plugins
@@ -8,4 +7,3 @@ ns2.col
 -------
 
 * `ns2.col.foo <ns2/col/foo_vars.rst>`_ -- Load foo :literal:`bar` (of vars plugin `ns2.col.foo <foo_vars.rst>`__)
-

--- a/tests/functional/baseline-simplified-rst/collections/ns/col1/index.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns/col1/index.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 
@@ -33,5 +32,3 @@ Plugin Index
 ------------
 
 There are no plugins in the ns.col1 collection with automatically generated documentation.
-
-

--- a/tests/functional/baseline-simplified-rst/collections/ns/col2/bar_role.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns/col2/bar_role.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 ns.col2.bar role -- Bar role
@@ -79,5 +78,3 @@ Authors
 
 
 .. Extra links
-
-

--- a/tests/functional/baseline-simplified-rst/collections/ns/col2/foo2_module.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns/col2/foo2_module.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 ns.col2.foo2 module -- Foo two
@@ -301,7 +300,3 @@ Authors
 ~~~~~~~
 
 - Someone else (@ansible)
-
-
-
-

--- a/tests/functional/baseline-simplified-rst/collections/ns/col2/foo3_module.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns/col2/foo3_module.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 ns.col2.foo3 module -- Foo III
@@ -201,4 +200,3 @@ The errors were:
           string does not match regex "^(any|bits|bool|bytes|complex|dict|float|int|json|jsonarg|list|path|sid|str|pathspec|pathlist)$" (type=value_error.str.regex; pattern=^(any|bits|bool|bytes|complex|dict|float|int|json|jsonarg|list|path|sid|str|pathspec|pathlist)$)
         return -> baz
           value is not a valid dict (type=type_error.dict)
-

--- a/tests/functional/baseline-simplified-rst/collections/ns/col2/foo4_module.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns/col2/foo4_module.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 ns.col2.foo4 module -- Markup reference linting test
@@ -173,7 +172,3 @@ Authors
 ~~~~~~~
 
 - Nobody (@ansible)
-
-
-
-

--- a/tests/functional/baseline-simplified-rst/collections/ns/col2/foo_module.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns/col2/foo_module.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 ns.col2.foo module

--- a/tests/functional/baseline-simplified-rst/collections/ns/col2/index.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns/col2/index.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 
@@ -34,7 +33,7 @@ These are the plugins in the ns.col2 collection:
 Modules
 ~~~~~~~
 
-* `foo module <foo_module.rst>`_ -- 
+* `foo module <foo_module.rst>`_ --
 * `foo2 module <foo2_module.rst>`_ -- Foo two
 * `foo3 module <foo3_module.rst>`_ -- Foo III
 * `foo4 module <foo4_module.rst>`_ -- Markup reference linting test
@@ -46,4 +45,3 @@ Role Index
 These are the roles in the ns.col2 collection:
 
 * `bar role <bar_role.rst>`_ -- Bar role
-

--- a/tests/functional/baseline-simplified-rst/collections/ns/index.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns/index.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/bar_filter.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/bar_filter.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 ns2.col.bar filter -- The bar filter
@@ -244,4 +243,3 @@ Collection links
 * `Homepage <https://github.com/ansible-collections/community.crypto>`__
 * `Repository (Sources) <https://github.com/ansible-collections/community.internal\_test\_tools>`__
 * `Submit a bug report <https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&labels=&template=bug\_report.md>`__
-

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/bar_test.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/bar_test.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 ns2.col.bar test -- Is something a bar
@@ -130,4 +129,3 @@ Collection links
 * `Homepage <https://github.com/ansible-collections/community.crypto>`__
 * `Repository (Sources) <https://github.com/ansible-collections/community.internal\_test\_tools>`__
 * `Submit a bug report <https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&labels=&template=bug\_report.md>`__
-

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo2_module.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo2_module.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 ns2.col.foo2 module -- Another foo
@@ -193,4 +192,3 @@ Collection links
 * `Homepage <https://github.com/ansible-collections/community.crypto>`__
 * `Repository (Sources) <https://github.com/ansible-collections/community.internal\_test\_tools>`__
 * `Submit a bug report <https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&labels=&template=bug\_report.md>`__
-

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_become.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_become.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 ns2.col.foo become -- Use foo :literal:`bar` (`link <#parameter-bar>`_)
@@ -224,4 +223,3 @@ Collection links
 * `Homepage <https://github.com/ansible-collections/community.crypto>`__
 * `Repository (Sources) <https://github.com/ansible-collections/community.internal\_test\_tools>`__
 * `Submit a bug report <https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&labels=&template=bug\_report.md>`__
-

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_cache.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_cache.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 ns2.col.foo cache -- Foo files :literal:`bar` (`link <#parameter-bar>`_)
@@ -116,4 +115,3 @@ Collection links
 * `Homepage <https://github.com/ansible-collections/community.crypto>`__
 * `Repository (Sources) <https://github.com/ansible-collections/community.internal\_test\_tools>`__
 * `Submit a bug report <https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&labels=&template=bug\_report.md>`__
-

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_callback.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_callback.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 ns2.col.foo callback -- Foo output :literal:`bar` (`link <#parameter-bar>`_)
@@ -88,4 +87,3 @@ Collection links
 * `Homepage <https://github.com/ansible-collections/community.crypto>`__
 * `Repository (Sources) <https://github.com/ansible-collections/community.internal\_test\_tools>`__
 * `Submit a bug report <https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&labels=&template=bug\_report.md>`__
-

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_cliconf.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_cliconf.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 ns2.col.foo cliconf -- Foo router CLI config
@@ -56,4 +55,3 @@ Collection links
 * `Homepage <https://github.com/ansible-collections/community.crypto>`__
 * `Repository (Sources) <https://github.com/ansible-collections/community.internal\_test\_tools>`__
 * `Submit a bug report <https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&labels=&template=bug\_report.md>`__
-

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_connection.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_connection.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 ns2.col.foo connection -- Foo connection :literal:`bar` (`link <#parameter-bar>`_)
@@ -131,4 +130,3 @@ Collection links
 * `Homepage <https://github.com/ansible-collections/community.crypto>`__
 * `Repository (Sources) <https://github.com/ansible-collections/community.internal\_test\_tools>`__
 * `Submit a bug report <https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&labels=&template=bug\_report.md>`__
-

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_filter.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_filter.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 ns2.col.foo filter -- The foo filter :literal:`bar` (`link <#parameter-bar>`_)
@@ -176,4 +175,3 @@ Collection links
 * `Homepage <https://github.com/ansible-collections/community.crypto>`__
 * `Repository (Sources) <https://github.com/ansible-collections/community.internal\_test\_tools>`__
 * `Submit a bug report <https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&labels=&template=bug\_report.md>`__
-

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_inventory.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_inventory.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 ns2.col.foo inventory -- The foo inventory :literal:`bar` (`link <#parameter-bar>`_)
@@ -91,4 +90,3 @@ Collection links
 * `Homepage <https://github.com/ansible-collections/community.crypto>`__
 * `Repository (Sources) <https://github.com/ansible-collections/community.internal\_test\_tools>`__
 * `Submit a bug report <https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&labels=&template=bug\_report.md>`__
-

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_lookup.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_lookup.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 ns2.col.foo lookup -- Look up some foo :literal:`bar` (`link <#parameter-bar>`_)
@@ -173,4 +172,3 @@ Collection links
 * `Homepage <https://github.com/ansible-collections/community.crypto>`__
 * `Repository (Sources) <https://github.com/ansible-collections/community.internal\_test\_tools>`__
 * `Submit a bug report <https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&labels=&template=bug\_report.md>`__
-

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_module.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 ns2.col.foo module -- Do some foo :literal:`bar` (`link <#parameter-bar>`_)
@@ -360,4 +359,3 @@ Collection links
 * `Homepage <https://github.com/ansible-collections/community.crypto>`__
 * `Repository (Sources) <https://github.com/ansible-collections/community.internal\_test\_tools>`__
 * `Submit a bug report <https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&labels=&template=bug\_report.md>`__
-

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_redirect_module.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_redirect_module.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 ns2.col.foo_redirect module

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_role.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_role.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 ns2.col.foo role -- Foo role
@@ -162,4 +161,3 @@ Collection links
 * `Homepage <https://github.com/ansible-collections/community.crypto>`__
 * `Repository (Sources) <https://github.com/ansible-collections/community.internal\_test\_tools>`__
 * `Submit a bug report <https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&labels=&template=bug\_report.md>`__
-

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_shell.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_shell.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 ns2.col.foo shell -- Foo shell :literal:`bar` (`link <#parameter-bar>`_)
@@ -120,4 +119,3 @@ Collection links
 * `Homepage <https://github.com/ansible-collections/community.crypto>`__
 * `Repository (Sources) <https://github.com/ansible-collections/community.internal\_test\_tools>`__
 * `Submit a bug report <https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&labels=&template=bug\_report.md>`__
-

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_strategy.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_strategy.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 ns2.col.foo strategy -- Executes tasks in foo
@@ -57,4 +56,3 @@ Collection links
 * `Homepage <https://github.com/ansible-collections/community.crypto>`__
 * `Repository (Sources) <https://github.com/ansible-collections/community.internal\_test\_tools>`__
 * `Submit a bug report <https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&labels=&template=bug\_report.md>`__
-

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_test.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_test.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 ns2.col.foo test -- Is something a foo :literal:`bar` (`link <#parameter-bar>`_)
@@ -164,4 +163,3 @@ Collection links
 * `Homepage <https://github.com/ansible-collections/community.crypto>`__
 * `Repository (Sources) <https://github.com/ansible-collections/community.internal\_test\_tools>`__
 * `Submit a bug report <https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&labels=&template=bug\_report.md>`__
-

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_vars.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/foo_vars.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 ns2.col.foo vars -- Load foo :literal:`bar` (`link <#parameter-bar>`_)
@@ -123,4 +122,3 @@ Collection links
 * `Homepage <https://github.com/ansible-collections/community.crypto>`__
 * `Repository (Sources) <https://github.com/ansible-collections/community.internal\_test\_tools>`__
 * `Submit a bug report <https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&labels=&template=bug\_report.md>`__
-

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/index.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/index.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 
@@ -149,4 +148,3 @@ Role Index
 These are the roles in the ns2.col collection:
 
 * `foo role <foo_role.rst>`_ -- Foo role
-

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/is_bar_test.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/is_bar_test.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 ns2.col.is_bar test

--- a/tests/functional/baseline-simplified-rst/collections/ns2/col/sub.foo3_module.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/col/sub.foo3_module.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 ns2.col.sub.foo3 module -- A sub-foo
@@ -192,4 +191,3 @@ Collection links
 * `Homepage <https://github.com/ansible-collections/community.crypto>`__
 * `Repository (Sources) <https://github.com/ansible-collections/community.internal\_test\_tools>`__
 * `Submit a bug report <https://github.com/ansible-community/antsibull-docs/issues/new?assignees=&labels=&template=bug\_report.md>`__
-

--- a/tests/functional/baseline-simplified-rst/collections/ns2/flatcol/foo2_module.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/flatcol/foo2_module.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 ns2.flatcol.foo2 module -- Another foo
@@ -127,4 +126,3 @@ Collection links
 ~~~~~~~~~~~~~~~~
 
 * `Report an issue <https://github.com/ansible-collections/community.REPO\_NAME/issues/new/choose>`__
-

--- a/tests/functional/baseline-simplified-rst/collections/ns2/flatcol/foo_module.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/flatcol/foo_module.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 ns2.flatcol.foo module -- Do some foo :literal:`bar` (`link <#parameter-bar>`_)
@@ -193,4 +192,3 @@ Collection links
 ~~~~~~~~~~~~~~~~
 
 * `Report an issue <https://github.com/ansible-collections/community.REPO\_NAME/issues/new/choose>`__
-

--- a/tests/functional/baseline-simplified-rst/collections/ns2/flatcol/index.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/flatcol/index.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 
@@ -45,5 +44,3 @@ Modules
 
 * `foo module <foo_module.rst>`_ -- Do some foo :literal:`bar` (of module `ns2.flatcol.foo <foo_module.rst>`__)
 * `foo2 module <foo2_module.rst>`_ -- Another foo
-
-

--- a/tests/functional/baseline-simplified-rst/collections/ns2/index.rst
+++ b/tests/functional/baseline-simplified-rst/collections/ns2/index.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 

--- a/tests/functional/baseline-sphinx-init-collections/build.sh
+++ b/tests/functional/baseline-sphinx-init-collections/build.sh
@@ -26,4 +26,3 @@ rsync -cprv --delete-after temp-rst/collections/ rst/collections/
 
 # Build Sphinx site
 sphinx-build -M html rst build -c . -W --keep-going
-

--- a/tests/functional/baseline-sphinx-init-collections/conf.py
+++ b/tests/functional/baseline-sphinx-init-collections/conf.py
@@ -43,4 +43,3 @@ intersphinx_mapping = {
 default_role = 'any'
 
 nitpicky = True
-

--- a/tests/functional/baseline-sphinx-init-collections/rst/index.rst
+++ b/tests/functional/baseline-sphinx-init-collections/rst/index.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 .. _docsite_root_index:

--- a/tests/functional/baseline-sphinx-init-config/build.sh
+++ b/tests/functional/baseline-sphinx-init-config/build.sh
@@ -28,4 +28,3 @@ rsync -cprv --delete-after temp-rst/ rst/
 
 # Build Sphinx site
 sphinx-build -M html rst build -c .
-

--- a/tests/functional/baseline-sphinx-init-config/conf.py
+++ b/tests/functional/baseline-sphinx-init-config/conf.py
@@ -44,5 +44,3 @@ intersphinx_mapping = {
 }
 
 default_role = 'any'
-
-

--- a/tests/functional/baseline-sphinx-init-current/build.sh
+++ b/tests/functional/baseline-sphinx-init-current/build.sh
@@ -24,4 +24,3 @@ rsync -cprv --delete-after temp-rst/collections/ rst/collections/
 
 # Build Sphinx site
 sphinx-build -M html rst build -c . -W --keep-going
-

--- a/tests/functional/baseline-sphinx-init-current/conf.py
+++ b/tests/functional/baseline-sphinx-init-current/conf.py
@@ -43,4 +43,3 @@ intersphinx_mapping = {
 default_role = 'any'
 
 nitpicky = True
-

--- a/tests/functional/baseline-sphinx-init-current/rst/index.rst
+++ b/tests/functional/baseline-sphinx-init-current/rst/index.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 .. _docsite_root_index:

--- a/tests/functional/baseline-sphinx-init-extra/build.sh
+++ b/tests/functional/baseline-sphinx-init-extra/build.sh
@@ -26,4 +26,3 @@ rsync -cprv --delete-after temp-rst/collections/ rst/collections/
 
 # Build Sphinx site
 sphinx-build -M html rst build -c . -W --keep-going
-

--- a/tests/functional/baseline-sphinx-init-extra/conf.py
+++ b/tests/functional/baseline-sphinx-init-extra/conf.py
@@ -56,4 +56,3 @@ html_theme_options = {
     'key': 'value',
     'long key': 'very "long" \'value\'',
 }
-

--- a/tests/functional/baseline-sphinx-init-extra/rst/index.rst
+++ b/tests/functional/baseline-sphinx-init-extra/rst/index.rst
@@ -1,4 +1,3 @@
-
 .. Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
 .. _docsite_root_index:

--- a/tests/functional/baseline-squash-hierarchy/bar_filter.rst
+++ b/tests/functional/baseline-squash-hierarchy/bar_filter.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -420,4 +419,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-squash-hierarchy/bar_test.rst
+++ b/tests/functional/baseline-squash-hierarchy/bar_test.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -240,4 +239,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-squash-hierarchy/environment_variables.rst
+++ b/tests/functional/baseline-squash-hierarchy/environment_variables.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::

--- a/tests/functional/baseline-squash-hierarchy/foo2_module.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo2_module.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -428,4 +427,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-squash-hierarchy/foo_become.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_become.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -382,4 +381,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-squash-hierarchy/foo_cache.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_cache.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -227,4 +226,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-squash-hierarchy/foo_callback.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_callback.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -176,4 +175,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-squash-hierarchy/foo_cliconf.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_cliconf.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -121,4 +120,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-squash-hierarchy/foo_connection.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_connection.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -237,4 +236,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-squash-hierarchy/foo_filter.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_filter.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -328,4 +327,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-squash-hierarchy/foo_inventory.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_inventory.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -178,4 +177,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-squash-hierarchy/foo_lookup.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_lookup.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -303,4 +302,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-squash-hierarchy/foo_module.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_module.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -302,7 +301,7 @@ Parameters
       .. raw:: html
 
         </div>
-    
+
   * - .. raw:: html
 
         <div class="ansible-option-indent"></div><div class="ansible-option-cell">
@@ -683,4 +682,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-squash-hierarchy/foo_redirect_module.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_redirect_module.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:

--- a/tests/functional/baseline-squash-hierarchy/foo_role.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_role.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -326,4 +325,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-squash-hierarchy/foo_shell.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_shell.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -233,4 +232,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-squash-hierarchy/foo_strategy.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_strategy.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -124,4 +123,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-squash-hierarchy/foo_test.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_test.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -293,4 +292,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-squash-hierarchy/foo_vars.rst
+++ b/tests/functional/baseline-squash-hierarchy/foo_vars.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -237,4 +236,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-squash-hierarchy/index.rst
+++ b/tests/functional/baseline-squash-hierarchy/index.rst
@@ -1,5 +1,3 @@
-
-
 .. meta::
   :antsibull-docs: <ANTSIBULL_DOCS_VERSION>
 
@@ -263,4 +261,3 @@ These are the roles in the ns2.col collection:
     :hidden:
 
     foo_role
-

--- a/tests/functional/baseline-squash-hierarchy/is_bar_test.rst
+++ b/tests/functional/baseline-squash-hierarchy/is_bar_test.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:

--- a/tests/functional/baseline-squash-hierarchy/sub.foo3_module.rst
+++ b/tests/functional/baseline-squash-hierarchy/sub.foo3_module.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -427,4 +426,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-use-html-blobs/collections/callback_index_stdout.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/callback_index_stdout.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -15,4 +14,3 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.foo#callback` -- Foo output :ansopt:`ns2.col.foo#callback:bar`
-

--- a/tests/functional/baseline-use-html-blobs/collections/environment_variables.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/environment_variables.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::

--- a/tests/functional/baseline-use-html-blobs/collections/index.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::

--- a/tests/functional/baseline-use-html-blobs/collections/index_become.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_become.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -13,4 +12,3 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.foo#become` -- Use foo :ansopt:`ns2.col.foo#become:bar`
-

--- a/tests/functional/baseline-use-html-blobs/collections/index_cache.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_cache.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -13,4 +12,3 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.foo#cache` -- Foo files :ansopt:`ns2.col.foo#cache:bar`
-

--- a/tests/functional/baseline-use-html-blobs/collections/index_callback.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_callback.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -21,4 +20,3 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.foo#callback` -- Foo output :ansopt:`ns2.col.foo#callback:bar`
-

--- a/tests/functional/baseline-use-html-blobs/collections/index_cliconf.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_cliconf.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -13,4 +12,3 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.foo#cliconf` -- Foo router CLI config
-

--- a/tests/functional/baseline-use-html-blobs/collections/index_connection.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_connection.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -13,4 +12,3 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.foo#connection` -- Foo connection :ansopt:`ns2.col.foo#connection:bar`
-

--- a/tests/functional/baseline-use-html-blobs/collections/index_filter.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_filter.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -14,4 +13,3 @@ ns2.col
 
 * :ansplugin:`ns2.col.bar#filter` -- The bar filter
 * :ansplugin:`ns2.col.foo#filter` -- The foo filter :ansopt:`ns2.col.foo#filter:bar`
-

--- a/tests/functional/baseline-use-html-blobs/collections/index_inventory.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_inventory.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -13,4 +12,3 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.foo#inventory` -- The foo inventory :ansopt:`ns2.col.foo#inventory:bar`
-

--- a/tests/functional/baseline-use-html-blobs/collections/index_lookup.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_lookup.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -13,4 +12,3 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.foo#lookup` -- Look up some foo :ansopt:`ns2.col.foo#lookup:bar`
-

--- a/tests/functional/baseline-use-html-blobs/collections/index_module.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_module.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -15,4 +14,3 @@ ns2.col
 * :ansplugin:`ns2.col.foo#module` -- Do some foo :ansopt:`ns2.col.foo#module:bar`
 * :ansplugin:`ns2.col.foo2#module` -- Another foo
 * :ansplugin:`ns2.col.sub.foo3#module` -- A sub-foo
-

--- a/tests/functional/baseline-use-html-blobs/collections/index_role.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_role.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -13,4 +12,3 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.foo#role` -- Foo role
-

--- a/tests/functional/baseline-use-html-blobs/collections/index_shell.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_shell.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -13,4 +12,3 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.foo#shell` -- Foo shell :ansopt:`ns2.col.foo#shell:bar`
-

--- a/tests/functional/baseline-use-html-blobs/collections/index_strategy.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_strategy.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -13,4 +12,3 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.foo#strategy` -- Executes tasks in foo
-

--- a/tests/functional/baseline-use-html-blobs/collections/index_test.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_test.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -14,4 +13,3 @@ ns2.col
 
 * :ansplugin:`ns2.col.bar#test` -- Is something a bar
 * :ansplugin:`ns2.col.foo#test` -- Is something a foo :ansopt:`ns2.col.foo#test:bar`
-

--- a/tests/functional/baseline-use-html-blobs/collections/index_vars.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/index_vars.rst
@@ -1,4 +1,3 @@
-
 :orphan:
 
 .. meta::
@@ -13,4 +12,3 @@ ns2.col
 -------
 
 * :ansplugin:`ns2.col.foo#vars` -- Load foo :ansopt:`ns2.col.foo#vars:bar`
-

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/bar_filter.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/bar_filter.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -316,4 +315,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/bar_test.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/bar_test.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -197,4 +196,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo2_module.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo2_module.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -380,4 +379,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_become.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_become.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -291,4 +290,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_cache.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_cache.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -183,4 +182,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_callback.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_callback.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -156,4 +155,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_cliconf.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_cliconf.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -121,4 +120,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_connection.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_connection.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -199,4 +198,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_filter.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_filter.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -245,4 +244,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_inventory.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_inventory.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -158,4 +157,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_lookup.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_lookup.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -243,4 +242,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_module.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_module.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -546,4 +545,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_redirect_module.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_redirect_module.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_role.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_role.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -279,4 +278,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_shell.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_shell.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -187,4 +186,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_strategy.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_strategy.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -124,4 +123,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_test.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_test.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -231,4 +230,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_vars.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/foo_vars.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -190,4 +189,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/index.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/index.rst
@@ -1,5 +1,3 @@
-
-
 .. meta::
   :antsibull-docs: <ANTSIBULL_DOCS_VERSION>
 

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/is_bar_test.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/is_bar_test.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/col/sub.foo3_module.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/col/sub.foo3_module.rst
@@ -1,4 +1,3 @@
-
 .. Document meta
 
 :orphan:
@@ -379,4 +378,3 @@ Collection links
 
 
 .. Parsing errors
-

--- a/tests/functional/baseline-use-html-blobs/collections/ns2/index.rst
+++ b/tests/functional/baseline-use-html-blobs/collections/ns2/index.rst
@@ -1,5 +1,3 @@
-
-
 .. meta::
   :antsibull-docs: <ANTSIBULL_DOCS_VERSION>
 

--- a/tests/units/utils/test_text.py
+++ b/tests/units/utils/test_text.py
@@ -55,10 +55,18 @@ def test_count_leading_whitespace(line, max_count, expected):
 
 
 @pytest.mark.parametrize(
-    "content, expected",
+    "content, trailing_newline, remove_common_leading_whitespace, expected",
     [
         (
             "",
+            False,
+            True,
+            "",
+        ),
+        (
+            "",
+            True,
+            True,
             "",
         ),
         (
@@ -66,7 +74,34 @@ def test_count_leading_whitespace(line, max_count, expected):
 Test
   Test
 """,
+            False,
+            True,
             r"""Test
+  Test""",
+        ),
+        (
+            r"""
+Test
+  Test
+""",
+            True,
+            True,
+            r"""Test
+  Test
+""",
+        ),
+        (
+            r"""
+
+      Test!
+  Test  
+    Test
+
+""",
+            False,
+            True,
+            r"""    Test!
+Test
   Test""",
         ),
         (
@@ -77,9 +112,11 @@ Test
     Test
 
 """,
-            r"""    Test!
-Test
-  Test""",
+            False,
+            False,
+            r"""      Test!
+  Test
+    Test""",
         ),
         (
             """
@@ -87,12 +124,20 @@ Test
   ns2.flatcol.foo2:
     bar: foo
 """,
+            False,
+            True,
             """- name: Do some foo
   ns2.flatcol.foo2:
     bar: foo""",
         ),
     ],
 )
-def test_sanitize_whitespace(content, expected):
-    result = sanitize_whitespace(content)
+def test_sanitize_whitespace(
+    content, trailing_newline, remove_common_leading_whitespace, expected
+):
+    result = sanitize_whitespace(
+        content,
+        trailing_newline=trailing_newline,
+        remove_common_leading_whitespace=remove_common_leading_whitespace,
+    )
     assert result == expected


### PR DESCRIPTION
- Trim empty lines before and after templated content.
- Ensure templated content ends with a single newline, if the file isn't empty.
- Strip all trailing ASCII whitespace from lines.

Fixes #305.