### PR TITLE
Add tombstones for removed collections

### DIFF
--- a/changelogs/fragments/341-removed-collections.yml
+++ b/changelogs/fragments/341-removed-collections.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - "When rendering the Ansible docsite with the ``stable`` and ``devel`` subcommands, stub pages for removed collections are added
+     (https://github.com/ansible-community/ansible-build-data/pull/459, https://github.com/ansible-community/antsibull-docs/pull/341)."

--- a/src/antsibull_docs/cli/doc_commands/_build.py
+++ b/src/antsibull_docs/cli/doc_commands/_build.py
@@ -55,7 +55,7 @@ from ...schemas.app_context import (
 from ...utils.collection_name_transformer import CollectionNameTransformer
 from ...write_docs import CollectionInfoT, _get_collection_dir
 from ...write_docs.changelog import output_changelogs
-from ...write_docs.collections import output_extra_docs, output_indexes
+from ...write_docs.collections import output_collection_indexes, output_extra_docs
 from ...write_docs.hierarchy import (
     output_collection_index,
     output_collection_namespace_indexes,
@@ -552,7 +552,7 @@ def generate_docs_for_all_collections(  # noqa: C901
 
     if create_collection_indexes:
         asyncio.run(
-            output_indexes(
+            output_collection_indexes(
                 collection_to_plugin_info,
                 output,
                 collection_url=collection_url,

--- a/src/antsibull_docs/cli/doc_commands/_build.py
+++ b/src/antsibull_docs/cli/doc_commands/_build.py
@@ -55,7 +55,11 @@ from ...schemas.app_context import (
 from ...utils.collection_name_transformer import CollectionNameTransformer
 from ...write_docs import CollectionInfoT, _get_collection_dir
 from ...write_docs.changelog import output_changelogs
-from ...write_docs.collections import output_collection_indexes, output_extra_docs
+from ...write_docs.collections import (
+    output_collection_indexes,
+    output_collection_tombstones,
+    output_extra_docs,
+)
 from ...write_docs.hierarchy import (
     output_collection_index,
     output_collection_namespace_indexes,
@@ -569,7 +573,23 @@ def generate_docs_for_all_collections(  # noqa: C901
                 add_version=add_antsibull_docs_version,
             )
         )
-        flog.notice("Finished writing indexes")
+        flog.notice("Finished writing collection indexes")
+
+        asyncio.run(
+            output_collection_tombstones(
+                collection_meta,
+                output,
+                collection_url=collection_url,
+                collection_install=collection_install,
+                squash_hierarchy=squash_hierarchy,
+                output_format=output_format,
+                filename_generator=filename_generator,
+                breadcrumbs=breadcrumbs,
+                for_official_docsite=for_official_docsite,
+                add_version=add_antsibull_docs_version,
+            )
+        )
+        flog.notice("Finished writing collection tombstones")
 
         asyncio.run(
             output_changelogs(

--- a/src/antsibull_docs/cli/doc_commands/_build.py
+++ b/src/antsibull_docs/cli/doc_commands/_build.py
@@ -464,7 +464,9 @@ def generate_docs_for_all_collections(  # noqa: C901
         referenced_env_vars, core_env_vars, collection_metadata
     )
 
-    collection_namespaces = get_collection_namespaces(collection_to_plugin_info.keys())
+    collection_namespaces = get_collection_namespaces(
+        collection_to_plugin_info.keys(), collection_meta=collection_meta
+    )
 
     collection_url = CollectionNameTransformer(
         app_ctx.collection_url, DEFAULT_COLLECTION_URL_TRANSFORM

--- a/src/antsibull_docs/data/docsite/ansible-docsite/collection-tombstone.rst.j2
+++ b/src/antsibull_docs/data/docsite/ansible-docsite/collection-tombstone.rst.j2
@@ -1,0 +1,23 @@
+{#
+  Copyright (c) Ansible Project
+  GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+  SPDX-License-Identifier: GPL-3.0-or-later
+#}
+
+:orphan:
+
+{% if antsibull_docs_version %}
+.. meta::
+  :antsibull-docs: @{ antsibull_docs_version }@
+
+{% endif %}
+
+.. _plugins_in_@{collection_name}@:
+
+@{collection_name.title()}@
+@{ '=' * (collection_name | column_width) }@
+
+This collection has been removed from Ansible @{ collection_removal_version.major }@.
+
+If you want to continue using this collection, you can install it manually using
+@{ collection_name | collection_install | rst_code }@.

--- a/src/antsibull_docs/data/docsite/ansible-docsite/list_of_collections_by_namespace.rst.j2
+++ b/src/antsibull_docs/data/docsite/ansible-docsite/list_of_collections_by_namespace.rst.j2
@@ -30,6 +30,8 @@ These are the collections documented here in the **@{ namespace }@** namespace.
 
 {% for name in collections | sort %}
 * :ref:`@{ namespace }@.@{ name }@ <plugins_in_@{ namespace }@.@{ name }@>` @{ collection_deprecation_marker(collection_metadata[namespace ~ '.' ~ name]) }@
+{% else %}
+There is no collection in this namespace.
 {% endfor %}
 
 {% if breadcrumbs %}

--- a/src/antsibull_docs/data/docsite/simplified-rst/collection-tombstone.rst.j2
+++ b/src/antsibull_docs/data/docsite/simplified-rst/collection-tombstone.rst.j2
@@ -1,0 +1,19 @@
+{#
+  Copyright (c) Ansible Project
+  GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+  SPDX-License-Identifier: GPL-3.0-or-later
+#}
+
+{% if antsibull_docs_version %}
+.. Created with antsibull-docs @{ antsibull_docs_version }@
+{% else %}
+.. Created with antsibull-docs
+{% endif %}
+
+@{collection_name.title()}@
+@{ '=' * (collection_name | column_width) }@
+
+This collection has been removed from Ansible @{ collection_removal_version.major }@.
+
+If you want to continue using this collection, you can install it manually using
+@{ collection_name | collection_install | rst_code }@.

--- a/src/antsibull_docs/data/docsite/simplified-rst/list_of_collections_by_namespace.rst.j2
+++ b/src/antsibull_docs/data/docsite/simplified-rst/list_of_collections_by_namespace.rst.j2
@@ -29,4 +29,6 @@ These are the collections documented here in the **@{ namespace }@** namespace.
 
 {% for name in collections | sort %}
 * `@{ namespace }@.@{ name }@ <namespace/index.rst>`_
+{% else %}
+There is no collection in this namespace.
 {% endfor %}

--- a/src/antsibull_docs/write_docs/collections.py
+++ b/src/antsibull_docs/write_docs/collections.py
@@ -54,7 +54,7 @@ def _parse_required_ansible(requires_ansible: str) -> list[str]:
     return result
 
 
-async def write_plugin_lists(
+async def write_collection_index(
     collection_name: str,
     plugin_maps: Mapping[str, Mapping[str, BasicPluginInfo]],
     template: Template,
@@ -90,7 +90,7 @@ async def write_plugin_lists(
     :kwarg add_version: If set to ``False``, will not insert antsibull-docs' version into
         the generated files.
     """
-    flog = mlog.fields(func="write_plugin_lists")
+    flog = mlog.fields(func="write_collection_index")
     flog.debug("Enter")
 
     requires_ansible = []
@@ -132,7 +132,7 @@ async def write_plugin_lists(
     flog.debug("Leave")
 
 
-async def output_indexes(
+async def output_collection_indexes(
     collection_to_plugin_info: CollectionInfoT,
     output: Output,
     collection_metadata: Mapping[str, AnsibleCollectionMetadata],
@@ -168,7 +168,7 @@ async def output_indexes(
     :kwarg add_version: If set to ``False``, will not insert antsibull-docs' version into
         the generated files.
     """
-    flog = mlog.fields(func="output_indexes")
+    flog = mlog.fields(func="output_collection_indexes")
     flog.debug("Enter")
 
     if collection_metadata is None:
@@ -201,7 +201,7 @@ async def output_indexes(
             )
             writers.append(
                 await pool.spawn(
-                    write_plugin_lists(
+                    write_collection_index(
                         collection_name,
                         plugin_maps,
                         collection_plugins_tmpl,


### PR DESCRIPTION
Uses the information added in https://github.com/ansible-community/ansible-build-data/pull/459 to add tombstones for removed collections. This ensures that if you are on the collection index page in a previous version of Ansible that still has this collection, and use the version selector to navigate to the current version, that you don't see a 404, but instead see the tombstone page.

This unfortunately only makes the tombstone appear in exactly one major version of Ansible - the version where the collection was removed -, but that's better than nothing IMO :)