### PR TITLE
Don't use empty dict for a non-deprecation, but instead use None

### DIFF
--- a/src/antsibull_docs/plugin_docs.py
+++ b/src/antsibull_docs/plugin_docs.py
@@ -44,7 +44,7 @@ class _PluginDocsTextWalker:
     def _walk_deprecation(
         self, owner: dict[str, t.Any], key_path: str, role_entrypoint: str | None = None
     ) -> None:
-        if "deprecated" not in owner:
+        if not owner.get("deprecated"):
             return
         key_path = f"{key_path} -> deprecated"
         deprecated = owner["deprecated"]

--- a/src/antsibull_docs/schemas/docs/base.py
+++ b/src/antsibull_docs/schemas/docs/base.py
@@ -623,7 +623,7 @@ class DocSchema(BaseModel):
     short_description: str
     aliases: list[str] = []
     author: list[str] = []
-    deprecated: DeprecationSchema = p.Field({})
+    deprecated: t.Optional[DeprecationSchema] = None
     extends_documentation_fragment: list[str] = []
     filename: str = ""
     notes: list[str] = []

--- a/src/antsibull_docs/schemas/docs/plugin.py
+++ b/src/antsibull_docs/schemas/docs/plugin.py
@@ -34,7 +34,7 @@ _EXAMPLES_FMT_RE = re.compile(r"^# fmt:\s+(\S+)")
 
 class OptionCliSchema(BaseModel):
     name: str = REQUIRED_CLI_F
-    deprecated: DeprecationSchema = p.Field({})
+    deprecated: t.Optional[DeprecationSchema] = None
     option: str = ""
     version_added: str = "historical"
     version_added_collection: str = COLLECTION_NAME_F
@@ -55,7 +55,7 @@ class OptionCliSchema(BaseModel):
 
 class OptionEnvSchema(BaseModel):
     name: str = REQUIRED_ENV_VAR_F
-    deprecated: DeprecationSchema = p.Field({})
+    deprecated: t.Optional[DeprecationSchema] = None
     version_added: str = "historical"
     version_added_collection: str = COLLECTION_NAME_F
 
@@ -63,21 +63,21 @@ class OptionEnvSchema(BaseModel):
 class OptionIniSchema(BaseModel):
     key: str
     section: str
-    deprecated: DeprecationSchema = p.Field({})
+    deprecated: t.Optional[DeprecationSchema] = None
     version_added: str = "historical"
     version_added_collection: str = COLLECTION_NAME_F
 
 
 class OptionVarsSchema(BaseModel):
     name: str
-    deprecated: DeprecationSchema = p.Field({})
+    deprecated: t.Optional[DeprecationSchema] = None
     version_added: str = "historical"
     version_added_collection: str = COLLECTION_NAME_F
 
 
 class OptionKeywordSchema(BaseModel):
     name: str
-    deprecated: DeprecationSchema = p.Field({})
+    deprecated: t.Optional[DeprecationSchema] = None
     version_added: str = "historical"
     version_added_collection: str = COLLECTION_NAME_F
 
@@ -190,7 +190,7 @@ class PluginOptionsSchema(OptionsSchema):
     suboptions: dict[str, "PluginOptionsSchema"] = {}
     vars: list[OptionVarsSchema] = []
     keyword: list[OptionKeywordSchema] = []
-    deprecated: DeprecationSchema = p.Field({})
+    deprecated: t.Optional[DeprecationSchema] = None
 
 
 PluginOptionsSchema.update_forward_refs()

--- a/src/antsibull_docs/schemas/docs/role.py
+++ b/src/antsibull_docs/schemas/docs/role.py
@@ -52,7 +52,7 @@ class RoleEntrypointSchema(PluginExamplesSchema, BaseModel):
     description: list[str]
     short_description: str
     author: list[str] = []
-    deprecated: DeprecationSchema = p.Field({})
+    deprecated: t.Optional[DeprecationSchema] = None
     notes: list[str] = []
     requirements: list[str] = []
     seealso: list[SeeAlsoSchemaT] = []

--- a/tests/functional/schema/good_data/one_become_results.json
+++ b/tests/functional/schema/good_data/one_become_results.json
@@ -8,7 +8,7 @@
                 ],
                 "attributes": {},
                 "collection": "",
-                "deprecated": {},
+                "deprecated": null,
                 "description": [
                     "This become plugins allows elevated permissions on a remote network device."
                 ],
@@ -25,20 +25,20 @@
                         "choices": [],
                         "cli": [],
                         "default": null,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "password"
                         ],
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_BECOME_PASS",
                                 "version_added": "historical",
                                 "version_added_collection": ""
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_ENABLE_PASS",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -46,7 +46,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "password",
                                 "section": "enable_become_plugin",
                                 "version_added": "historical",
@@ -59,19 +59,19 @@
                         "type": "str",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_become_password",
                                 "version_added": "historical",
                                 "version_added_collection": ""
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_become_pass",
                                 "version_added": "historical",
                                 "version_added_collection": ""
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_enable_pass",
                                 "version_added": "historical",
                                 "version_added_collection": ""

--- a/tests/functional/schema/good_data/one_cache_results.json
+++ b/tests/functional/schema/good_data/one_cache_results.json
@@ -8,7 +8,7 @@
                 ],
                 "attributes": {},
                 "collection": "",
-                "deprecated": {},
+                "deprecated": null,
                 "description": [
                     "This cache uses JSON formatted, per host, files saved to the filesystem."
                 ],
@@ -22,14 +22,14 @@
                         "choices": [],
                         "cli": [],
                         "default": null,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "User defined prefix to use when creating the JSON files"
                         ],
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_CACHE_PLUGIN_PREFIX",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -37,7 +37,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "fact_caching_prefix",
                                 "section": "defaults",
                                 "version_added": "historical",
@@ -57,14 +57,14 @@
                         "choices": [],
                         "cli": [],
                         "default": 86400,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Expiration timeout in seconds for the cache plugin data. Set to 0 to never expire"
                         ],
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_CACHE_PLUGIN_TIMEOUT",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -72,7 +72,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "fact_caching_timeout",
                                 "section": "defaults",
                                 "version_added": "historical",
