### PR TITLE
CI: Replace sensu.sensu_go with community.sops

### DIFF
--- a/.github/workflows/antsibull-docs.yml
+++ b/.github/workflows/antsibull-docs.yml
@@ -128,7 +128,7 @@ jobs:
         # We install some collections using ansible-galaxy and at least one by cloning its repository,
         # so we have galaxy.yml instead of MANIFEST.json present.
         run: |
-          ansible-galaxy collection install community.docker sensu.sensu_go
+          ansible-galaxy collection install community.docker community.sops
           git clone https://github.com/ansible-collections/community.crypto.git ~/.ansible/collections/ansible_collections/community/crypto
         if: contains(matrix.options, '--use-current')
 
@@ -136,7 +136,7 @@ jobs:
         run: |
           coverage run -p --source antsibull_docs --source sphinx_antsibull_ext -m antsibull_docs.cli.antsibull_docs lint-collection-docs ~/.ansible/collections/ansible_collections/community/docker --plugin-docs
           coverage run -p --source antsibull_docs --source sphinx_antsibull_ext -m antsibull_docs.cli.antsibull_docs lint-collection-docs ~/.ansible/collections/ansible_collections/community/crypto
-          coverage run -p --source antsibull_docs --source sphinx_antsibull_ext -m antsibull_docs.cli.antsibull_docs lint-collection-docs ~/.ansible/collections/ansible_collections/sensu/sensu_go
+          coverage run -p --source antsibull_docs --source sphinx_antsibull_ext -m antsibull_docs.cli.antsibull_docs lint-collection-docs ~/.ansible/collections/ansible_collections/community/sops --plugin-docs --skip-rstcheck
         working-directory: antsibull-docs
         if: contains(matrix.options, '--use-current')
 


### PR DESCRIPTION
Back then I chose sensu.sensu_go as the only collection included in Ansible that has roles. It's no longer the only one (https://docs.ansible.com/ansible/devel/collections/index_role.html), and it doesn't seem to be actively maintained (Ref: https://forum.ansible.com/t/8380), so I want to replace it with another collection.