### PR TITLE
Extend deprecation/removal note that collections can be installed manually after removal

### DIFF
--- a/changelogs/fragments/371-removal-hint.yml
+++ b/changelogs/fragments/371-removal-hint.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Extend deprecation/removal note that collections can be installed manually after removal (https://github.com/ansible-community/antsibull-docs/pull/371)."

--- a/src/antsibull_docs/cli/doc_commands/_build.py
+++ b/src/antsibull_docs/cli/doc_commands/_build.py
@@ -275,6 +275,12 @@ def _collect_removal_sentences(
     if reason_text:
         sentences.append(reason_text)
 
+    if reason not in ("renamed", "deprecated"):
+        sentences.append(
+            "Once removed, you can still install the collection manually"
+            f" with C(ansible-galaxy collection install {collection})."
+        )
+
     if sentences and discussion:
         sentences.append(
             f"See the L(discussion thread, {discussion}) for more information."


### PR DESCRIPTION
Similar to https://github.com/ansible-community/antsibull-build/pull/647.

The output looks like this:
```rst
.. note::
    The google.cloud collection will be removed from Ansible 12 due to violations of the Ansible inclusion requirements.
    The collection has \ `unresolved sanity test failures <https://github.com/ansible-collections/google.cloud/issues/613>`__.
    Once removed, you can still install the collection manually with :literal:`ansible-galaxy collection install google.cloud`.
    See the \ `discussion thread <https://forum.ansible.com/t/8609>`__ for more information.
```
(The line "Once removed, ..." is new.)