@@ -92,14 +92,14 @@
                         "choices": [],
                         "cli": [],
                         "default": null,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Path in which the cache plugin will save the JSON files"
                         ],
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_CACHE_PLUGIN_CONNECTION",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -107,7 +107,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "fact_caching_connection",
                                 "section": "defaults",
                                 "version_added": "historical",

--- a/tests/functional/schema/good_data/one_callback_results.json
+++ b/tests/functional/schema/good_data/one_callback_results.json
@@ -6,7 +6,7 @@
                 "author": [],
                 "attributes": {},
                 "collection": "",
-                "deprecated": {},
+                "deprecated": null,
                 "description": [
                     "Ansible callback plugin for collecting the AWS actions completed by all boto3 modules using AnsibleAWSModule in a playbook. Botocore endpoint logs need to be enabled for those modules, which can be done easily by setting debug_botocore_endpoint_logs to True for group/aws using module_defaults."
                 ],

--- a/tests/functional/schema/good_data/one_cliconf_results.json
+++ b/tests/functional/schema/good_data/one_cliconf_results.json
@@ -8,7 +8,7 @@
                 ],
                 "attributes": {},
                 "collection": "",
-                "deprecated": {},
+                "deprecated": null,
                 "description": [
                     "This eos plugin provides low level abstraction apis for sending and receiving CLI commands from Arista EOS network devices."
                 ],
@@ -22,14 +22,14 @@
                         "choices": [],
                         "cli": [],
                         "default": 1,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Specifies if sessions should be used on remote host or not"
                         ],
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_EOS_USE_SESSIONS",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -42,7 +42,7 @@
                         "type": "bool",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_eos_use_sessions",
                                 "version_added": "2.7",
                                 "version_added_collection": "foo.bar"

--- a/tests/functional/schema/good_data/one_connection_results.json
+++ b/tests/functional/schema/good_data/one_connection_results.json
@@ -8,7 +8,7 @@
                 ],
                 "attributes": {},
                 "collection": "",
-                "deprecated": {},
+                "deprecated": null,
                 "description": [
                     "This connection plugin provides a connection to remote devices over a HTTP(S)-based api."
                 ],
@@ -22,7 +22,7 @@
                         "choices": [],
                         "cli": [],
                         "default": 0,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "The become option will instruct the CLI session to attempt privilege escalation on platforms that support it.  Normally this means transitioning from user mode to C(enable) mode in the CLI session. If become is set to True and the remote device does not support privilege escalation or the privilege has already been elevated, then this option is silently ignored.",
                             "Can be configured from the CLI via the C(--become) or C(-b) options."
@@ -30,7 +30,7 @@
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_BECOME",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -38,7 +38,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "become",
                                 "section": "privilege_escalation",
                                 "version_added": "historical",
@@ -51,7 +51,7 @@
                         "type": "bool",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_become",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -65,14 +65,14 @@
                         "choices": [],
                         "cli": [],
                         "default": "sudo",
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "This option allows the become method to be specified in for handling privilege escalation.  Typically the become_method value is set to C(enable) but could be defined as other values."
                         ],
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_BECOME_METHOD",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -80,7 +80,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "become_method",
                                 "section": "privilege_escalation",
                                 "version_added": "historical",
@@ -93,7 +93,7 @@
                         "type": "str",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_become_method",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -107,7 +107,7 @@
                         "choices": [],
                         "cli": [],
                         "default": "inventory_hostname",
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Specifies the remote device FQDN or IP address to establish the HTTP(S) connection to."
                         ],
@@ -120,7 +120,7 @@
                         "type": "str",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_host",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -134,7 +134,7 @@
                         "choices": [],
                         "cli": [],
                         "default": null,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Configures the device platform network operating system.  This value is used to load the correct httpapi plugin to communicate with the remote device"
                         ],
@@ -147,7 +147,7 @@
                         "type": "str",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_network_os",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -161,7 +161,7 @@
                         "choices": [],
                         "cli": [],
                         "default": null,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Configures the user password used to authenticate to the remote device when needed for the device API."
                         ],
@@ -174,19 +174,19 @@
                         "type": "str",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_password",
                                 "version_added": "historical",
                                 "version_added_collection": ""
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_httpapi_pass",
                                 "version_added": "historical",
                                 "version_added_collection": ""
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_httpapi_password",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -200,14 +200,14 @@
                         "choices": [],
                         "cli": [],
                         "default": 30,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Configures, in seconds, the amount of time to wait for a command to return from the remote device.  If this timer is exceeded before the command returns, the connection plugin will raise an exception and close."
                         ],
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_PERSISTENT_COMMAND_TIMEOUT",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -215,7 +215,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "command_timeout",
                                 "section": "persistent_connection",
                                 "version_added": "historical",
@@ -228,7 +228,7 @@
                         "type": "int",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_command_timeout",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -242,14 +242,14 @@
                         "choices": [],
                         "cli": [],
                         "default": 30,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Configures, in seconds, the amount of time to wait when trying to initially establish a persistent connection.  If this value expires before the connection to the remote device is completed, the connection will fail."
                         ],
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_PERSISTENT_CONNECT_TIMEOUT",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -257,7 +257,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "connect_timeout",
                                 "section": "persistent_connection",
                                 "version_added": "historical",
@@ -270,7 +270,7 @@
                         "type": "int",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_connect_timeout",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -284,7 +284,7 @@
                         "choices": [],
                         "cli": [],
                         "default": 0,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "This flag will enable logging the command executed and response received from target device in the ansible log file. For this option to work 'log_path' ansible configuration option is required to be set to a file path with write access.",
                             "Be sure to fully understand the security implications of enabling this option as it could create a security vulnerability by logging sensitive information in log file."
@@ -292,7 +292,7 @@
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_PERSISTENT_LOG_MESSAGES",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -300,7 +300,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "log_messages",
                                 "section": "persistent_connection",
                                 "version_added": "historical",
@@ -313,7 +313,7 @@
                         "type": "bool",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_persistent_log_messages",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -327,7 +327,7 @@
                         "choices": [],
                         "cli": [],
                         "default": null,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Specifies the port on the remote device that listens for connections when establishing the HTTP(S) connection.",
                             "When unspecified, will pick 80 or 443 based on the value of use_ssl."
