### PR TITLE
Docsite: add Community guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ You can find a list of changes in [the antsibull-docs changelog](https://github.
 
 antsibull-docs is covered by the [Ansible Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html).
 
+## Community
+
+Need help or want to discuss the project? See our [Community guide](https://ansible.readthedocs.io/projects/antsibull-docs/community/) to learn how to join the conversation!
+
 ## Versioning and compatibility
 
 From version 1.0.0 on, antsibull-docs sticks to semantic versioning and aims at providing no backwards compatibility breaking changes **to the command line API (antsibull-docs)** during a major release cycle. We might make exceptions from this in case of security fixes for vulnerabilities that are severe enough.

--- a/docs/community.md
+++ b/docs/community.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (c) Ansible Project
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+-->
+
 # Community
 
 We welcome your feedback, questions and ideas. Here's how to reach the community.

--- a/docs/community.md
+++ b/docs/community.md
@@ -1,0 +1,14 @@
+# Community
+
+We welcome your feedback, questions and ideas. Here's how to reach the community.
+
+## Forum
+
+Join the [Ansible Forum](https://forum.ansible.com) as a single starting point and our default communication platform for questions and help, development discussions, events, and much more. [Register](https://forum.ansible.com/signup?) to join the community. Search by categories and tags to find interesting topics or start a new one; subscribe only to topics you need!
+
+* [Get Help](https://forum.ansible.com/c/help/6): get help or help others. Please add appropriate tags if you start new discussions, for example `antsibull`.
+* [Posts tagged with 'antsibull'](https://forum.ansible.com/tag/antsibull): subscribe to participate in project-related conversations.
+* [Social Spaces](https://forum.ansible.com/c/chat/4): gather and interact with fellow enthusiasts.
+* [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide announcements including social events. The [Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn), which is used to announce releases and important changes, can also be found here.
+
+For more information on the forum navigation, see [Navigating the Ansible forum](https://forum.ansible.com/t/navigating-the-ansible-forum-tags-categories-and-concepts/39) post.

--- a/docs/community.md
+++ b/docs/community.md
@@ -12,9 +12,12 @@ We welcome your feedback, questions and ideas. Here's how to reach the community
 
 Join the [Ansible Forum](https://forum.ansible.com) as a single starting point and our default communication platform for questions and help, development discussions, events, and much more. [Register](https://forum.ansible.com/signup?) to join the community. Search by categories and tags to find interesting topics or start a new one; subscribe only to topics you need!
 
-* [Get Help](https://forum.ansible.com/c/help/6): get help or help others. Please add appropriate tags if you start new discussions, for example `antsibull`.
 * [Posts tagged with 'antsibull'](https://forum.ansible.com/tag/antsibull): subscribe to participate in project-related conversations.
 * [Social Spaces](https://forum.ansible.com/c/chat/4): gather and interact with fellow enthusiasts.
 * [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide announcements including social events. The [Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn), which is used to announce releases and important changes, can also be found here.
 
-For more information on the forum navigation, see [Navigating the Ansible forum](https://forum.ansible.com/t/navigating-the-ansible-forum-tags-categories-and-concepts/39) post.
+For more information on the forum navigation, see the [Navigating the Ansible forum](https://forum.ansible.com/t/navigating-the-ansible-forum-tags-categories-and-concepts/39) post.
+
+## Matrix
+
+For real-time interactions, join the [#antsibull:ansible.com](https://matrix.to/#/#antsibull:ansible.com) Matrix channel. See the [Ansible communication guide](https://docs.ansible.com/ansible/devel/community/communication.html#real-time-chat) for more information.

--- a/docs/community.md
+++ b/docs/community.md
@@ -10,7 +10,7 @@ We welcome your feedback, questions and ideas. Here's how to reach the community
 
 ## Forum
 
-Join the [Ansible Forum](https://forum.ansible.com) as a single starting point and our default communication platform for questions and help, development discussions, events, and much more. [Register](https://forum.ansible.com/signup?) to join the community. Search by categories and tags to find interesting topics or start a new one; subscribe only to topics you need!
+Join the [Ansible Forum](https://forum.ansible.com) as a single starting point and our default communication platform for questions and help, development discussions, events, and much more. [Register on the Forum](https://forum.ansible.com/signup?) to join the community. Search by categories and tags to find interesting topics or start a new one; subscribe only to topics you need!
 
 * [Posts tagged with 'antsibull'](https://forum.ansible.com/tag/antsibull): subscribe to participate in project-related conversations.
 * [Social Spaces](https://forum.ansible.com/c/chat/4): gather and interact with fellow enthusiasts.
@@ -20,4 +20,4 @@ For more information on the forum navigation, see the [Navigating the Ansible fo
 
 ## Matrix
 
-For real-time interactions, join the [#antsibull:ansible.com](https://matrix.to/#/#antsibull:ansible.com) Matrix channel. See the [Ansible communication guide](https://docs.ansible.com/ansible/devel/community/communication.html#real-time-chat) for more information.
+For real-time interactions, join the [#antsibull:ansible.com Matrix room](https://matrix.to/#/#antsibull:ansible.com). See the [Ansible communication guide](https://docs.ansible.com/ansible/devel/community/communication.html#real-time-chat) for more information on Matrix.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,8 @@ This package provides tooling for validating and building Ansible documentation.
 
 antsibull-docs is covered by the [Ansible Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html).
 
-> Need help or want to discuss the project? See our [Community guide](community.md) to learn how to join the conversation!
+!!! note
+    Need help or want to discuss the project? See our [Community guide](community.md) to learn how to join the conversation!
 
 ## `antsibull-docs` subcommands
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,8 @@ SPDX-License-Identifier: GPL-3.0-or-later
 [![Discuss on Matrix at #antsibull:ansible.com](https://img.shields.io/matrix/antsibull:ansible.com.svg?server_fqdn=ansible-accounts.ems.host&label=Discuss%20on%20Matrix%20at%20%23antsibull:ansible.com&logo=matrix)](https://matrix.to/#/#antsibull:ansible.com)
 [![Discuss on Matrix at #docs:ansible.com](https://img.shields.io/matrix/docs:ansible.com.svg?server_fqdn=ansible-accounts.ems.host&label=Discuss%20on%20Matrix%20at%20%23docs:ansible.com&logo=matrix)](https://matrix.to/#/#docs:ansible.com)
 
+> Need help or want to discuss the project? See our [Community guide](https://ansible.readthedocs.io/projects/antsibull-docs/community/) to learn how to join the conversation!
+
 This package provides tooling for validating and building Ansible documentation. It mainly consists of a CLI tool, `antsibull-docs`, and a Sphinx extension. The main output format are [reStructured Text (RST)](https://en.wikipedia.org/wiki/ReStructuredText) files for consumption by [Sphinx](https://en.wikipedia.org/wiki/Sphinx_\(documentation_generator\)).
 
 **Collection maintainers and authors should look at the [Creating a collection docsite](collection-docs.md) section of this docsite.**

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,13 +9,13 @@ SPDX-License-Identifier: GPL-3.0-or-later
 [![Discuss on Matrix at #antsibull:ansible.com](https://img.shields.io/matrix/antsibull:ansible.com.svg?server_fqdn=ansible-accounts.ems.host&label=Discuss%20on%20Matrix%20at%20%23antsibull:ansible.com&logo=matrix)](https://matrix.to/#/#antsibull:ansible.com)
 [![Discuss on Matrix at #docs:ansible.com](https://img.shields.io/matrix/docs:ansible.com.svg?server_fqdn=ansible-accounts.ems.host&label=Discuss%20on%20Matrix%20at%20%23docs:ansible.com&logo=matrix)](https://matrix.to/#/#docs:ansible.com)
 
-> Need help or want to discuss the project? See our [Community guide](https://ansible.readthedocs.io/projects/antsibull-docs/community/) to learn how to join the conversation!
-
 This package provides tooling for validating and building Ansible documentation. It mainly consists of a CLI tool, `antsibull-docs`, and a Sphinx extension. The main output format are [reStructured Text (RST)](https://en.wikipedia.org/wiki/ReStructuredText) files for consumption by [Sphinx](https://en.wikipedia.org/wiki/Sphinx_\(documentation_generator\)).
 
 **Collection maintainers and authors should look at the [Creating a collection docsite](collection-docs.md) section of this docsite.**
 
 antsibull-docs is covered by the [Ansible Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html).
+
+> Need help or want to discuss the project? See our [Community guide](community.md) to learn how to join the conversation!
 
 ## `antsibull-docs` subcommands
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,4 +32,5 @@ nav:
   - antsibull-docs: index.md
   - Creating a collection docsite: collection-docs.md
   - Official Ansible docsite: package-docs.md
+  - Join the Community: community.md
   - antsibull-docs Release Notes: changelog.md


### PR DESCRIPTION
Dear maintainers,
As a part of the [Consolidating Ansible discussion platforms initiative](https://forum.ansible.com/t/proposal-consolidating-ansible-discussion-platforms/6812), this PR adds the communication section template defined by the community to the README and the docsite. Similar PRs are now being raised across all the Ansible ecosystem projects.

Thank you