### PR TITLE
Adjust to missing 'name' field in ansible-core 2.19 Jinja2 filters/tests

### DIFF
--- a/changelogs/fragments/393-ansible-core-jinja-filters-tests.yml
+++ b/changelogs/fragments/393-ansible-core-jinja-filters-tests.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "Ansible-core 2.19 now lists standard Jinja2 tests and filters as members of ``ansible.builtin``
+     with minimal documentation, but without a ``name`` field in ``doc`` (https://github.com/ansible-community/antsibull-docs/pull/393)."

--- a/src/antsibull_docs/cli/doc_commands/plugin.py
+++ b/src/antsibull_docs/cli/doc_commands/plugin.py
@@ -94,7 +94,9 @@ def generate_plugin_docs(
     flog.debug("Finished parsing info from plugin")
 
     try:
-        plugin_info, errors = normalize_plugin_info(plugin_type, plugin_info)
+        plugin_info, errors = normalize_plugin_info(
+            plugin_name, plugin_type, plugin_info
+        )
     except ValueError as exc:
         print("Cannot parse documentation:")
         print(str(exc))


### PR DESCRIPTION
https://docs.ansible.com/ansible/devel/collections/ansible/builtin/index.html#filter-plugins and https://docs.ansible.com/ansible/devel/collections/ansible/builtin/index.html#test-plugins are currently quite empty.