@@ -335,7 +335,7 @@
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_REMOTE_PORT",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -343,7 +343,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "remote_port",
                                 "section": "defaults",
                                 "version_added": "historical",
@@ -356,7 +356,7 @@
                         "type": "int",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_httpapi_port",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -370,7 +370,7 @@
                         "choices": [],
                         "cli": [],
                         "default": null,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "The username used to authenticate to the remote device when the API connection is first established.  If the remote_user is not specified, the connection will use the username of the logged in user.",
                             "Can be configured from the CLI via the C(--user) or C(-u) options."
@@ -378,7 +378,7 @@
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_REMOTE_USER",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -386,7 +386,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "remote_user",
                                 "section": "defaults",
                                 "version_added": "historical",
@@ -399,7 +399,7 @@
                         "type": "str",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_user",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -413,7 +413,7 @@
                         "choices": [],
                         "cli": [],
                         "default": 1,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Whether to use https_proxy for requests."
                         ],
@@ -426,7 +426,7 @@
                         "type": "bool",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_httpapi_use_proxy",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -440,7 +440,7 @@
                         "choices": [],
                         "cli": [],
                         "default": 0,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Whether to connect using SSL (HTTPS) or not (HTTP)."
                         ],
@@ -453,7 +453,7 @@
                         "type": "bool",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_httpapi_use_ssl",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -467,7 +467,7 @@
                         "choices": [],
                         "cli": [],
                         "default": 1,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Whether to validate SSL certificates"
                         ],
@@ -480,7 +480,7 @@
                         "type": "bool",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_httpapi_validate_certs",
                                 "version_added": "historical",
                                 "version_added_collection": ""

--- a/tests/functional/schema/good_data/one_filter_results.json
+++ b/tests/functional/schema/good_data/one_filter_results.json
@@ -8,7 +8,7 @@
                     "Brian Coca (@bcoca)"
                 ],
                 "collection": "ansible.builtin",
-                "deprecated": {},
+                "deprecated": null,
                 "description": [
                     "Return the first value if the input is C(True), the second if C(False)."
                 ],
@@ -24,7 +24,7 @@
                         "choices": [],
                         "cli": [],
                         "default": null,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "A boolean expression, must evaluate to C(True) or C(False)."
                         ],
@@ -44,7 +44,7 @@
                         "choices": [],
                         "cli": [],
                         "default": null,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Value to return if the input is C(False)."
                         ],
@@ -64,7 +64,7 @@
                         "choices": [],
                         "cli": [],
                         "default": null,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Value to return if the input is C(None). If not set, C(None) will be treated as C(False)."
                         ],
@@ -84,7 +84,7 @@
                         "choices": [],
                         "cli": [],
                         "default": null,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Value to return if the input is C(True)."
                         ],

--- a/tests/functional/schema/good_data/one_httpapi_results.json
+++ b/tests/functional/schema/good_data/one_httpapi_results.json
@@ -8,7 +8,7 @@
                 ],
                 "attributes": {},
                 "collection": "",
-                "deprecated": {},
+                "deprecated": null,
                 "description": [
                     "This HttpApi plugin provides methods to connect to Restconf API endpoints."
                 ],
@@ -22,7 +22,7 @@
                         "choices": [],
                         "cli": [],
                         "default": "/restconf",
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Specifies the location of the Restconf root."
                         ],
@@ -35,7 +35,7 @@
                         "type": "str",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_httpapi_restconf_root",
                                 "version_added": "historical",
                                 "version_added_collection": ""

--- a/tests/functional/schema/good_data/one_inventory_results.json
+++ b/tests/functional/schema/good_data/one_inventory_results.json
@@ -8,7 +8,7 @@
                 ],
                 "attributes": {},
                 "collection": "",
-                "deprecated": {},
+                "deprecated": null,
                 "description": [
                     "Get inventory hosts from Amazon Web Services EC2.",
                     "Uses a YAML configuration file that ends with C(aws_ec2.(yml|yaml))."
@@ -27,26 +27,26 @@
                         "choices": [],
                         "cli": [],
                         "default": null,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "The AWS access key to use."
                         ],
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "EC2_ACCESS_KEY",
                                 "version_added": "historical",
                                 "version_added_collection": ""
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "AWS_ACCESS_KEY",
                                 "version_added": "historical",
                                 "version_added_collection": ""
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "AWS_ACCESS_KEY_ID",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -68,20 +68,20 @@
                         "choices": [],
                         "cli": [],
                         "default": null,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "The AWS profile"
                         ],
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "AWS_DEFAULT_PROFILE",
                                 "version_added": "historical",
                                 "version_added_collection": ""
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "AWS_PROFILE",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -103,26 +103,26 @@
                         "choices": [],
                         "cli": [],
                         "default": null,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "The AWS secret key that corresponds to the access key."
                         ],
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "EC2_SECRET_KEY",
                                 "version_added": "historical",
                                 "version_added_collection": ""
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "AWS_SECRET_KEY",
                                 "version_added": "historical",
                                 "version_added_collection": ""
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "AWS_SECRET_ACCESS_KEY",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -142,26 +142,26 @@
                         "choices": [],
                         "cli": [],
                         "default": null,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "The AWS security token if using temporary access and secret keys."
                         ],
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "EC2_SECURITY_TOKEN",
                                 "version_added": "historical",
                                 "version_added_collection": ""
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "AWS_SESSION_TOKEN",
                                 "version_added": "historical",
                                 "version_added_collection": ""
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "AWS_SECURITY_TOKEN",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -181,14 +181,14 @@
                         "choices": [],
                         "cli": [],
                         "default": 0,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Toggle to enable/disable the caching of the inventory's source data, requires a cache plugin setup to work."
                         ],
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_INVENTORY_CACHE",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -196,7 +196,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "cache",
                                 "section": "inventory",
                                 "version_added": "historical",
@@ -216,20 +216,20 @@
                         "choices": [],
                         "cli": [],
                         "default": null,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Cache connection data or path, read cache plugin documentation for specifics."
                         ],
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_CACHE_PLUGIN_CONNECTION",
                                 "version_added": "historical",
                                 "version_added_collection": ""
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_INVENTORY_CACHE_CONNECTION",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -237,14 +237,14 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "fact_caching_connection",
                                 "section": "defaults",
                                 "version_added": "historical",
                                 "version_added_collection": ""
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "cache_connection",
                                 "section": "inventory",
                                 "version_added": "historical",
