### PR TITLE
Avoid using pydantic compat layer where easily possible

### DIFF
--- a/src/antsibull_docs/cli/antsibull_docs.py
+++ b/src/antsibull_docs/cli/antsibull_docs.py
@@ -903,7 +903,7 @@ def run(args: list[str]) -> int:
         args=parsed_args, cfg=cfg, app_context_model=DocsAppContext
     )
     with app_context.app_and_lib_context(context_data) as (app_ctx, dummy_):
-        twiggy.dict_config(app_ctx.logging_cfg.dict())
+        twiggy.dict_config(app_ctx.logging_cfg.model_dump())
         flog.debug("Set logging config")
 
         flog.fields(command=parsed_args.command).info("Action")

--- a/src/antsibull_docs/schemas/app_context.py
+++ b/src/antsibull_docs/schemas/app_context.py
@@ -8,11 +8,10 @@
 import pydantic as p
 from antsibull_core.schemas.context import AppContext as CoreAppContext
 from antsibull_core.schemas.validators import convert_bool
-
-from antsibull_docs._pydantic_compat import Field
+from pydantic import Field
 
 #: Valid choices for the docs parsing backend
-DOC_PARSING_BACKEND_CHOICES_F = Field("auto", regex="^(auto|ansible-core-2\\.13)$")
+DOC_PARSING_BACKEND_CHOICES_F = Field("auto", pattern="^(auto|ansible-core-2\\.13)$")
 
 
 DEFAULT_COLLECTION_URL_TRANSFORM = (

--- a/src/sphinx_antsibull_ext/directive_helper.py
+++ b/src/sphinx_antsibull_ext/directive_helper.py
@@ -12,13 +12,12 @@ from __future__ import annotations
 import abc
 import typing as t
 
+import pydantic as p
 from antsibull_fileutils.yaml import load_yaml_bytes
 from docutils import nodes
 from docutils.parsers.rst import Directive
 
-from antsibull_docs._pydantic_compat import v1
-
-SchemaT = t.TypeVar("SchemaT", bound=v1.BaseModel)
+SchemaT = t.TypeVar("SchemaT", bound=p.BaseModel)
 
 
 class YAMLDirective(Directive, t.Generic[SchemaT], metaclass=abc.ABCMeta):
@@ -45,8 +44,8 @@ class YAMLDirective(Directive, t.Generic[SchemaT], metaclass=abc.ABCMeta):
                 "data": content,
             }
         try:
-            content_obj = self.schema.parse_obj(content)
-        except v1.ValidationError as exc:
+            content_obj = self.schema.model_validate(content)
+        except p.ValidationError as exc:
             raise self.error(
                 f"Error while parsing content of {self.name}: {exc}"
             ) from exc

--- a/src/sphinx_antsibull_ext/schemas/ansible_links.py
+++ b/src/sphinx_antsibull_ext/schemas/ansible_links.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import typing as t
 
-from antsibull_docs._pydantic_compat import v1 as p
+import pydantic as p
 
 
 class AnsibleLink(p.BaseModel):
@@ -18,13 +18,14 @@ class AnsibleLink(p.BaseModel):
     ref: t.Optional[str] = None
     external: bool = False
 
-    @p.root_validator()
-    # pylint:disable=no-self-argument
-    def one_of_url_and_ref(cls, values: dict[str, t.Any]) -> dict[str, t.Any]:
-        has_url = values.get("url")
-        has_ref = values.get("ref")
-        if has_url == has_ref:
-            raise ValueError("Exactly one of 'url' and 'ref' must be specified.")
+    @p.model_validator(mode="before")
+    @classmethod
+    def one_of_url_and_ref(cls, values: t.Any) -> t.Any:
+        if isinstance(values, dict):
+            has_url = values.get("url")
+            has_ref = values.get("ref")
+            if has_url == has_ref:
+                raise ValueError("Exactly one of 'url' and 'ref' must be specified.")
         return values
 
 


### PR DESCRIPTION
All other cases need v1 for easy linting (with extra checks).