### PR TITLE
Add `--cleanup` option; get rid of `rsync` in `sphinx-init` subcommand

### DIFF
--- a/changelogs/fragments/315-cleanup.yml
+++ b/changelogs/fragments/315-cleanup.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - "Most documentation generating subcommands now have a ``--cleanup`` parameter which allows to delete
+     files and directories that were not created by antsibull-docs in the destination directory
+     (https://github.com/ansible-community/antsibull-docs/pull/315)."

--- a/changelogs/fragments/315-cleanup.yml
+++ b/changelogs/fragments/315-cleanup.yml
@@ -2,3 +2,5 @@ minor_changes:
   - "Most documentation generating subcommands now have a ``--cleanup`` parameter which allows to delete
      files and directories that were not created by antsibull-docs in the destination directory
      (https://github.com/ansible-community/antsibull-docs/pull/315)."
+  - "No longer use ``rsync`` when creating a build script with the ``sphinx-init`` subcommand
+     (https://github.com/ansible-community/antsibull-docs/pull/315)."

--- a/src/antsibull_docs/cli/antsibull_docs.py
+++ b/src/antsibull_docs/cli/antsibull_docs.py
@@ -355,6 +355,34 @@ def parse_args(program_name: str, args: list[str]) -> argparse.Namespace:
         " This option is deprecated in favor of --no-indexes",
     )
 
+    cleanup_parser = argparse.ArgumentParser(add_help=False)
+    cleanup_parser.add_argument(
+        "--cleanup",
+        dest="cleanup",
+        choices=[
+            "no",
+            "similar-files",
+            "similar-files-and-dirs",
+            "everything",
+        ],
+        default="no",
+        help="Whether to clean-up the output directory after writing the own"
+        " files and directories. Generally this only affects the collections/"
+        " subdirectory of the output directly, unless no hierarchy is emitted."
+        # no:
+        " 'no' means that no cleanup is done."
+        # similar-files:
+        " 'similar-files' removes similar files in directories that"
+        " antsibull-docs writes to, for example files like 'foo_module.rst';"
+        # similar-files-and-dirs:
+        " 'similar-files-and-dirs' also removes directories that are not"
+        " written by antsibull-docs inside the directory structure, for"
+        " example other collections;"
+        # everything:
+        " 'everything' ensures that only what antsibull-docs has written stays"
+        " inside the output directory. (default: no)",
+    )
+
     parser = get_toplevel_parser(
         prog=program_name,
         package="antsibull_docs",
@@ -378,6 +406,7 @@ def parse_args(program_name: str, args: list[str]) -> argparse.Namespace:
             whole_site_parser,
             template_parser,
             insert_version_parser,
+            cleanup_parser,
         ],
         description="Generate documentation for the next major release of Ansible",
     )
@@ -406,6 +435,7 @@ def parse_args(program_name: str, args: list[str]) -> argparse.Namespace:
             whole_site_parser,
             template_parser,
             insert_version_parser,
+            cleanup_parser,
         ],
         description="Generate documentation for a current version of ansible",
     )
@@ -435,6 +465,7 @@ def parse_args(program_name: str, args: list[str]) -> argparse.Namespace:
             template_parser,
             insert_version_parser,
             output_format_parser,
+            cleanup_parser,
         ],
         description="Generate documentation for the current"
         " installed version of ansible and the current installed"
@@ -464,6 +495,7 @@ def parse_args(program_name: str, args: list[str]) -> argparse.Namespace:
             template_parser,
             insert_version_parser,
             output_format_parser,
+            cleanup_parser,
         ],
         description="Generate documentation for specified collections",
     )
@@ -537,6 +569,7 @@ def parse_args(program_name: str, args: list[str]) -> argparse.Namespace:
             template_parser,
             insert_version_parser,
             output_format_parser,
+            cleanup_parser,
         ],
         description="Generate documentation for all plugins of a specified collection",
     )

--- a/src/antsibull_docs/cli/doc_commands/_build.py
+++ b/src/antsibull_docs/cli/doc_commands/_build.py
@@ -56,6 +56,7 @@ from ...write_docs.indexes import (
     output_environment_variables,
     output_plugin_indexes,
 )