@@ -264,20 +264,20 @@
                         "choices": [],
                         "cli": [],
                         "default": "memory",
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Cache plugin to use for the inventory's source data."
                         ],
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_CACHE_PLUGIN",
                                 "version_added": "historical",
                                 "version_added_collection": ""
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_INVENTORY_CACHE_PLUGIN",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -285,14 +285,14 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "fact_caching",
                                 "section": "defaults",
                                 "version_added": "historical",
                                 "version_added_collection": ""
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "cache_plugin",
                                 "section": "inventory",
                                 "version_added": "historical",
@@ -312,20 +312,20 @@
                         "choices": [],
                         "cli": [],
                         "default": "ansible_inventory_",
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Prefix to use for cache plugin files/tables"
                         ],
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_CACHE_PLUGIN_PREFIX",
                                 "version_added": "historical",
                                 "version_added_collection": ""
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_INVENTORY_CACHE_PLUGIN_PREFIX",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -333,14 +333,14 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "fact_caching_prefix",
                                 "section": "default",
                                 "version_added": "historical",
                                 "version_added_collection": ""
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "cache_prefix",
                                 "section": "inventory",
                                 "version_added": "historical",
@@ -360,20 +360,20 @@
                         "choices": [],
                         "cli": [],
                         "default": 3600,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Cache duration in seconds"
                         ],
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_CACHE_PLUGIN_TIMEOUT",
                                 "version_added": "historical",
                                 "version_added_collection": ""
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_INVENTORY_CACHE_TIMEOUT",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -381,14 +381,14 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "fact_caching_timeout",
                                 "section": "defaults",
                                 "version_added": "historical",
                                 "version_added_collection": ""
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "cache_timeout",
                                 "section": "inventory",
                                 "version_added": "historical",
@@ -408,7 +408,7 @@
                         "choices": [],
                         "cli": [],
                         "default": {},
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Create vars from jinja2 expressions."
                         ],
@@ -428,7 +428,7 @@
                         "choices": [],
                         "cli": [],
                         "default": {},
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "A dictionary of filter value pairs.",
                             "Available filters are listed here U(http://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instances.html#options)."
@@ -449,7 +449,7 @@
                         "choices": [],
                         "cli": [],
                         "default": {},
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Add hosts to group based on Jinja2 conditionals."
                         ],
@@ -469,7 +469,7 @@
                         "choices": [],
                         "cli": [],
                         "default": [],
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "A list in order of precedence for hostname variables.",
                             "You can use the options specified in U(http://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instances.html#options).",
@@ -491,7 +491,7 @@
                         "choices": [],
                         "cli": [],
                         "default": null,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "The ARN of the IAM role to assume to perform the inventory lookup. You should still provide AWS credentials with enough privilege to perform the AssumeRole action."
                         ],
@@ -511,7 +511,7 @@
                         "choices": [],
                         "cli": [],
                         "default": 0,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Add two additional API calls for every instance to include 'persistent' and 'events' host variables.",
                             "Spot instances may be persistent and instances may have associated events."
@@ -532,7 +532,7 @@
                         "choices": [],
                         "cli": [],
                         "default": [],
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Add hosts to group based on the values of a variable."
                         ],
@@ -554,7 +554,7 @@
                         ],
                         "cli": [],
                         "default": null,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Token that ensures this is a source file for the plugin."
                         ],
@@ -574,7 +574,7 @@
                         "choices": [],
                         "cli": [],
                         "default": [],
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "A list of regions in which to describe EC2 instances.",
                             "If empty (the default) default this will include all regions, except possibly restricted ones like us-gov-west-1 and cn-north-1."
@@ -595,7 +595,7 @@
                         "choices": [],
                         "cli": [],
                         "default": 0,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "If C(yes) make invalid entries a fatal error, otherwise skip and continue.",
                             "Since it is possible to use facts in the expressions they might not always be available and we ignore those errors by default."
@@ -616,7 +616,7 @@
                         "choices": [],
                         "cli": [],
                         "default": 1,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "By default if a 403 (Forbidden) error code is encountered this plugin will fail.",
                             "You can set this option to False in the inventory config file which will allow 403 errors to be gracefully skipped."
@@ -637,7 +637,7 @@
                         "choices": [],
                         "cli": [],
                         "default": 0,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "By default this plugin is using a general group name sanitization to create safe and usable group names for use in Ansible. This option allows you to override that, in efforts to allow migration from the old inventory script and matches the sanitization of groups when the script's ``replace_dash_in_groups`` option is set to ``False``. To replicate behavior of ``replace_dash_in_groups = True`` with constructed groups, you will need to replace hyphens with underscores via the regex_replace filter for those entries.",
                             "For this to work you should also turn off the TRANSFORM_INVALID_GROUP_CHARS setting, otherwise the core engine will just use the standard sanitization on top.",

--- a/tests/functional/schema/good_data/one_lookup_results.json
+++ b/tests/functional/schema/good_data/one_lookup_results.json
@@ -6,7 +6,7 @@
                 "author": [],
                 "attributes": {},
                 "collection": "",
-                "deprecated": {},
+                "deprecated": null,
                 "description": [
                     "Lookup metadata for a playbook from the key value store in a Consul cluster. Values can be easily set in the kv store with simple rest commands",
                     "C(curl -X PUT -d 'some-value' http://localhost:8500/v1/kv/ansible/somedata)"
@@ -21,7 +21,7 @@
                         "choices": [],
                         "cli": [],
                         "default": null,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "List of key(s) to retrieve."
                         ],
@@ -41,14 +41,14 @@
                         "choices": [],
                         "cli": [],
                         "default": null,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "The client cert to verify the ssl connection."
                         ],
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_CONSUL_CLIENT_CERT",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -56,7 +56,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "client_cert",
                                 "section": "lookup_consul",
                                 "version_added": "historical",
@@ -76,7 +76,7 @@
                         "choices": [],
                         "cli": [],
                         "default": null,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Retrieve the key from a consul datatacenter other than the default for the consul host."
                         ],
