### PR TITLE
Docs normalization error handling: also consider BaseException

### DIFF
--- a/changelogs/fragments/389-docs-parsing-base-exception.yml
+++ b/changelogs/fragments/389-docs-parsing-base-exception.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - "Make sure that all errors are caught during documentation normalization.
+     Until now exceptions derived from ``BaseException`` that are not derived from ``Exception`` are not handled correctly
+     (https://github.com/ansible-community/antsibull-docs/pull/389)."

--- a/src/antsibull_docs/process_docs.py
+++ b/src/antsibull_docs/process_docs.py
@@ -234,7 +234,7 @@ async def normalize_all_plugin_info(
     for (plugin_type, plugin_name), plugin_record in zip(normalizers, results):
         # Errors which broke doc parsing (and therefore we won't have enough info to
         # build a docs page)
-        if isinstance(plugin_record, Exception):
+        if isinstance(plugin_record, BaseException):
             # An exception means there is no usable documentation for this plugin
             # Record a nonfatal error and then move on
             nonfatal_errors[plugin_type][plugin_name].append(str(plugin_record))


### PR DESCRIPTION
mypy now handles `return_exceptions=True` for `asyncio.gather()` better and knows that exceptions can also be derived from `BaseException`.