### PR TITLE
Remove ignore of pydantic deprecation warnings

### DIFF
--- a/changelogs/fragments/332-pydantic-2.yml
+++ b/changelogs/fragments/332-pydantic-2.yml
@@ -3,4 +3,5 @@ minor_changes:
      some validation is more strict. For example, if a boolean is used instead of a string, say in a description, this now results
      in an error instead of a silent coercion. Numbers are still accepted for strings (for example ``version_added`` with float values
      like ``2.14``)
-     (https://github.com/ansible-community/antsibull-docs/pull/331, https://github.com/ansible-community/antsibull-core/pull/333)."
+     (https://github.com/ansible-community/antsibull-docs/pull/331, https://github.com/ansible-community/antsibull-core/pull/333,
+     https://github.com/ansible-community/antsibull-core/pull/344)."

--- a/src/antsibull_docs/__init__.py
+++ b/src/antsibull_docs/__init__.py
@@ -4,27 +4,7 @@
 # SPDX-FileCopyrightText: 2020, Ansible Project
 """The main antsibull-docs module. Contains versioning information."""
 
-import os
-import warnings
-
-import pydantic
-
 __version__ = "2.14.0.post0"
 
-
-def _filter_pydantic_v2_warnings() -> None:
-    """
-    Filter DeprecationWarnings from Pydantic v2. We cannot fix these without
-    dropping support for v1 entirely, and we don't want to break setups with
-    PYTHONWARNINGS=error.
-    """
-
-    typ: type[DeprecationWarning] | None
-    if typ := getattr(pydantic, "PydanticDeprecatedSince20", None):
-        warnings.simplefilter(action="ignore", category=typ)
-
-
-if "_ANTSIBULL_SHOW_PYDANTIC_WARNINGS" not in os.environ:
-    _filter_pydantic_v2_warnings()
 
 __all__ = ("__version__",)

--- a/src/antsibull_docs/schemas/ansible_doc.py
+++ b/src/antsibull_docs/schemas/ansible_doc.py
@@ -20,3 +20,5 @@ warnings.warn(
     DeprecationWarning,
     stacklevel=2,
 )
+
+# TODO: remove in 3.0.0

--- a/src/antsibull_docs/schemas/app_context.py
+++ b/src/antsibull_docs/schemas/app_context.py
@@ -33,11 +33,10 @@ class DocsAppContext(CoreAppContext):
     }
 
     # pylint: disable-next=unused-private-member
-    __convert_docs_bools = p.validator(  # type: ignore
+    __convert_docs_bools = p.field_validator(  # type: ignore
         "breadcrumbs",
         "indexes",
         "use_html_blobs",
         "add_antsibull_docs_version",
-        pre=True,
-        allow_reuse=True,
+        mode="before",
     )(convert_bool)


### PR DESCRIPTION
This should no longer be needed (and potentially hides problems from us).