### PR TITLE
Update CI and instructions for antsibull-fileutils; add explicit dependency on antsibull-fileutils

### DIFF
--- a/.github/workflows/antsibull-docs.yml
+++ b/.github/workflows/antsibull-docs.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[coverage] ../antsibull-core ../antsibull-docs-parser
+          pip install -e .[coverage] ../antsibull-core ../antsibull-changelog ../antsibull-docs-parser ../antsibull-docutils ../antsibull-fileutils
         working-directory: antsibull-docs
 
       - name: Use antsibull-docs sphinx-init
@@ -201,6 +201,18 @@ jobs:
           repository: ansible-community/antsibull-changelog
           path: antsibull-changelog
 
+      - name: Check out dependent project antsibull-docutils
+        uses: actions/checkout@v4
+        with:
+          repository: ansible-community/antsibull-docutils
+          path: antsibull-docutils
+
+      - name: Check out dependent project antsibull-fileutils
+        uses: actions/checkout@v4
+        with:
+          repository: ansible-community/antsibull-fileutils
+          path: antsibull-fileutils
+
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
@@ -209,7 +221,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[coverage] ../antsibull-core ../antsibull-docs-parser
+          pip install -e .[coverage] ../antsibull-core ../antsibull-changelog ../antsibull-docs-parser ../antsibull-docutils ../antsibull-fileutils
         working-directory: antsibull-docs
 
       - name: Get hold of deps file
@@ -265,6 +277,18 @@ jobs:
           repository: ansible-community/antsibull-changelog
           path: antsibull-changelog
 
+      - name: Check out dependent project antsibull-docutils
+        uses: actions/checkout@v4
+        with:
+          repository: ansible-community/antsibull-docutils
+          path: antsibull-docutils
+
+      - name: Check out dependent project antsibull-fileutils
+        uses: actions/checkout@v4
+        with:
+          repository: ansible-community/antsibull-fileutils
+          path: antsibull-fileutils
+
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
@@ -273,7 +297,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[coverage] ../antsibull-core ../antsibull-docs-parser
+          pip install -e .[coverage] ../antsibull-core ../antsibull-changelog ../antsibull-docs-parser ../antsibull-docutils ../antsibull-fileutils
         working-directory: antsibull-docs
 
       - name: Get hold of ansible.in file

--- a/.github/workflows/antsibull-docs.yml
+++ b/.github/workflows/antsibull-docs.yml
@@ -40,6 +40,8 @@ jobs:
           - main
         antsibull_docutils_ref:
           - main
+        antsibull_fileutils_ref:
+          - main
         include:
           - options: '--use-current --use-html-blobs --no-breadcrumbs community.crypto community.docker --extra-conf antsibull_ext_color_scheme=none'
             python: '3.9'
@@ -79,6 +81,13 @@ jobs:
           repository: ansible-community/antsibull-docutils
           path: antsibull-docutils
           ref: ${{ matrix.antsibull_docutils_ref }}
+
+      - name: Check out dependent project antsibull-fileutils
+        uses: actions/checkout@v4
+        with:
+          repository: ansible-community/antsibull-fileutils
+          path: antsibull-fileutils
+          ref: ${{ matrix.antsibull_fileutils_ref }}
 
       - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v5

--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -68,6 +68,11 @@ jobs:
         with:
           repository: ansible-community/antsibull-docutils
           path: antsibull-docutils
+      - name: Check out dependent project antsibull-fileutils
+        uses: actions/checkout@v4
+        with:
+          repository: ansible-community/antsibull-fileutils
+          path: antsibull-fileutils
       - name: Install extra packages
         if: "matrix.packages != ''"
         run: |

--- a/README.md
+++ b/README.md
@@ -41,18 +41,20 @@ and install the requirements needed to run the tests there.
 
 ---
 
-antsibull-docs depends on the sister antsibull-changelog, antsibull-core, and
-antsibull-docs-parser projects.
+antsibull-docs depends on the sister antsibull-changelog, antsibull-core,
+antsibull-docs-parser, antsibull-docutils, and antsibull-fileutils projects.
 By default, `nox` will install a development version of these projects from Github.