@@ -96,7 +96,7 @@
                         "choices": [],
                         "cli": [],
                         "default": "localhost",
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "The target to connect to, must be a resolvable address. Will be determined from C(ANSIBLE_CONSUL_URL) if that is set.",
                             "C(ANSIBLE_CONSUL_URL) should look like this: C(https://my.consul.server:8500)"
@@ -104,7 +104,7 @@
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_CONSUL_URL",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -112,7 +112,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "host",
                                 "section": "lookup_consul",
                                 "version_added": "historical",
@@ -132,7 +132,7 @@
                         "choices": [],
                         "cli": [],
                         "default": null,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "If the key has a value with the specified index then this is returned allowing access to historical values."
                         ],
@@ -152,7 +152,7 @@
                         "choices": [],
                         "cli": [],
                         "default": 8500,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "The port of the target host to connect to.",
                             "If you use C(ANSIBLE_CONSUL_URL) this value will be used from there."
@@ -173,7 +173,7 @@
                         "choices": [],
                         "cli": [],
                         "default": 0,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "If true, will retrieve all the values that have the given key as prefix."
                         ],
@@ -193,7 +193,7 @@
                         "choices": [],
                         "cli": [],
                         "default": "http",
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Whether to use http or https.",
                             "If you use C(ANSIBLE_CONSUL_URL) this value will be used from there."
@@ -214,7 +214,7 @@
                         "choices": [],
                         "cli": [],
                         "default": null,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "The acl token to allow access to restricted values."
                         ],
@@ -234,14 +234,14 @@
                         "choices": [],
                         "cli": [],
                         "default": 1,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Whether to verify the ssl connection or not."
                         ],
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_CONSUL_VALIDATE_CERTS",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -249,7 +249,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "validate_certs",
                                 "section": "lookup_consul",
                                 "version_added": "historical",

--- a/tests/functional/schema/good_data/one_module_results.json
+++ b/tests/functional/schema/good_data/one_module_results.json
@@ -186,7 +186,7 @@
                     }
                 },
                 "collection": "",
-                "deprecated": {},
+                "deprecated": null,
                 "description": [
                     "Use variables to create new hosts and groups in inventory for use in later plays of the same playbook.",
                     "Takes variables so you can define the new hosts more fully.",

--- a/tests/functional/schema/good_data/one_netconf_results.json
+++ b/tests/functional/schema/good_data/one_netconf_results.json
@@ -8,7 +8,7 @@
                 ],
                 "attributes": {},
                 "collection": "",
-                "deprecated": {},
+                "deprecated": null,
                 "description": [
                     "This iosxr plugin provides low level abstraction apis for sending and receiving netconf commands from Cisco iosxr network devices."
                 ],
@@ -22,7 +22,7 @@
                         "choices": [],
                         "cli": [],
                         "default": "iosxr",
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Specifies the ncclient device handler name for Cisco iosxr network os. To identify the ncclient device handler name refer ncclient library documentation."
                         ],

--- a/tests/functional/schema/good_data/one_shell_results.json
+++ b/tests/functional/schema/good_data/one_shell_results.json
@@ -6,7 +6,7 @@
                 "author": [],
                 "attributes": {},
                 "collection": "",
-                "deprecated": {},
+                "deprecated": null,
                 "description": [
                     "This shell plugin is the one you want to use on most Unix systems, it is the most compatible and widely installed shell."
                 ],
@@ -23,14 +23,14 @@
                             "root",
                             "toor"
                         ],
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "list of users to be expected to have admin privileges. This is used by the controller to determine how to share temporary files between the remote user and the become user."
                         ],
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_ADMIN_USERS",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -38,7 +38,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "admin_users",
                                 "section": "defaults",
                                 "version_added": "historical",
@@ -51,7 +51,7 @@
                         "type": "list",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_admin_users",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -65,14 +65,14 @@
                         "choices": [],
                         "cli": [],
                         "default": "~/.ansible_async",
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Directory in which ansible will keep async job information"
                         ],
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_ASYNC_DIR",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -80,7 +80,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "async_dir",
                                 "section": "defaults",
                                 "version_added": "historical",
@@ -93,7 +93,7 @@
                         "type": "str",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_async_dir",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -107,7 +107,7 @@
                         "choices": [],
                         "cli": [],
                         "default": {},
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "dictionary of environment variables and their values to use when executing commands."
                         ],
@@ -127,20 +127,20 @@
                         "choices": [],
                         "cli": [],
                         "default": "~/.ansible/tmp",
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Temporary directory to use on targets when executing tasks."
                         ],
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_REMOTE_TEMP",
                                 "version_added": "historical",
                                 "version_added_collection": ""
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_REMOTE_TMP",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -148,7 +148,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "remote_tmp",
                                 "section": "defaults",
                                 "version_added": "historical",
@@ -161,7 +161,7 @@
                         "type": "str",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_remote_tmp",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -178,14 +178,14 @@
                             "/var/tmp",
                             "/tmp"
                         ],
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "List of valid system temporary directories for Ansible to choose when it cannot use ``remote_tmp``, normally due to permission issues.  These must be world readable, writable, and executable."
                         ],
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_SYSTEM_TMPDIRS",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -193,7 +193,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "system_tmpdirs",
                                 "section": "defaults",
                                 "version_added": "historical",
@@ -206,7 +206,7 @@
                         "type": "list",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_system_tmpdirs",
                                 "version_added": "historical",
                                 "version_added_collection": ""

--- a/tests/functional/schema/good_data/one_strategy_results.json
+++ b/tests/functional/schema/good_data/one_strategy_results.json
@@ -8,7 +8,7 @@
                 ],
                 "attributes": {},
                 "collection": "",
-                "deprecated": {},
+                "deprecated": null,
                 "description": [
                     "Task execution is as fast as possible per batch as defined by C(serial) (default all). Ansible will not wait for other hosts to finish the current task before queuing more tasks for other hosts. All hosts are still attempted for the current task, but it prevents blocking new tasks for hosts that have already finished.",
                     "With the free strategy, unlike the default linear strategy, a host that is slow or stuck on a specific task won't hold up the rest of the hosts and tasks."

--- a/tests/functional/schema/good_data/one_test_results.json
+++ b/tests/functional/schema/good_data/one_test_results.json
@@ -8,7 +8,7 @@
                     "Ansible Core"
                 ],
                 "collection": "ansible.builtin",
