### PR TITLE
Add Python 3.13 to CI and supported Python versions

### DIFF
--- a/.github/workflows/antsibull-docs.yml
+++ b/.github/workflows/antsibull-docs.yml
@@ -30,7 +30,7 @@ jobs:
           - '--use-current --sphinx-theme sphinx_rtd_theme'
           - '--no-indexes --squash-hierarchy --intersphinx ansible7:https://docs.ansible.com/ansible/6/ community.crypto --collection-version 2.0.0'
         python:
-          - '3.12'
+          - '3.13'
         antsibull_core_ref:
           - main
           - '3.2.0'
@@ -215,10 +215,10 @@ jobs:
           repository: ansible-community/antsibull-fileutils
           path: antsibull-fileutils
 
-      - name: Set up Python 3.12
+      - name: Set up Python 3.13
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Install dependencies
         run: |
@@ -294,10 +294,10 @@ jobs:
           repository: ansible-community/antsibull-fileutils
           path: antsibull-fileutils
 
-      - name: Set up Python 3.12
+      - name: Set up Python 3.13
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -34,12 +34,12 @@ jobs:
       matrix:
         include:
           - session: test
-            python-versions: "3.9, 3.10, 3.11, 3.12"
+            python-versions: "3.9, 3.10, 3.11, 3.12, 3.13"
             codecov: true
             packages: ""
 
           - session: lint
-            python-versions: "3.12"
+            python-versions: "3.13"
             codecov: false
             packages: ""
     name: "Run nox ${{ matrix.session }} session"

--- a/changelogs/fragments/python-3.13.yml
+++ b/changelogs/fragments/python-3.13.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Declare support for Python 3.13 (https://github.com/ansible-community/antsibull-docs/pull/349).

--- a/noxfile.py
+++ b/noxfile.py
@@ -75,7 +75,7 @@ def other_antsibull(
     return to_install
 
 
-@nox.session(python=["3.9", "3.10", "3.11", "3.12"])
+@nox.session(python=["3.9", "3.10", "3.11", "3.12", "3.13"])
 def test(session: nox.Session):
     install(
         session,
@@ -85,7 +85,7 @@ def test(session: nox.Session):
     )
     covfile = Path(session.create_tmp(), ".coverage")
     more_args = []
-    if session.python in {"3.11", "3.12"}:
+    if session.python in {"3.11", "3.12", "3.13"}:
         more_args.append("--error-for-skips")
     session.run(
         "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Typing :: Typed",
 ]
 requires-python = ">=3.9"


### PR DESCRIPTION
Since Python 3.13.0 has been released, let's use it in CI and officially support it.