-If you're hacking on antsibull-changelog, antsibull-core, antsibull-docs-parser, and/or
-antsibull-docutils alongside antsibull-docs, nox will automatically install the projects
-from  `../antsibull-changelog`, `../antsibull-core`, `../antsibull-docs-parser`, and
-`../antsibull-docutils` when running tests if those paths exist.
+If you're hacking on antsibull-changelog, antsibull-core, antsibull-docs-parser,
+antsibull-docutils, and/or antsibull-fileutils alongside antsibull-docs,
+nox will automatically install the projects from  `../antsibull-changelog`,
+`../antsibull-core`, `../antsibull-docs-parser`, `../antsibull-docutils`,
+and `../antsibull-fileutils` when running tests if those paths exist.
 You can change this behavior through the `OTHER_ANTSIBULL_MODE` env var:
 
 - `OTHER_ANTSIBULL_MODE=auto` — the default behavior described above
 - `OTHER_ANTSIBULL_MODE=local` — install the projects from `../antsibull-changelog`,
-  `../antsibull-core`, `../antsibull-docs-parser`, and `../antsibull-docutils`.
+  `../antsibull-core`, `../antsibull-docs-parser`, `../antsibull-docutils`, and
+  `../antsibull-fileutils`.
   Fail if those paths don't exist.
 - `OTHER_ANTSIBULL_MODE=git` — install the projects from the Github main branch
 - `OTHER_ANTSIBULL_MODE=pypi` — install the latest versions from PyPI