-                "deprecated": {},
+                "deprecated": null,
                 "description": [
                     "Tests if task required changes to complete",
                     "This test checks for the existance of a C(changed) key in the input dictionary and that it is C(True) if present"
@@ -23,7 +23,7 @@
                         "choices": [],
                         "cli": [],
                         "default": null,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "registered result from an Ansible task"
                         ],

--- a/tests/functional/schema/good_data/one_vars_results.json
+++ b/tests/functional/schema/good_data/one_vars_results.json
@@ -6,7 +6,7 @@
                 "author": [],
                 "attributes": {},
                 "collection": "",
-                "deprecated": {},
+                "deprecated": null,
                 "description": [
                     "Loads YAML vars into corresponding groups/hosts in group_vars/ and host_vars/ directories.",
                     "Files are restricted by extension to one of .yaml, .json, .yml or no extension.",
@@ -28,7 +28,7 @@
                             ".yaml",
                             ".json"
                         ],
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Check all of these extensions when looking for 'variable' files which should be YAML or JSON or vaulted versions of these.",
                             "This affects vars_files, include_vars, inventory and vars plugins among others."
@@ -36,7 +36,7 @@
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_YAML_FILENAME_EXT",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -44,7 +44,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "defaults",
                                 "section": "yaml_valid_extensions",
                                 "version_added": "historical",
@@ -68,7 +68,7 @@
                         ],
                         "cli": [],
                         "default": null,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Control when this vars plugin may be executed.",
                             "Setting this option to C(all) will run the vars plugin after importing inventory and whenever it is demanded by a task.",
@@ -79,7 +79,7 @@
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_VARS_PLUGIN_STAGE",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -87,7 +87,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "stage",
                                 "section": "vars_host_group_vars",
                                 "version_added": "historical",

--- a/tests/functional/schema/good_data/ssh_connection_results.json
+++ b/tests/functional/schema/good_data/ssh_connection_results.json
@@ -8,7 +8,7 @@
                 ],
                 "attributes": {},
                 "collection": "ansible.builtin",
-                "deprecated": {},
+                "deprecated": null,
                 "description": [
                     "This connection plugin allows ansible to communicate to the target machines via normal ssh command line.",
                     "Ansible does not expose a channel to allow communication between the user and the ssh process to accept a password manually to decrypt an ssh key when using this connection plugin (which is the default). The use of ``ssh-agent`` is highly recommended."
@@ -25,7 +25,7 @@
                         "choices": [],
                         "cli": [],
                         "default": null,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "This is the location to save ssh's ControlPath sockets, it uses ssh's variable substitution.",
                             "Since 2.3, if null (default), ansible will generate a unique hash. Use `%(directory)s` to indicate where to use the control dir path setting.",
@@ -35,7 +35,7 @@
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_SSH_CONTROL_PATH",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -43,7 +43,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "control_path",
                                 "section": "ssh_connection",
                                 "version_added": "historical",
@@ -56,7 +56,7 @@
                         "type": "str",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_control_path",
                                 "version_added": "2.7",
                                 "version_added_collection": "ansible.builtin"
@@ -70,7 +70,7 @@
                         "choices": [],
                         "cli": [],
                         "default": "~/.ansible/cp",
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "This sets the directory to use for ssh control path if the control path setting is null.",
                             "Also, provides the `%(directory)s` variable for the control path setting."
@@ -78,7 +78,7 @@
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_SSH_CONTROL_PATH_DIR",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -86,7 +86,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "control_path_dir",
                                 "section": "ssh_connection",
                                 "version_added": "historical",
@@ -99,7 +99,7 @@
                         "type": "str",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_control_path_dir",
                                 "version_added": "2.7",
                                 "version_added_collection": "ansible.builtin"
@@ -113,7 +113,7 @@
                         "choices": [],
                         "cli": [],
                         "default": null,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Hostname/ip to connect to."
                         ],
@@ -126,31 +126,31 @@
                         "type": "str",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "inventory_hostname",
                                 "version_added": "historical",
                                 "version_added_collection": ""
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_host",
                                 "version_added": "historical",
                                 "version_added_collection": ""
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_ssh_host",
                                 "version_added": "historical",
                                 "version_added_collection": ""
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "delegated_vars['ansible_host']",
                                 "version_added": "historical",
                                 "version_added_collection": ""
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "delegated_vars['ansible_ssh_host']",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -164,20 +164,20 @@
                         "choices": [],
                         "cli": [],
                         "default": null,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Determines if ssh should check host keys"
                         ],
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_HOST_KEY_CHECKING",
                                 "version_added": "historical",
                                 "version_added_collection": ""
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_SSH_HOST_KEY_CHECKING",
                                 "version_added": "2.5",
                                 "version_added_collection": "ansible.builtin"
@@ -185,14 +185,14 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "host_key_checking",
                                 "section": "defaults",
                                 "version_added": "historical",
                                 "version_added_collection": ""
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "host_key_checking",
                                 "section": "ssh_connection",
                                 "version_added": "2.5",
@@ -205,13 +205,13 @@
                         "type": "bool",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_host_key_checking",
                                 "version_added": "2.5",
                                 "version_added_collection": "ansible.builtin"
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_ssh_host_key_checking",
                                 "version_added": "2.5",
                                 "version_added_collection": "ansible.builtin"
@@ -225,7 +225,7 @@
                         "choices": [],
                         "cli": [],
                         "default": null,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Authentication password for the C(remote_user). Can be supplied as CLI option."
                         ],
@@ -238,19 +238,19 @@
                         "type": "str",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_password",
                                 "version_added": "historical",
                                 "version_added_collection": ""
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_ssh_pass",
                                 "version_added": "historical",
                                 "version_added_collection": ""
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_ssh_password",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -264,7 +264,7 @@
                         "choices": [],
                         "cli": [],
                         "default": false,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Pipelining reduces the number of connection operations required to execute a module on the remote server, by executing many Ansible modules without actual file transfers.",
                             "This can result in a very significant performance improvement when enabled.",