+from ...write_docs.io import Output
 from ...write_docs.plugin_stubs import output_all_plugin_stub_rst
 from ...write_docs.plugins import output_all_plugin_rst
 
@@ -270,13 +271,15 @@ def generate_docs_for_all_collections(  # noqa: C901
         include_collection_name_in_plugins=include_collection_name_in_plugins
     )
 
+    output = Output(dest_dir)
+
     # Only build top-level index if requested
     if create_indexes:
         asyncio.run(
             output_collection_index(
                 collection_to_plugin_info,
                 collection_namespaces,
-                dest_dir,
+                output,
                 collection_url=collection_url,
                 collection_install=collection_install,
                 output_format=output_format,
@@ -291,7 +294,7 @@ def generate_docs_for_all_collections(  # noqa: C901
         asyncio.run(
             output_collection_namespace_indexes(
                 collection_namespaces,
-                dest_dir,
+                output,
                 collection_url=collection_url,
                 collection_install=collection_install,
                 output_format=output_format,
@@ -307,7 +310,7 @@ def generate_docs_for_all_collections(  # noqa: C901
             output_plugin_indexes(
                 plugin_contents,
                 collection_metadata,
-                dest_dir,
+                output,
                 collection_url=collection_url,
                 collection_install=collection_install,
                 output_format=output_format,
@@ -321,7 +324,7 @@ def generate_docs_for_all_collections(  # noqa: C901
         asyncio.run(
             output_callback_indexes(
                 callback_plugin_contents,
-                dest_dir,
+                output,
                 collection_url=collection_url,
                 collection_install=collection_install,
                 output_format=output_format,
@@ -337,7 +340,7 @@ def generate_docs_for_all_collections(  # noqa: C901
         asyncio.run(
             output_indexes(
                 collection_to_plugin_info,
-                dest_dir,
+                output,
                 collection_url=collection_url,
                 collection_install=collection_install,
                 collection_metadata=collection_metadata,
@@ -357,7 +360,7 @@ def generate_docs_for_all_collections(  # noqa: C901
         asyncio.run(
             output_changelogs(
                 collection_to_plugin_info,
-                dest_dir,
+                output,
                 collection_metadata=collection_metadata,
                 squash_hierarchy=squash_hierarchy,
                 output_format=output_format,
@@ -369,7 +372,7 @@ def generate_docs_for_all_collections(  # noqa: C901
         asyncio.run(
             output_all_plugin_stub_rst(
                 stubs_info,
-                dest_dir,
+                output,
                 collection_url=collection_url,
                 collection_install=collection_install,
                 collection_metadata=collection_metadata,
@@ -389,7 +392,7 @@ def generate_docs_for_all_collections(  # noqa: C901
             collection_to_plugin_info,
             new_plugin_info,
             nonfatal_errors,
-            dest_dir,
+            output,
             collection_url=collection_url,
             collection_install=collection_install,
             collection_metadata=collection_metadata,
@@ -408,7 +411,7 @@ def generate_docs_for_all_collections(  # noqa: C901
     if add_extra_docs:
         asyncio.run(
             output_extra_docs(
-                dest_dir, extra_docs_data, squash_hierarchy=squash_hierarchy
+                output, extra_docs_data, squash_hierarchy=squash_hierarchy
             )
         )
         flog.debug("Finished writing extra docs")
@@ -416,7 +419,7 @@ def generate_docs_for_all_collections(  # noqa: C901
     if output_format == OutputFormat.ANSIBLE_DOCSITE:
         asyncio.run(
             output_environment_variables(
-                dest_dir,
+                output,
                 referenced_env_vars,
                 output_format=output_format,
                 filename_generator=filename_generator,

--- a/src/antsibull_docs/cli/doc_commands/_build.py
+++ b/src/antsibull_docs/cli/doc_commands/_build.py
@@ -8,10 +8,11 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import sys
 import textwrap
 import typing as t
-from collections.abc import MutableMapping
+from collections.abc import Mapping, MutableMapping
 
 from antsibull_core.logging import log
 from antsibull_core.venv import FakeVenvRunner, VenvRunner
@@ -19,6 +20,7 @@ from antsibull_core.venv import FakeVenvRunner, VenvRunner
 from ... import app_context
 from ...augment_docs import augment_docs
 from ...collection_links import load_collections_links
+from ...constants import DOCUMENTABLE_PLUGINS
 from ...docs_parsing import AnsibleCollectionMetadata
 from ...docs_parsing.parsing import get_ansible_plugin_info
 from ...docs_parsing.routing import (
@@ -31,7 +33,7 @@ from ...env_variables import (
     collect_referenced_environment_variables,
     load_ansible_config,
 )
-from ...extra_docs import load_collections_extra_docs
+from ...extra_docs import CollectionExtraDocsInfoT, load_collections_extra_docs
 from ...jinja2 import FilenameGenerator, OutputFormat
 from ...process_docs import (
     get_callback_plugin_contents,
@@ -45,6 +47,7 @@ from ...schemas.app_context import (
     DEFAULT_COLLECTION_URL_TRANSFORM,
 )
 from ...utils.collection_name_transformer import CollectionNameTransformer
+from ...write_docs import CollectionInfoT, _get_collection_dir
 from ...write_docs.changelog import output_changelogs
 from ...write_docs.collections import output_extra_docs, output_indexes
 from ...write_docs.hierarchy import (
@@ -56,7 +59,7 @@ from ...write_docs.indexes import (
     output_environment_variables,
     output_plugin_indexes,
 )
-from ...write_docs.io import Output
+from ...write_docs.io import TrackingOutput
 from ...write_docs.plugin_stubs import output_all_plugin_stub_rst
 from ...write_docs.plugins import output_all_plugin_rst
 
@@ -112,6 +115,56 @@ def _validate_options(
         )
 
 
+def _register_plugin_patterns(
+    output: TrackingOutput,
+    collection_to_plugin_info: CollectionInfoT,
+    /,
+    *,
+    filename_generator: FilenameGenerator,
+    output_format: OutputFormat,
+    squash_hierarchy: bool,
+) -> None:
+    for collection_name in collection_to_plugin_info:
+        namespace, collection = collection_name.split(".")
+        collection_dir = _get_collection_dir(
+            output,
+            namespace,
+            collection,
+            squash_hierarchy=squash_hierarchy,
+            create_if_not_exists=False,
+        )
+        for plugin_type in DOCUMENTABLE_PLUGINS:
+            output.register_pattern(
+                collection_dir,
+                filename_generator.plugin_filename(
+                    f"{collection_name}.*", plugin_type, output_format
+                ),
+            )
+
+
+def _register_extra_docs(
+    output: TrackingOutput,
+    extra_docs_data: Mapping[str, CollectionExtraDocsInfoT],
+    /,
+    *,
+    squash_hierarchy: bool,
+) -> None:
+    for collection_name, (dummy, documents) in extra_docs_data.items():
+        namespace, collection = collection_name.split(".", 1)
+        collection_dir = _get_collection_dir(
+            output,
+            namespace,
+            collection,
+            squash_hierarchy=squash_hierarchy,
+            create_if_not_exists=False,
+        )
+        directories = {os.path.join(collection_dir, "docsite")}
+        for _, rel_path in documents:
+            directories.add(os.path.dirname(os.path.join(collection_dir, rel_path)))
+        for directory in sorted(directories):
+            output.register_pattern(directory, "*")
+
+
 def generate_docs_for_all_collections(  # noqa: C901
     venv: VenvRunner | FakeVenvRunner,
     collection_dir: str | None,
@@ -131,6 +184,9 @@ def generate_docs_for_all_collections(  # noqa: C901
     for_official_docsite: bool = False,
     include_collection_name_in_plugins: bool = False,
     add_antsibull_docs_version: bool = True,
+    cleanup: t.Literal[
+        "no", "similar-files", "similar-files-and-dirs", "everything"
+    ] = "no",
 ) -> int:
     """
     Create documentation for a set of installed collections.
@@ -271,7 +327,7 @@ def generate_docs_for_all_collections(  # noqa: C901
         include_collection_name_in_plugins=include_collection_name_in_plugins
     )
 
-    output = Output(dest_dir)
+    output = TrackingOutput(dest_dir)
 
     # Only build top-level index if requested
     if create_indexes:
@@ -319,6 +375,9 @@ def generate_docs_for_all_collections(  # noqa: C901
                 referable_envvars=referable_envvars,
                 add_version=add_antsibull_docs_version,
             )
+        )
+        output.register_pattern(
+            "collections", f"index_*{output_format.output_extension}"
         )
         flog.notice("Finished writing plugin indexes")
         asyncio.run(
@@ -408,6 +467,14 @@ def generate_docs_for_all_collections(  # noqa: C901
     )
     flog.debug("Finished writing plugin docs")
 
+    _register_plugin_patterns(
+        output,
+        collection_to_plugin_info,
+        filename_generator=filename_generator,
+        output_format=output_format,
+        squash_hierarchy=squash_hierarchy,
+    )
+
     if add_extra_docs:
         asyncio.run(
             output_extra_docs(
@@ -415,6 +482,8 @@ def generate_docs_for_all_collections(  # noqa: C901
             )
         )
         flog.debug("Finished writing extra docs")
+
+        _register_extra_docs(output, extra_docs_data, squash_hierarchy=squash_hierarchy)
 
     if output_format == OutputFormat.ANSIBLE_DOCSITE:
         asyncio.run(
@@ -429,5 +498,9 @@ def generate_docs_for_all_collections(  # noqa: C901
             )
         )
         flog.debug("Finished writing environment variables")
+
+    # Cleanup
+    if cleanup != "no":
+        output.cleanup("." if squash_hierarchy else "collections", cleanup)
 
     return 0

--- a/src/antsibull_docs/cli/doc_commands/collection.py
+++ b/src/antsibull_docs/cli/doc_commands/collection.py
@@ -49,6 +49,7 @@ def generate_collection_docs(
         use_html_blobs=app_ctx.use_html_blobs,
         fail_on_error=app_ctx.extra["fail_on_error"],
         add_antsibull_docs_version=app_ctx.add_antsibull_docs_version,
+        cleanup=app_ctx.extra["cleanup"],
     )
 
 

--- a/src/antsibull_docs/cli/doc_commands/collection_plugins.py
+++ b/src/antsibull_docs/cli/doc_commands/collection_plugins.py
@@ -52,6 +52,7 @@ def generate_collection_plugins_docs(
         fail_on_error=app_ctx.extra["fail_on_error"],
         include_collection_name_in_plugins=fqcn_plugin_names,
         add_antsibull_docs_version=app_ctx.add_antsibull_docs_version,
+        cleanup=app_ctx.extra["cleanup"],
     )
 
 

--- a/src/antsibull_docs/cli/doc_commands/current.py
+++ b/src/antsibull_docs/cli/doc_commands/current.py
@@ -47,4 +47,5 @@ def generate_docs() -> int:
         use_html_blobs=app_ctx.use_html_blobs,
         fail_on_error=app_ctx.extra["fail_on_error"],
         add_antsibull_docs_version=app_ctx.add_antsibull_docs_version,
+        cleanup=app_ctx.extra["cleanup"],
     )

--- a/src/antsibull_docs/cli/doc_commands/devel.py
+++ b/src/antsibull_docs/cli/doc_commands/devel.py
@@ -183,4 +183,5 @@ def generate_docs() -> int:
             fail_on_error=app_ctx.extra["fail_on_error"],
             for_official_docsite=True,
             add_antsibull_docs_version=app_ctx.add_antsibull_docs_version,
+            cleanup=app_ctx.extra["cleanup"],
         )

--- a/src/antsibull_docs/cli/doc_commands/plugin.py
+++ b/src/antsibull_docs/cli/doc_commands/plugin.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
 import sys
 import traceback
 
@@ -32,6 +31,7 @@ from ...schemas.app_context import (
     DEFAULT_COLLECTION_URL_TRANSFORM,
 )
 from ...utils.collection_name_transformer import CollectionNameTransformer
+from ...write_docs.io import Output
 from ...write_docs.plugins import write_plugin_rst
 
 mlog = log.fields(mod=__name__)
@@ -42,7 +42,10 @@ def generate_plugin_docs(
     plugin_name: str,
     collection_name: str,
     plugin: str,
-    output_path: str,
+    /,
+    *,
+    output_dir: str,
+    output_filename: str,
     output_format: OutputFormat,
     filename_generator: FilenameGenerator,
     add_antsibull_docs_version: bool,
@@ -134,10 +137,10 @@ def generate_plugin_docs(
             errors,
             plugin_tmpl,
             error_tmpl,
-            "",
+            Output(output_dir),
             output_format,
             filename_generator,
-            path_override=output_path,
+            path_override=output_filename,
             use_html_blobs=app_ctx.use_html_blobs,
             add_version=add_antsibull_docs_version,
         )
@@ -164,10 +167,6 @@ def generate_docs() -> int:
     plugin_name: str = app_ctx.extra["plugin"][0]
     output_format = OutputFormat.parse(app_ctx.extra["output_format"])
 
-    output_path = os.path.join(
-        app_ctx.extra["dest_dir"], f"{plugin_name}_{plugin_type}.rst"
-    )
-
     try:
         namespace, collection, plugin = get_fqcn_parts(plugin_name)
     except ValueError:
@@ -183,8 +182,9 @@ def generate_docs() -> int:
         plugin_name,
         collection_name,
         plugin,
-        output_path,
-        output_format,
-        filename_generator,
+        output_dir=app_ctx.extra["dest_dir"],
+        output_filename=f"{plugin_name}_{plugin_type}.{output_format.output_extension}",
+        output_format=output_format,
+        filename_generator=filename_generator,
         add_antsibull_docs_version=app_ctx.add_antsibull_docs_version,
     )

--- a/src/antsibull_docs/cli/doc_commands/stable.py
+++ b/src/antsibull_docs/cli/doc_commands/stable.py
@@ -185,4 +185,5 @@ def generate_docs() -> int:
             fail_on_error=app_ctx.extra["fail_on_error"],
             for_official_docsite=True,
             add_antsibull_docs_version=app_ctx.add_antsibull_docs_version,
+            cleanup=app_ctx.extra["cleanup"],
         )

--- a/src/antsibull_docs/data/sphinx_init/_gitignore.j2
+++ b/src/antsibull_docs/data/sphinx_init/_gitignore.j2
@@ -4,5 +4,4 @@
 
 # Created with antsibull-docs @{ antsibull_docs_version }@
 
-/temp-rst
 /build

--- a/src/antsibull_docs/data/sphinx_init/build_sh.j2
+++ b/src/antsibull_docs/data/sphinx_init/build_sh.j2
@@ -10,15 +10,15 @@ set -e
 pushd "$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 trap "{ popd; }" EXIT
 
-# Create collection documentation into temporary directory
-rm -rf temp-rst
-mkdir -p temp-rst
-chmod og-w temp-rst  # antsibull-docs wants that directory only readable by itself
+# Create collection documentation
+mkdir -p rst
+chmod og-w rst  # antsibull-docs wants that directory only readable by itself
 antsibull-docs \
     --config-file antsibull-docs.cfg \
 {% if use_current %}
 {%   if collections | length > 0 %}
     collection \
+    --cleanup everything \
 {%     if fail_on_error %}
     --fail-on-error \
 {%     endif %}
@@ -26,17 +26,19 @@ antsibull-docs \
 {%     if squash_hierarchy %}
     --squash-hierarchy \
 {%     endif %}
-    --dest-dir temp-rst \
+    --dest-dir rst \
     @{ ' '.join(collections) }@
 {%   else %}
     current \
+    --cleanup everything \
 {%     if fail_on_error %}
     --fail-on-error \
 {%     endif %}
-    --dest-dir temp-rst
+    --dest-dir rst
 {%   endif %}
 {% else %}
     collection \
+    --cleanup everything \
 {%     if fail_on_error %}
     --fail-on-error \
 {%     endif %}
@@ -47,15 +49,8 @@ antsibull-docs \
     --squash-hierarchy \
 {%     endif %}
     --output-format @{ output_format }@ \
-    --dest-dir temp-rst \
+    --dest-dir rst \
     @{ ' '.join(collections) }@
-{% endif %}
-
-# Copy collection documentation into source directory
-{% if squash_hierarchy %}
-rsync -cprv --delete-after temp-rst/ rst/
-{% else %}
-rsync -cprv --delete-after temp-rst/collections/ rst/collections/
 {% endif %}
 
 # Build Sphinx site

--- a/src/antsibull_docs/write_docs/__init__.py
+++ b/src/antsibull_docs/write_docs/__init__.py
@@ -16,6 +16,7 @@ from jinja2 import Template
 import antsibull_docs
 
 from ..utils.text import sanitize_whitespace as _sanitize_whitespace
+from .io import Output
 
 mlog = log.fields(mod=__name__)
 
@@ -56,33 +57,30 @@ def _render_template(
 
 
 def _get_collection_dir(
-    dest_dir: str,
+    output: Output,
     namespace: str,
     collection: str,
     /,
+    *,
     squash_hierarchy: bool = False,
     create_if_not_exists: bool = False,
 ):
     """
-    Compose collection directory.
+    Compose collection directory, for consumption by ``Output``.
 
-    :arg dest_dir: Destination directory for the plugin data.  For instance,
-        :file:`ansible-checkout/docs/docsite/rst/`.  The directory structure underneath this
-        directory will be created if needed.
+    :arg output: Output helper for writing output.
     :arg namespace: The collection's namespace.
     :arg collection: The collection's name.
     :kwarg squash_hierarchy: If set to ``True``, no directory hierarchy will be used.
                              Undefined behavior if documentation for multiple collections are
                              created.
     :kwarg create_if_not_exists: If set to ``True``, the directory will be created if it does
-                                 not exist. The ``dest_dir`` is assumed to exist.
+                                 not exist.
     """
     if squash_hierarchy:
-        return dest_dir
+        return "."
 
-    collection_dir = os.path.join(dest_dir, "collections", namespace, collection)
+    collection_dir = os.path.join("collections", namespace, collection)
     if create_if_not_exists:
-        # This is dangerous but the code that takes dest_dir from the user checks
-        # permissions on it to make it as safe as possible.
-        os.makedirs(collection_dir, mode=0o755, exist_ok=True)
+        output.ensure_directory(collection_dir)
     return collection_dir

--- a/src/antsibull_docs/write_docs/io.py
+++ b/src/antsibull_docs/write_docs/io.py
@@ -1,0 +1,62 @@
+# Author: Toshio Kuratomi <tkuratom@redhat.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2020, Ansible Project
+"""Output helpers."""
+
+from __future__ import annotations
+
+import os
+import typing as t
+
+from antsibull_core.utils.io import copy_file as _copy_file
+from antsibull_core.utils.io import write_file as _write_file
+
+if t.TYPE_CHECKING:
+    from _typeshed import StrOrBytesPath
+
+
+class Output:
+    """
+    Thread-safe class that allows to create directories and copy/write files into the output tree.
+    """
+
+    def __init__(self, root: StrOrBytesPath):
+        """
+        Create Output object.
+
+        ``root`` is assumed to be an existing directory the user can write to.
+        """
+        self.root = root
+
+    def ensure_directory(self, directory: StrOrBytesPath, /):
+        """
+        Ensure that the directory (relative to our root) exists.
+        """
+        path = os.path.join(self.root, directory)  # type: ignore
+        # This is dangerous but the code that takes dest_dir from the user checks
+        # permissions on it to make it as safe as possible.
+        os.makedirs(path, mode=0o755, exist_ok=True)
+
+    async def write_file(self, filename: StrOrBytesPath, /, content: str):
+        """
+        Write the given text content to a file (relative to our root).
+        """
+        path = os.path.join(self.root, filename)  # type: ignore
+        await _write_file(path, content)
+
+    async def copy_file(
+        self,
+        source_path: StrOrBytesPath,
+        dest_path: StrOrBytesPath,
+        /,
+        *,
+        check_content: bool = True,
+    ):
+        """
+        Copy the given ``source_path`` (relative to CWD) to the ``dest_path``
+        (relative to our root).
+        """
+        src_path = os.path.join(self.root, dest_path)  # type: ignore
+        await _copy_file(source_path, src_path, check_content=check_content)

--- a/src/antsibull_docs/write_docs/plugin_stubs.py
+++ b/src/antsibull_docs/write_docs/plugin_stubs.py
@@ -16,7 +16,6 @@ from collections.abc import Mapping
 import asyncio_pool  # type: ignore[import]
 from antsibull_core import app_context
 from antsibull_core.logging import log
-from antsibull_core.utils.io import write_file
 from jinja2 import Template
 
 from ..collection_links import CollectionLinks
@@ -25,6 +24,7 @@ from ..jinja2 import FilenameGenerator, OutputFormat
 from ..jinja2.environment import doc_environment, get_template_filename
 from ..utils.collection_name_transformer import CollectionNameTransformer
 from . import _get_collection_dir, _render_template
+from .io import Output
 
 mlog = log.fields(mod=__name__)
 
@@ -38,7 +38,7 @@ async def write_stub_rst(
     routing_data: Mapping[str, t.Any],
     redirect_tmpl: Template,
     tombstone_tmpl: Template,
-    dest_dir: str,
+    output: Output,
     output_format: OutputFormat,
     filename_generator: FilenameGenerator,
     path_override: str | None = None,
@@ -58,9 +58,7 @@ async def write_stub_rst(
         redirect, redirect_is_symlink are the optional toplevel fields.
     :arg redirect_tmpl: Template for redirects.
     :arg tombstone_tmpl: Template for tombstones.
-    :arg dest_dir: Destination directory for the plugin data.  For instance,
-        :file:`ansible-checkout/docs/docsite/rst/`.  The directory structure underneath this
-        directory will be created if needed.
+    :arg output: Output helper for writing output.
     :arg squash_hierarchy: If set to ``True``, no directory hierarchy will be used.
                            Undefined behavior if documentation for multiple collections are
                            created.
@@ -110,7 +108,7 @@ async def write_stub_rst(
         plugin_file = path_override
     else:
         collection_dir = _get_collection_dir(
-            dest_dir,
+            output,
             namespace,
             collection,
             squash_hierarchy=squash_hierarchy,
@@ -122,14 +120,14 @@ async def write_stub_rst(
             filename_generator.plugin_filename(plugin_name, plugin_type, output_format),
         )
 
-    await write_file(plugin_file, plugin_contents)
+    await output.write_file(plugin_file, plugin_contents)
 
     flog.debug("Leave")
 
 
 async def output_all_plugin_stub_rst(
     stubs_info: Mapping[str, Mapping[str, Mapping[str, t.Any]]],
-    dest_dir: str,
+    output: Output,
     collection_url: CollectionNameTransformer,
     collection_install: CollectionNameTransformer,
     collection_metadata: Mapping[str, AnsibleCollectionMetadata],
@@ -146,7 +144,7 @@ async def output_all_plugin_stub_rst(
 
     :arg stubs_info: Mapping of collection_name to Mapping of plugin_type to Mapping
         of plugin_name to routing information.
-    :arg dest_dir: The directory to place the documentation in.
+    :arg output: Output helper for writing output.
     :arg collection_metadata: Dictionary mapping collection names to collection metadata objects.
     :arg link_data: Dictionary mapping collection names to CollectionLinks.
     :arg squash_hierarchy: If set to ``True``, no directory hierarchy will be used.
@@ -192,7 +190,7 @@ async def output_all_plugin_stub_rst(
                                 routing_data,
                                 redirect_tmpl,
                                 tombstone_tmpl,
-                                dest_dir,
+                                output,
                                 output_format,
                                 filename_generator,
                                 squash_hierarchy=squash_hierarchy,

--- a/tests/functional/baseline-sphinx-init-collections/.gitignore
+++ b/tests/functional/baseline-sphinx-init-collections/.gitignore
@@ -4,5 +4,4 @@
 
 # Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
-/temp-rst
 /build

--- a/tests/functional/baseline-sphinx-init-collections/build.sh
+++ b/tests/functional/baseline-sphinx-init-collections/build.sh
@@ -10,19 +10,16 @@ set -e
 pushd "$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 trap "{ popd; }" EXIT
 
-# Create collection documentation into temporary directory
-rm -rf temp-rst
-mkdir -p temp-rst
-chmod og-w temp-rst  # antsibull-docs wants that directory only readable by itself
+# Create collection documentation
+mkdir -p rst
+chmod og-w rst  # antsibull-docs wants that directory only readable by itself
 antsibull-docs \
     --config-file antsibull-docs.cfg \
     collection \
+    --cleanup everything \
     --output-format ansible-docsite \
-    --dest-dir temp-rst \
+    --dest-dir rst \
     ns.col1 ns.col2 ns2.col
-
-# Copy collection documentation into source directory
-rsync -cprv --delete-after temp-rst/collections/ rst/collections/
 
 # Build Sphinx site
 sphinx-build -M html rst build -c . -W --keep-going

--- a/tests/functional/baseline-sphinx-init-config/.gitignore
+++ b/tests/functional/baseline-sphinx-init-config/.gitignore
@@ -4,5 +4,4 @@
 
 # Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
-/temp-rst
 /build

--- a/tests/functional/baseline-sphinx-init-config/build.sh
+++ b/tests/functional/baseline-sphinx-init-config/build.sh
@@ -10,21 +10,18 @@ set -e
 pushd "$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 trap "{ popd; }" EXIT
 
-# Create collection documentation into temporary directory
-rm -rf temp-rst
-mkdir -p temp-rst
-chmod og-w temp-rst  # antsibull-docs wants that directory only readable by itself
+# Create collection documentation
+mkdir -p rst
+chmod og-w rst  # antsibull-docs wants that directory only readable by itself
 antsibull-docs \
     --config-file antsibull-docs.cfg \
     collection \
+    --cleanup everything \
     --fail-on-error \
     --squash-hierarchy \
     --output-format ansible-docsite \
-    --dest-dir temp-rst \
+    --dest-dir rst \
     ns.col1
-
-# Copy collection documentation into source directory
-rsync -cprv --delete-after temp-rst/ rst/
 
 # Build Sphinx site
 sphinx-build -M html rst build -c .

--- a/tests/functional/baseline-sphinx-init-current/.gitignore
+++ b/tests/functional/baseline-sphinx-init-current/.gitignore
@@ -4,5 +4,4 @@
 
 # Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
-/temp-rst
 /build

--- a/tests/functional/baseline-sphinx-init-current/build.sh
+++ b/tests/functional/baseline-sphinx-init-current/build.sh
@@ -10,17 +10,14 @@ set -e
 pushd "$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 trap "{ popd; }" EXIT
 
-# Create collection documentation into temporary directory
-rm -rf temp-rst
-mkdir -p temp-rst
-chmod og-w temp-rst  # antsibull-docs wants that directory only readable by itself
+# Create collection documentation
+mkdir -p rst
+chmod og-w rst  # antsibull-docs wants that directory only readable by itself
 antsibull-docs \
     --config-file antsibull-docs.cfg \
     current \
-    --dest-dir temp-rst
-
-# Copy collection documentation into source directory
-rsync -cprv --delete-after temp-rst/collections/ rst/collections/
+    --cleanup everything \
+    --dest-dir rst
 
 # Build Sphinx site
 sphinx-build -M html rst build -c . -W --keep-going

--- a/tests/functional/baseline-sphinx-init-extra/.gitignore
+++ b/tests/functional/baseline-sphinx-init-extra/.gitignore
@@ -4,5 +4,4 @@
 
 # Created with antsibull-docs <ANTSIBULL_DOCS_VERSION>
 
-/temp-rst
 /build

--- a/tests/functional/baseline-sphinx-init-extra/build.sh
+++ b/tests/functional/baseline-sphinx-init-extra/build.sh
@@ -10,19 +10,16 @@ set -e
 pushd "$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 trap "{ popd; }" EXIT
 
-# Create collection documentation into temporary directory
-rm -rf temp-rst
-mkdir -p temp-rst
-chmod og-w temp-rst  # antsibull-docs wants that directory only readable by itself
+# Create collection documentation
+mkdir -p rst
+chmod og-w rst  # antsibull-docs wants that directory only readable by itself
 antsibull-docs \
     --config-file antsibull-docs.cfg \
     collection \
+    --cleanup everything \
     --output-format ansible-docsite \
-    --dest-dir temp-rst \
+    --dest-dir rst \
     ns.col1
-
-# Copy collection documentation into source directory
-rsync -cprv --delete-after temp-rst/collections/ rst/collections/
 
 # Build Sphinx site
 sphinx-build -M html rst build -c . -W --keep-going


### PR DESCRIPTION
Adds a `--cleanup` option that allows to delete files and directories in the destination directory that were not generated by antsibull-docs. This is then used by the `sphinx-init` subcommand to generate a build script that doesn't need `rsync`.

Fixes #306.
Closes #307.