--- a/changelogs/fragments/322-antsibull-fileutils.yml
+++ b/changelogs/fragments/322-antsibull-fileutils.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - "Add dependency on antsibull-fileutils. Some functionality from antsibull-core is moving there, so we can use it from there directly
+     (https://github.com/ansible-community/antsibull-docs/pull/322)."

--- a/noxfile.py
+++ b/noxfile.py
@@ -47,6 +47,7 @@ def other_antsibull(
         "antsibull-core",
         "antsibull-docs-parser",
         "antsibull-docutils",
+        "antsibull-fileutils",
     )
     for project in args:
         path = Path("../", project)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "antsibull-changelog >= 0.24.0",
     "antsibull-core >= 2.1.0, < 4.0.0",
     "antsibull-docs-parser >= 1.1.0, < 2.0.0",
+    "antsibull-fileutils >= 1.0.0, < 2.0.0",
     "asyncio-pool",
     "docutils",
     "jinja2 >= 3.0",

--- a/src/antsibull_docs/collection_config.py
+++ b/src/antsibull_docs/collection_config.py
@@ -14,7 +14,7 @@ from collections.abc import Mapping
 import asyncio_pool  # type: ignore[import]
 from antsibull_core import app_context
 from antsibull_core.logging import log
-from antsibull_core.yaml import load_yaml_file
+from antsibull_fileutils.yaml import load_yaml_file
 
 from antsibull_docs._pydantic_compat import v1
 

--- a/src/antsibull_docs/collection_links.py
+++ b/src/antsibull_docs/collection_links.py
@@ -15,7 +15,7 @@ from collections.abc import Mapping
 import asyncio_pool  # type: ignore[import]
 from antsibull_core import app_context
 from antsibull_core.logging import log
-from antsibull_core.yaml import load_yaml_file
+from antsibull_fileutils.yaml import load_yaml_file
 
 from antsibull_docs._pydantic_compat import v1
 

--- a/src/antsibull_docs/docs_parsing/routing.py
+++ b/src/antsibull_docs/docs_parsing/routing.py
@@ -17,8 +17,9 @@ from collections import defaultdict
 from collections.abc import Mapping, MutableMapping, Sequence
 
 import asyncio_pool  # type: ignore[import]
-from antsibull_core import app_context, yaml
+from antsibull_core import app_context
 from antsibull_core.utils.collections import compare_all_but
+from antsibull_fileutils import yaml
 
 from ..constants import DOCUMENTABLE_PLUGINS
 from ..utils.get_pkg_data import get_antsibull_data

--- a/src/antsibull_docs/env_variables.py
+++ b/src/antsibull_docs/env_variables.py
@@ -12,7 +12,7 @@ import os.path
 import typing as t
 from collections.abc import Generator, Mapping
 
-from antsibull_core import yaml
+from antsibull_fileutils import yaml
 
 from .docs_parsing import AnsibleCollectionMetadata
 

--- a/src/antsibull_docs/extra_docs.py
+++ b/src/antsibull_docs/extra_docs.py
@@ -17,7 +17,7 @@ from collections.abc import Mapping
 import asyncio_pool  # type: ignore[import]
 from antsibull_core import app_context
 from antsibull_core.logging import log
-from antsibull_core.utils.io import read_file
+from antsibull_fileutils.io import read_file
 from antsibull_fileutils.yaml import load_yaml_file
 
 mlog = log.fields(mod=__name__)

--- a/src/antsibull_docs/extra_docs.py
+++ b/src/antsibull_docs/extra_docs.py
@@ -18,7 +18,7 @@ import asyncio_pool  # type: ignore[import]
 from antsibull_core import app_context
 from antsibull_core.logging import log
 from antsibull_core.utils.io import read_file
-from antsibull_core.yaml import load_yaml_file
+from antsibull_fileutils.yaml import load_yaml_file
 
 mlog = log.fields(mod=__name__)
 

--- a/src/antsibull_docs/lint_helpers.py
+++ b/src/antsibull_docs/lint_helpers.py
@@ -12,7 +12,7 @@ import os
 import os.path
 import typing as t
 
-from antsibull_core.yaml import load_yaml_file
+from antsibull_fileutils.yaml import load_yaml_file
 
 
 def load_collection_info(path_to_collection: str) -> dict[str, t.Any]:

--- a/src/antsibull_docs/schemas/docs/base.py
+++ b/src/antsibull_docs/schemas/docs/base.py
@@ -122,7 +122,7 @@ import abc
 import typing as t
 from collections.abc import Mapping
 
-from antsibull_core.yaml import load_yaml_bytes
+from antsibull_fileutils.yaml import load_yaml_bytes
 
 from antsibull_docs._pydantic_compat import v1 as p
 from antsibull_docs.vendored.ansible import (  # type: ignore[import]

--- a/src/antsibull_docs/write_docs/io.py
+++ b/src/antsibull_docs/write_docs/io.py
@@ -14,9 +14,10 @@ import typing as t
 from collections import defaultdict
 from threading import Lock
 
+from antsibull_core import app_context
 from antsibull_core.logging import log
-from antsibull_core.utils.io import copy_file as _copy_file
-from antsibull_core.utils.io import write_file as _write_file
+from antsibull_fileutils.io import copy_file as _copy_file
+from antsibull_fileutils.io import write_file as _write_file
 
 if t.TYPE_CHECKING:
     from _typeshed import StrOrBytesPath
@@ -51,7 +52,8 @@ class Output:
         Write the given text content to a file (relative to our root).
         """
         path = os.path.join(self.root, filename)  # type: ignore
-        await _write_file(path, content)
+        lib_ctx = app_context.lib_ctx.get()
+        await _write_file(path, content, file_check_content=lib_ctx.file_check_content)
 
     async def copy_file(
         self,
@@ -66,7 +68,14 @@ class Output:
         (relative to our root).
         """
         src_path = os.path.join(self.root, dest_path)  # type: ignore
-        await _copy_file(source_path, src_path, check_content=check_content)
+        lib_ctx = app_context.lib_ctx.get()
+        await _copy_file(
+            source_path,
+            src_path,
+            check_content=check_content,
+            file_check_content=lib_ctx.file_check_content,
+            chunksize=lib_ctx.chunksize,
+        )
 
 
 class TrackingOutput(Output):

--- a/src/sphinx_antsibull_ext/directive_helper.py
+++ b/src/sphinx_antsibull_ext/directive_helper.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import abc
 import typing as t
 
-from antsibull_core.yaml import load_yaml_bytes
+from antsibull_fileutils.yaml import load_yaml_bytes
 from docutils import nodes
 from docutils.parsers.rst import Directive
 


### PR DESCRIPTION
- [x] Wait for https://github.com/ansible-community/antsibull-fileutils/pull/1 to be merged
- [x] Use that code
- [x] Wait for antsibull-fileutils 1.0.0 release
- [x] Remove `a1` in version bound
- [x] Remove `[TEMP]` commits