@@ -273,13 +273,13 @@
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_PIPELINING",
                                 "version_added": "historical",
                                 "version_added_collection": ""
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_SSH_PIPELINING",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -287,14 +287,14 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "pipelining",
                                 "section": "connection",
                                 "version_added": "historical",
                                 "version_added_collection": ""
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "pipelining",
                                 "section": "ssh_connection",
                                 "version_added": "historical",
@@ -307,13 +307,13 @@
                         "type": "bool",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_pipelining",
                                 "version_added": "historical",
                                 "version_added_collection": ""
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_ssh_pipelining",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -327,14 +327,14 @@
                         "choices": [],
                         "cli": [],
                         "default": null,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Remote port to connect to."
                         ],
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_REMOTE_PORT",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -342,7 +342,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "remote_port",
                                 "section": "defaults",
                                 "version_added": "historical",
@@ -351,7 +351,7 @@
                         ],
                         "keyword": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "port",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -362,13 +362,13 @@
                         "type": "int",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_port",
                                 "version_added": "historical",
                                 "version_added_collection": ""
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_ssh_port",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -382,7 +382,7 @@
                         "choices": [],
                         "cli": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "private_key_file",
                                 "option": "--private-key",
                                 "version_added": "historical",
@@ -390,14 +390,14 @@
                             }
                         ],
                         "default": null,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Path to private key file to use for authentication"
                         ],
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_PRIVATE_KEY_FILE",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -405,7 +405,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "private_key_file",
                                 "section": "defaults",
                                 "version_added": "historical",
@@ -418,13 +418,13 @@
                         "type": "str",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_private_key_file",
                                 "version_added": "historical",
                                 "version_added_collection": ""
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_ssh_private_key_file",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -438,7 +438,7 @@
                         "choices": [],
                         "cli": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "user",
                                 "option": "--user",
                                 "version_added": "historical",
@@ -446,7 +446,7 @@
                             }
                         ],
                         "default": null,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "User name with which to login to the remote server, normally set by the remote_user keyword.",
                             "If no user is supplied, Ansible will let the ssh client binary choose the user as it normally"
@@ -454,7 +454,7 @@
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_REMOTE_USER",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -462,7 +462,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "remote_user",
                                 "section": "defaults",
                                 "version_added": "historical",
@@ -471,7 +471,7 @@
                         ],
                         "keyword": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "remote_user",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -482,13 +482,13 @@
                         "type": "str",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_user",
                                 "version_added": "historical",
                                 "version_added_collection": ""
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_ssh_user",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -502,14 +502,14 @@
                         "choices": [],
                         "cli": [],
                         "default": 3,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Number of attempts to connect."
                         ],
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_SSH_RETRIES",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -517,14 +517,14 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "retries",
                                 "section": "connection",
                                 "version_added": "historical",
                                 "version_added_collection": ""
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "retries",
                                 "section": "ssh_connection",
                                 "version_added": "historical",
@@ -537,7 +537,7 @@
                         "type": "int",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_ssh_retries",
                                 "version_added": "2.7",
                                 "version_added_collection": "ansible.builtin"
@@ -551,14 +551,14 @@
                         "choices": [],
                         "cli": [],
                         "default": "scp",
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "This defines the location of the scp binary. It defaults to `scp` which will use the first binary available in $PATH."
                         ],
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_SCP_EXECUTABLE",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -566,7 +566,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "scp_executable",
                                 "section": "ssh_connection",
                                 "version_added": "historical",
@@ -579,7 +579,7 @@
                         "type": "str",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_scp_executable",
                                 "version_added": "2.7",
                                 "version_added_collection": "ansible.builtin"
@@ -593,7 +593,7 @@
                         "choices": [],
                         "cli": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "scp_extra_args",
                                 "option": "--scp-extra-args",
                                 "version_added": "historical",
@@ -601,14 +601,14 @@
                             }
                         ],
                         "default": null,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Extra exclusive to the ``scp`` CLI"
                         ],
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_SCP_EXTRA_ARGS",
                                 "version_added": "2.7",
                                 "version_added_collection": "ansible.builtin"
@@ -616,7 +616,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "scp_extra_args",
                                 "section": "ssh_connection",
                                 "version_added": "2.7",
@@ -629,7 +629,7 @@
                         "type": "str",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_scp_extra_args",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -643,7 +643,7 @@
                         "choices": [],
                         "cli": [],
                         "default": "smart",
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Preferred method to use when transfering files over ssh",
                             "When set to smart, Ansible will try them until one succeeds or they all fail",
@@ -652,7 +652,7 @@
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_SCP_IF_SSH",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -660,7 +660,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "scp_if_ssh",
                                 "section": "ssh_connection",
                                 "version_added": "historical",
@@ -673,7 +673,7 @@
                         "type": "str",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_scp_if_ssh",
                                 "version_added": "2.7",
                                 "version_added_collection": "ansible.builtin"
@@ -687,14 +687,14 @@
                         "choices": [],
                         "cli": [],
                         "default": true,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "TODO: write it"
                         ],
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_SFTP_BATCH_MODE",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -702,7 +702,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "sftp_batch_mode",
                                 "section": "ssh_connection",
                                 "version_added": "historical",
@@ -715,7 +715,7 @@
                         "type": "bool",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_sftp_batch_mode",
                                 "version_added": "2.7",
                                 "version_added_collection": "ansible.builtin"
@@ -729,14 +729,14 @@
                         "choices": [],
                         "cli": [],
                         "default": "sftp",
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "This defines the location of the sftp binary. It defaults to ``sftp`` which will use the first binary available in $PATH."
                         ],
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_SFTP_EXECUTABLE",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -744,7 +744,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "sftp_executable",
                                 "section": "ssh_connection",
                                 "version_added": "historical",
@@ -757,7 +757,7 @@
                         "type": "str",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_sftp_executable",
                                 "version_added": "2.7",
                                 "version_added_collection": "ansible.builtin"
@@ -771,7 +771,7 @@
                         "choices": [],
                         "cli": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "sftp_extra_args",
                                 "option": "--sftp-extra-args",
                                 "version_added": "historical",
@@ -779,14 +779,14 @@
                             }
                         ],
                         "default": null,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Extra exclusive to the ``sftp`` CLI"
                         ],
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_SFTP_EXTRA_ARGS",
                                 "version_added": "2.7",
                                 "version_added_collection": "ansible.builtin"
@@ -794,7 +794,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "sftp_extra_args",
                                 "section": "ssh_connection",
                                 "version_added": "2.7",
@@ -807,7 +807,7 @@
                         "type": "str",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_sftp_extra_args",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -821,7 +821,7 @@
                         "choices": [],
                         "cli": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ssh_args",
                                 "option": "--ssh-args",
                                 "version_added": "historical",
@@ -829,14 +829,14 @@
                             }
                         ],
                         "default": "-C -o ControlMaster=auto -o ControlPersist=60s",
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Arguments to pass to all ssh cli tools"
                         ],
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_SSH_ARGS",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -844,7 +844,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "ssh_args",
                                 "section": "ssh_connection",
                                 "version_added": "historical",
@@ -857,7 +857,7 @@
                         "type": "str",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_ssh_args",
                                 "version_added": "2.7",
                                 "version_added_collection": "ansible.builtin"
@@ -871,7 +871,7 @@
                         "choices": [],
                         "cli": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ssh_common_args",
                                 "option": "--ssh-common-args",
                                 "version_added": "historical",
@@ -879,14 +879,14 @@
                             }
                         ],
                         "default": null,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Common extra args for all ssh CLI tools"
                         ],
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_SSH_COMMON_ARGS",
                                 "version_added": "2.7",
                                 "version_added_collection": "ansible.builtin"
@@ -894,7 +894,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "ssh_common_args",
                                 "section": "ssh_connection",
                                 "version_added": "2.7",
@@ -907,7 +907,7 @@
                         "type": "str",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_ssh_common_args",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -921,7 +921,7 @@
                         "choices": [],
                         "cli": [],
                         "default": "ssh",
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "This defines the location of the ssh binary. It defaults to ``ssh`` which will use the first ssh binary available in $PATH.",
                             "This option is usually not required, it might be useful when access to system ssh is restricted, or when using ssh wrappers to connect to remote hosts."
@@ -929,7 +929,7 @@
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_SSH_EXECUTABLE",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -937,7 +937,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "ssh_executable",
                                 "section": "ssh_connection",
                                 "version_added": "historical",
@@ -950,7 +950,7 @@
                         "type": "str",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_ssh_executable",
                                 "version_added": "2.7",
                                 "version_added_collection": "ansible.builtin"
@@ -964,7 +964,7 @@
                         "choices": [],
                         "cli": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ssh_extra_args",
                                 "option": "--ssh-extra-args",
                                 "version_added": "historical",
@@ -972,14 +972,14 @@
                             }
                         ],
                         "default": null,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Extra exclusive to the 'ssh' CLI"
                         ],
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_SSH_EXTRA_ARGS",
                                 "version_added": "2.7",
                                 "version_added_collection": "ansible.builtin"
@@ -987,7 +987,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "ssh_extra_args",
                                 "section": "ssh_connection",
                                 "version_added": "2.7",
@@ -1000,7 +1000,7 @@
                         "type": "str",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_ssh_extra_args",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -1019,7 +1019,7 @@
                         ],
                         "cli": [],
                         "default": "smart",
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Preferred method to use when transferring files over ssh",
                             "Setting to 'smart' (default) will try them in order, until one succeeds or they all fail",
@@ -1028,7 +1028,7 @@
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_SSH_TRANSFER_METHOD",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -1036,7 +1036,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "transfer_method",
                                 "section": "ssh_connection",
                                 "version_added": "historical",
@@ -1056,14 +1056,14 @@
                         "choices": [],
                         "cli": [],
                         "default": "",
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "Password prompt that sshpass should search for. Supported by sshpass 1.06 and up."
                         ],
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_SSHPASS_PROMPT",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -1071,7 +1071,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "sshpass_prompt",
                                 "section": "ssh_connection",
                                 "version_added": "historical",
@@ -1084,7 +1084,7 @@
                         "type": "str",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_sshpass_prompt",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -1098,7 +1098,7 @@
                         "choices": [],
                         "cli": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "timeout",
                                 "option": "--timeout",
                                 "version_added": "historical",
@@ -1106,7 +1106,7 @@
                             }
                         ],
                         "default": 10,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "This is the default ammount of time we will wait while establishing an ssh connection",
                             "It also controls how long we can wait to access reading the connection once established (select on the socket)"
@@ -1114,13 +1114,13 @@
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_TIMEOUT",
                                 "version_added": "historical",
                                 "version_added_collection": ""
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_SSH_TIMEOUT",
                                 "version_added": "2.11",
                                 "version_added_collection": "ansible.builtin"
@@ -1128,14 +1128,14 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "timeout",
                                 "section": "defaults",
                                 "version_added": "historical",
                                 "version_added_collection": ""
                             },
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "timeout",
                                 "section": "ssh_connection",
                                 "version_added": "2.11",
@@ -1148,7 +1148,7 @@
                         "type": "int",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_ssh_timeout",
                                 "version_added": "2.11",
                                 "version_added_collection": "ansible.builtin"
@@ -1162,14 +1162,14 @@
                         "choices": [],
                         "cli": [],
                         "default": true,
-                        "deprecated": {},
+                        "deprecated": null,
                         "description": [
                             "add -tt to ssh commands to force tty allocation"
                         ],
                         "elements": "str",
                         "env": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ANSIBLE_SSH_USETTY",
                                 "version_added": "historical",
                                 "version_added_collection": ""
@@ -1177,7 +1177,7 @@
                         ],
                         "ini": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "key": "usetty",
                                 "section": "ssh_connection",
                                 "version_added": "historical",
@@ -1190,7 +1190,7 @@
                         "type": "bool",
                         "vars": [
                             {
-                                "deprecated": {},
+                                "deprecated": null,
                                 "name": "ansible_ssh_use_tty",
                                 "version_added": "2.7",
                                 "version_added_collection": "ansible.builtin"


### PR DESCRIPTION
This is also compatible with the typing. An empty `dict` is never of type `DeprecationSchema`.

(No changelog fragment since this is a purely internal change.)