### PR TITLE
Add subcommand to render Ansible output directly into RST files

### DIFF
--- a/changelogs/fragments/397-ansible-output.yml
+++ b/changelogs/fragments/397-ansible-output.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Add a new subcommand ``ansible-output`` which allows to render Ansible output into RST code blocks (https://github.com/ansible-community/antsibull-docs/pull/397)."

--- a/docs/ansible-output.md
+++ b/docs/ansible-output.md
@@ -135,3 +135,20 @@ ansible_output:
 ```
 
 This is useful to standardize the callback and its settings for most code blocks in a collection's extra docs.
+
+## Usage in CI
+
+If you want to run `antsibull-docs ansible-output` in CI, you might find the `--check` parameter useful.
+If that parameter is specified, antsibull-docs will not update files, but instead fail if a file would be modified.
+A diff of the changes that would be applied will be printed to standard output.
+
+!!! warning
+    Please note that you have to make sure that `antsibull-docs ansible-output` runs in CI with minimum number of privileges,
+    since it can run **arbitrary code**!
+
+    Someone can add a playbook to documentation that recursively deletes all files you have access to.
+    If you run `antsibull-docs ansible-output` (with or without `--check`) on such a RST file without sufficient isolation,
+    all your files will be gone.
+
+    If you run `antsibull-docs ansible-output` in CI in a context where the code run has access to credentials,
+    a playbook could send these credentials to an arbitrary location on the internet.

--- a/docs/ansible-output.md
+++ b/docs/ansible-output.md
@@ -1,0 +1,137 @@
+<!--
+Copyright (c) Ansible Project
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+-->
+
+# Updating ansible-playbook output in RST files
+
+One common problem with Ansible playbook examples in documentation is that while it is helpful to include the playbook's output,
+it is somewhat tedious to update the playbook output, especially when the used plugins or modules change.
+
+Antsibull-docs has a tool, its `antsibull-docs ansible-output` subcommand, that lets you update the `ansible-playbook` output
+in code blocks in RST files, and check whether they need to be updated (for example useful for CI).
+
+## Metadata and code blocks
+
+To know which code blocks to update and what playbook and environment variables to use, you need to provide a `ansible-output-data` directive before the actual code block:
+
+```rst
+.. ansible-output-data::
+
+    env:
+      ANSIBLE_STDOUT_CALLBACK: community.general.tasks_only
+      ANSIBLE_COLLECTIONS_TASKS_ONLY_COLUMN_WIDTH: "90"
+    playbook: |-
+      - hosts: localhost
+        gather_facts: false
+        tasks:
+          - name: Sort list by version number
+            debug:
+              var: ansible_versions | community.general.version_sort
+            vars:
+              ansible_versions:
+                - '2.8.0'
+                - '2.11.0'
+                - '2.7.0'
+                - '2.10.0'
+                - '2.9.0'
+
+.. code-block:: ansible-output
+
+    TASK [Sort list by version number] ********************************************************
+    ok: [localhost] => {
+        "ansible_versions | community.general.version_sort": [
+            "2.7.0",
+            "2.8.0",
+            "2.9.0",
+            "2.10.0",
+            "2.11.0"
+        ]
+    }
+```
+
+The `ansible-output-data` directive results in no output when the `sphinx_antsibull_ext` Sphinx extension is used, and contains YAML data.
+The `env` dictionary allows to set environment variables that are set when calling `ansible-playbook`.
+In this example, we set an explicit callback stdout plugin (using `ANSIBLE_STDOUT_CALLBACK`),
+and provide configuration for that plugin (`ANSIBLE_COLLECTIONS_TASKS_ONLY_COLUMN_WIDTH`).
+
+The playbook is provided as a multi-line YAML string.
+Antsibull-docs looks for the next code block with language `ansible-output`, and replaces its contents with the output of `ansible-playbook playbook.yml`,
+where `playbook.yml` is filled with the provided playbook.
+
+Note that the lanuage for the code block can be overridden by providing `language`.
+Also you can prepend lines to the output using `prepend_lines`:
+
+```rst
+.. ansible-output-data::
+
+    env:
+      ANSIBLE_STDOUT_CALLBACK: community.general.tasks_only
+      ANSIBLE_COLLECTIONS_TASKS_ONLY_COLUMN_WIDTH: "90"
+    language: console
+    prepend_lines: |
+      $ ansible-playbook playbook.yml
+    playbook: |-
+      - hosts: localhost
+        gather_facts: false
+        tasks:
+          - name: Sort list by version number
+            debug:
+              var: ansible_versions | community.general.version_sort
+            vars:
+              ansible_versions:
+                - '2.8.0'
+                - '2.11.0'
+                - '2.7.0'
+                - '2.10.0'
+                - '2.9.0'
+
+.. code-block:: console
+
+    $ ansible-playbook playbook.yml
+
+    TASK [Sort list by version number] ********************************************************
+    ok: [localhost] => {
+        "ansible_versions | community.general.version_sort": [
+            "2.7.0",
+            "2.8.0",
+            "2.9.0",
+            "2.10.0",
+            "2.11.0"
+        ]
+    }
+```
+
+## Standalone usage
+
+If you want to update a RST file, or all RST files in a directory, you can run antsibull-docs as follows:
+
+```shell
+$ antsibull-docs ansible-output /path/to/rst-file.rst
+$ antsibull-docs ansible-output /path/to/directory-with-rst-files
+```
+
+If the provided path is a directory, it will recursively look for `.rst` files in it.
+
+## Collection usage
+
+If you run `antsibull-docs ansible-output` without a path, it assumes that you are in a collection's root directory.
+(This is the directory that contains `galaxy.yml` or `MANIFEST.json`.)
+
+It will check all `.rst` files in `docs/docsite/rst/`, if that directory exists,
+and load configuration from `docs/docsite/config.yml`.
+(See [more information on that configuration file](../collection-docs/#configuring-the-docsite).)
+The configuration allows you to specify entries for `env` for all code blocks:
+
+```yaml
+---
+# Configuration for 'antsibull-docs ansible-output'
+ansible_output:
+  # Insert definitions into 'env' for every ansible-output-data directive
+  global_env:
+    ANSIBLE_STDOUT_CALLBACK: community.general.tasks_only
+    ANSIBLE_COLLECTIONS_TASKS_ONLY_COLUMN_WIDTH: 80
+```
+
+This is useful to standardize the callback and its settings for most code blocks in a collection's extra docs.

--- a/docs/ansible-output.md
+++ b/docs/ansible-output.md
@@ -7,10 +7,9 @@ SPDX-License-Identifier: GPL-3.0-or-later
 # Updating ansible-playbook output in RST files
 
 One common problem with Ansible playbook examples in documentation is that while it is helpful to include the playbook's output,
-it is somewhat tedious to update the playbook output, especially when the used plugins or modules change.
+it is somewhat tedious to update the playbook output, especially when changes occur to plugins or modules.
 
-Antsibull-docs has a tool, its `antsibull-docs ansible-output` subcommand, that lets you update the `ansible-playbook` output
-in code blocks in RST files, and check whether they need to be updated (for example useful for CI).
+Antsibull-docs provides a tool through the `antsibull-docs ansible-output` subcommand that lets you update the `ansible-playbook` output in code blocks within RST files. The `antsibull-docs ansible-output` subcommand also lets you check whether code blocks need to be updated, which can be a useful consistency check in CI pipelines.
 
 ## Metadata and code blocks
 
@@ -51,9 +50,10 @@ To know which code blocks to update and what playbook and environment variables 
     }
 ```
 
-The `ansible-output-data` directive results in no output when the `sphinx_antsibull_ext` Sphinx extension is used, and contains YAML data.
-The `env` dictionary allows to set environment variables that are set when calling `ansible-playbook`.
-In this example, we set an explicit callback stdout plugin (using `ANSIBLE_STDOUT_CALLBACK`),
+The `ansible-output-data` directive does not generate any visible content in rendered documentation when the `sphinx_antsibull_ext` Sphinx extension is used.
+The directive contains YAML configuration data that is meant for `antsibull-docs` and not for readers.
+The `env` dictionary allows you to set environment variables that are set when calling `ansible-playbook`.
+In this example, we set an explicit callback stdout plugin (using `ANSIBLE_STDOUT_CALLBACK`)
 and provide configuration for that plugin (`ANSIBLE_COLLECTIONS_TASKS_ONLY_NUMBER_OF_COLUMNS`).
 
 The playbook is provided as a multi-line YAML string.
@@ -143,12 +143,12 @@ If that parameter is specified, antsibull-docs will not update files, but instea
 A diff of the changes that would be applied will be printed to standard output.
 
 !!! warning
-    Please note that you have to make sure that `antsibull-docs ansible-output` runs in CI with minimum number of privileges,
+    Please note that you have to make sure that `antsibull-docs ansible-output` runs in CI with the minimum set of privileges,
     since it can run **arbitrary code**!
 
     Someone can add a playbook to documentation that recursively deletes all files you have access to.
     If you run `antsibull-docs ansible-output` (with or without `--check`) on such a RST file without sufficient isolation,
-    all your files will be gone.
+    all your files will be deleted.
 
     If you run `antsibull-docs ansible-output` in CI in a context where the code run has access to credentials,
     a playbook could send these credentials to an arbitrary location on the internet.

--- a/docs/ansible-output.md
+++ b/docs/ansible-output.md
@@ -21,7 +21,7 @@ To know which code blocks to update and what playbook and environment variables 
 
     env:
       ANSIBLE_STDOUT_CALLBACK: community.general.tasks_only
-      ANSIBLE_COLLECTIONS_TASKS_ONLY_COLUMN_WIDTH: "90"
+      ANSIBLE_COLLECTIONS_TASKS_ONLY_NUMBER_OF_COLUMNS: "90"
     playbook: |-
       - hosts: localhost
         gather_facts: false
@@ -54,7 +54,7 @@ To know which code blocks to update and what playbook and environment variables 
 The `ansible-output-data` directive results in no output when the `sphinx_antsibull_ext` Sphinx extension is used, and contains YAML data.
 The `env` dictionary allows to set environment variables that are set when calling `ansible-playbook`.
 In this example, we set an explicit callback stdout plugin (using `ANSIBLE_STDOUT_CALLBACK`),
-and provide configuration for that plugin (`ANSIBLE_COLLECTIONS_TASKS_ONLY_COLUMN_WIDTH`).
+and provide configuration for that plugin (`ANSIBLE_COLLECTIONS_TASKS_ONLY_NUMBER_OF_COLUMNS`).
 
 The playbook is provided as a multi-line YAML string.
 Antsibull-docs looks for the next code block with language `ansible-output`, and replaces its contents with the output of `ansible-playbook playbook.yml`,
@@ -68,7 +68,7 @@ Also you can prepend lines to the output using `prepend_lines`:
 
     env:
       ANSIBLE_STDOUT_CALLBACK: community.general.tasks_only
-      ANSIBLE_COLLECTIONS_TASKS_ONLY_COLUMN_WIDTH: "90"
+      ANSIBLE_COLLECTIONS_TASKS_ONLY_NUMBER_OF_COLUMNS: "90"
     language: console
     prepend_lines: |
       $ ansible-playbook playbook.yml
@@ -131,7 +131,7 @@ ansible_output:
   # Insert definitions into 'env' for every ansible-output-data directive
   global_env:
     ANSIBLE_STDOUT_CALLBACK: community.general.tasks_only
-    ANSIBLE_COLLECTIONS_TASKS_ONLY_COLUMN_WIDTH: 80
+    ANSIBLE_COLLECTIONS_TASKS_ONLY_NUMBER_OF_COLUMNS: 80
 ```
 
 This is useful to standardize the callback and its settings for most code blocks in a collection's extra docs.

--- a/docs/ansible-output.md
+++ b/docs/ansible-output.md
@@ -13,7 +13,8 @@ Antsibull-docs provides a tool through the `antsibull-docs ansible-output` subco
 
 ## Metadata and code blocks
 
-To know which code blocks to update and what playbook and environment variables to use, you need to provide a `ansible-output-data` directive before the actual code block:
+To know which code blocks to update and what playbook and environment variables to use,
+you need to provide a `ansible-output-data` directive before the actual code block:
 
 ```rst
 .. ansible-output-data::
@@ -50,28 +51,55 @@ To know which code blocks to update and what playbook and environment variables 
     }
 ```
 
-The `ansible-output-data` directive does not generate any visible content in rendered documentation when the `sphinx_antsibull_ext` Sphinx extension is used.
-The directive contains YAML configuration data that is meant for `antsibull-docs` and not for readers.
-The `env` dictionary allows you to set environment variables that are set when calling `ansible-playbook`.
-In this example, we set an explicit callback stdout plugin (using `ANSIBLE_STDOUT_CALLBACK`)
-and provide configuration for that plugin (`ANSIBLE_COLLECTIONS_TASKS_ONLY_NUMBER_OF_COLUMNS`).
-
-The playbook is provided as a multi-line YAML string.
-Antsibull-docs looks for the next code block with language `ansible-output`, and replaces its contents with the output of `ansible-playbook playbook.yml`,
+Antsibull-docs looks for the next code block with language `ansible-output`,
+and replaces its contents with the output of `ansible-playbook playbook.yml`,
 where `playbook.yml` is filled with the provided playbook.
 
-Note that the lanuage for the code block can be overridden by providing `language`.
-Also you can prepend lines to the output using `prepend_lines`:
+### The `ansible-output-data` directive in detail
 
+The `ansible-output-data` directive does not generate any visible content in rendered documentation when the `sphinx_antsibull_ext` Sphinx extension is used.
+The directive contains YAML configuration data that is meant for `antsibull-docs` and not for readers.
+In the YAML configuration you can use the following top-level keys.
+Also take a look at the example further below which demonstrates all of them.
+
+* The playbook is provided as a multi-line YAML string `playbook`.
+  At a later point we might allow to reference playbooks (or parts of playbooks) from earlier code blocks.
+
+* The `env` dictionary allows you to set environment variables that are set when calling `ansible-playbook`.
+  In the example further below, we set an explicit callback stdout plugin (using `ANSIBLE_STDOUT_CALLBACK`)
+  and provide configuration for that plugin (`ANSIBLE_COLLECTIONS_TASKS_ONLY_NUMBER_OF_COLUMNS`).
+
+* The `language` key allows to override the language for the code block that will be replaced.
+  By default `antsibull-docs ansible-output` looks for code blocks of language `ansible-output`.
+
+* The `prepend_lines` key allows to prepend a multi-line YAML string to the `ansible-playbook` output.
+
+An example looks like this. The `console` code block contains the generated result:
 ```rst
 .. ansible-output-data::
 
+    ---
+    # Note that the content of the 'ansible-output-data' directive
+    # is hidden from the user
+    # (assuming you are using the sphinx_antsibull_ext Sphinx extension)
+
+    # Use the community.general.tasks_only callback plugin
+    # and configure it to use 90 columns by setting appropriate
+    # environment variables:
     env:
       ANSIBLE_STDOUT_CALLBACK: community.general.tasks_only
       ANSIBLE_COLLECTIONS_TASKS_ONLY_NUMBER_OF_COLUMNS: "90"
+
+    # Look for the next code-block with language 'console':
     language: console
+
+    # Prepend the following lines to the output of 'ansible-playbook'.
+    # In this case, we add a fake console prompt that seems to run the
+    # playbook:
     prepend_lines: |
       $ ansible-playbook playbook.yml
+
+    # The actual playbook to run:
     playbook: |-
       - hosts: localhost
         gather_facts: false

--- a/docs/collection-docs.md
+++ b/docs/collection-docs.md
@@ -164,7 +164,7 @@ ansible_output:
   # Insert definitions into 'env' for every ansible-output-data directive
   global_env:
     ANSIBLE_STDOUT_CALLBACK: community.general.tasks_only
-    ANSIBLE_COLLECTIONS_TASKS_ONLY_COLUMN_WIDTH: 80
+    ANSIBLE_COLLECTIONS_TASKS_ONLY_NUMBER_OF_COLUMNS: 80
 ```
 
 Most collections should use `envvar_directives`, `changelog`, and `ansible_output` only. The `flatmap` option applies to older versions of community.general and community.network and should be used for legacy collections only, not for new ones.

--- a/docs/collection-docs.md
+++ b/docs/collection-docs.md
@@ -157,9 +157,17 @@ changelog:
   # antsibull-changelog documentation for more information) and link to it from the
   # collection's index page.
   write_changelog: false
+
+# Configuration for 'antsibull-docs ansible-output'
+# (See documentation for ansible-output for more information.)
+ansible_output:
+  # Insert definitions into 'env' for every ansible-output-data directive
+  global_env:
+    ANSIBLE_STDOUT_CALLBACK: community.general.tasks_only
+    ANSIBLE_COLLECTIONS_TASKS_ONLY_COLUMN_WIDTH: 80
 ```
 
-Most collections should use `envvar_directives` and `changelog` only. The `flatmap` option applies to older versions of community.general and community.network and should be used for legacy collections only, not for new ones.
+Most collections should use `envvar_directives`, `changelog`, and `ansible_output` only. The `flatmap` option applies to older versions of community.general and community.network and should be used for legacy collections only, not for new ones.
 
 ## Adding extra documentation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,8 @@ The main CLI tool, `antsibull-docs`, has multiple subcommands:
   The former is described in more detail in [Creating a collection docsite](collection-docs.md).
 * The `sphinx-init` subcommmand is used for setting up a Sphinx-based collection docsite.
   This is described in more detail in [Creating a collection docsite](collection-docs.md).
+* The `ansible-output` subcommmand can render ansible-playbook output directly in RST files.
+  This is described in more detail in [Updating ansible-playbook output in RST files](ansible-output.md).
 
 ## Using the Sphinx extension
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,7 @@ markdown_extensions:
 nav:
   - antsibull-docs: index.md
   - Creating a collection docsite: collection-docs.md
+  - Updating playbook output in RST files: ansible-output.md
   - Official Ansible docsite: package-docs.md
   - Join the Community: community.md
   - antsibull-docs Release Notes: changelog.md

--- a/src/antsibull_docs/cli/antsibull_docs.py
+++ b/src/antsibull_docs/cli/antsibull_docs.py
@@ -845,7 +845,8 @@ def parse_args(program_name: str, args: list[str]) -> argparse.Namespace:
         default=[],
         help="One or more path to a directory or a RST file. If a directory"
         " is specified, all RST files in it are processed recursively."
-        " If not specified, docs/docsite/rst is used.",
+        " If not specified, assumes that the current working directory"
+        " is a collection's root directory, and uses docs/docsite/rst if it exists.",
     )
     ansible_output_parser.add_argument(
         "--check",

--- a/src/antsibull_docs/cli/antsibull_docs.py
+++ b/src/antsibull_docs/cli/antsibull_docs.py
@@ -847,6 +847,19 @@ def parse_args(program_name: str, args: list[str]) -> argparse.Namespace:
         " is specified, all RST files in it are processed recursively."
         " If not specified, docs/docsite/rst is used.",
     )
+    ansible_output_parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Do not write files, but return non-zero exit code in case"
+        " files would be written and show changes as errors.",
+    )
+    ansible_output_parser.add_argument(
+        "--force-color",
+        dest="force_color",
+        action=BooleanOptionalAction,
+        help="Force enable or disable color in diffs when using --check."
+        " By default decides on whether stdout is a tty or not.",
+    )
 
     # This must come after all parser setup
     if HAS_ARGCOMPLETE:

--- a/src/antsibull_docs/cli/antsibull_docs.py
+++ b/src/antsibull_docs/cli/antsibull_docs.py
@@ -846,7 +846,9 @@ def parse_args(program_name: str, args: list[str]) -> argparse.Namespace:
         help="One or more path to a directory or a RST file. If a directory"
         " is specified, all RST files in it are processed recursively."
         " If not specified, assumes that the current working directory"
-        " is a collection's root directory, and uses docs/docsite/rst if it exists.",
+        " is a collection's root directory, and uses docs/docsite/rst if it exists."
+        " In that case, also additional configuration from docs/docsite/config.yml"
+        " will be loaded.",
     )
     ansible_output_parser.add_argument(
         "--check",

--- a/src/antsibull_docs/cli/antsibull_docs.py
+++ b/src/antsibull_docs/cli/antsibull_docs.py
@@ -842,7 +842,7 @@ def parse_args(program_name: str, args: list[str]) -> argparse.Namespace:
     ansible_output_parser.add_argument(
         nargs="*",
         dest="paths",
-        default=["docs/docsite/rst"],
+        default=[],
         help="One or more path to a directory or a RST file. If a directory"
         " is specified, all RST files in it are processed recursively."
         " If not specified, docs/docsite/rst is used.",

--- a/src/antsibull_docs/cli/antsibull_docs.py
+++ b/src/antsibull_docs/cli/antsibull_docs.py
@@ -81,6 +81,7 @@ ARGS_MAP: dict[str, Callable[[], Callable[[], int]]] = {
     "sphinx-init": _create_loader("sphinx_init", "site_init"),
     "lint-collection-docs": _create_loader("lint_docs", "lint_collection_docs"),
     "lint-core-docs": _create_loader("lint_docs", "lint_core_docs"),
+    "ansible-output": _create_loader("ansible_output", "run_ansible_output"),
 }
 
 #: The filename for the file which lists raw collection names
@@ -88,7 +89,7 @@ DEFAULT_PIECES_FILE: str = "ansible.in"
 
 
 def _normalize_docs_options(args: argparse.Namespace) -> None:
-    if args.command in ("lint-collection-docs", "lint-core-docs"):
+    if args.command in ("lint-collection-docs", "lint-core-docs", "ansible-output"):
         return
 
     args.dest_dir = os.path.abspath(os.path.realpath(args.dest_dir))
@@ -829,6 +830,22 @@ def parse_args(program_name: str, args: list[str]) -> argparse.Namespace:
         default=False,
         help="Determine whether to accept references to unknown collections"
         " that are not covered by --validate-collection-refs.",
+    )
+
+    #
+    # Compute/Update Ansible output in RST files
+    #
+    ansible_output_parser = subparsers.add_parser(
+        "ansible-output",
+        description="Update ansible-output code blocks in RST files",
+    )
+    ansible_output_parser.add_argument(
+        nargs="*",
+        dest="paths",
+        default=["docs/docsite/rst"],
+        help="One or more path to a directory or a RST file. If a directory"
+        " is specified, all RST files in it are processed recursively."
+        " If not specified, docs/docsite/rst is used.",
     )
 
     # This must come after all parser setup

--- a/src/antsibull_docs/cli/doc_commands/ansible_output.py
+++ b/src/antsibull_docs/cli/doc_commands/ansible_output.py
@@ -224,8 +224,9 @@ def _apply_replacements(
     *,
     path: Path,
     errors: list[tuple[Path, int | None, int | None, str]],
-) -> str:
+) -> tuple[str, bool]:
     content_lines = content.split("\n")
+    changed = False
 
     # Apply replacements sorted back to front
     for block, new_content in sorted(
@@ -242,11 +243,12 @@ def _apply_replacements(
             )
             continue
         content_lines = _replace(content_lines, block=block, new_content=new_content)
+        changed = True
 
     # Ensure trailing newline
     if content_lines and content_lines[-1]:
         content_lines.append("")
-    return "\n".join(content_lines)
+    return "\n".join(content_lines), changed
 
 
 def _compute_replacements(
@@ -432,7 +434,9 @@ def process_file(
         return
 
     flog.notice("Do replacements for {}", path)
-    content = _apply_replacements(content, replacements, path=path, errors=errors)
+    content, changed = _apply_replacements(content, replacements, path=path, errors=errors)
+    if not changed:
+        return
 
     flog.notice("Write {}", path)
     print(f"Write {path}...")

--- a/src/antsibull_docs/cli/doc_commands/ansible_output.py
+++ b/src/antsibull_docs/cli/doc_commands/ansible_output.py
@@ -344,7 +344,7 @@ def _add_replacements_as_errors(
             changes[-lines_to_skip:] = [
                 _colorize_diff(f"[... {lines_to_skip} lines skipped ...]", color=color)
             ]
-        message = f"Output would differ:\n{'\n'.join(changes)}"
+        message = "Output would differ:\n" + "\n".join(changes)
         errors.append(
             (path, code_block.row_offset + 1, code_block.col_offset + 1, message)
         )

--- a/src/antsibull_docs/cli/doc_commands/ansible_output.py
+++ b/src/antsibull_docs/cli/doc_commands/ansible_output.py
@@ -178,14 +178,17 @@ def _compute_code_block_content(
 
         command = ["ansible-playbook", "playbook.yml"]
         flog.notice("Run ansible-playbook: {}", command)
-        result = subprocess.run(
-            command,
-            capture_output=True,
-            cwd=directory,
-            env=env,
-            check=True,
-            encoding="utf-8",
-        )
+        try:
+            result = subprocess.run(
+                command,
+                capture_output=True,
+                cwd=directory,
+                env=env,
+                check=True,
+                encoding="utf-8",
+            )
+        except subprocess.CalledProcessError as exc:
+            raise ValueError(f"{exc}\nError output:\n{exc.stderr}") from exc
 
         flog.notice("Post-process result")
         # Compute result lines
@@ -279,7 +282,7 @@ def _compute_replacements(
                     path,
                     block_data.line,
                     block_data.col,
-                    f"Error while computing code block's expected contents: {exc}",
+                    f"Error while computing code block's expected contents:\n{exc}",
                 )
             )
             continue

--- a/src/antsibull_docs/cli/doc_commands/ansible_output.py
+++ b/src/antsibull_docs/cli/doc_commands/ansible_output.py
@@ -1,0 +1,357 @@
+# Author: Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2024, Ansible Project
+"""Entrypoint to the antsibull-docs script."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+from antsibull_core.logging import log
+from antsibull_docutils.rst_code_finder import (
+    CodeBlockInfo,
+    find_code_blocks,
+    mark_antsibull_code_block,
+)
+from docutils import nodes
+from yaml import MarkedYAMLError
+
+from sphinx_antsibull_ext.directive_helper import YAMLDirective
+from sphinx_antsibull_ext.schemas.ansible_output_data import AnsibleOutputData
+
+from ... import app_context
+
+mlog = log.fields(mod=__name__)
+
+
+_ANSIBLE_OUTPUT_DATA_IDENTIFIER = "{}[]XXXXXX"
+
+
+class AnsibleOutputDataDirective(YAMLDirective[AnsibleOutputData]):
+    wrap_as_data = False
+    schema = AnsibleOutputData
+
+    def _handle_error(self, message: str, from_exc: Exception) -> list[nodes.Node]:
+        literal = nodes.literal_block("", "")
+        mark_antsibull_code_block(
+            literal,
+            language=_ANSIBLE_OUTPUT_DATA_IDENTIFIER,
+            line=self.lineno,
+            other={
+                "error": message,
+                "exception": from_exc,
+            },
+        )
+        return [literal]
+
+    def _run(self, content_str: str, content: AnsibleOutputData) -> list[nodes.Node]:
+        literal = nodes.literal_block(content_str, "")
+        mark_antsibull_code_block(
+            literal,
+            language=_ANSIBLE_OUTPUT_DATA_IDENTIFIER,
+            line=self.lineno,
+            other={
+                "data": content,
+            },
+        )
+        return [literal]
+
+
+_DIRECTIVES = {
+    "ansible-output-data": AnsibleOutputDataDirective,
+}
+
+
+@dataclass
+class AnsibleOutputDataExt:
+    data: AnsibleOutputData
+    line: int
+    col: int
+
+
+def _get_ansible_output_data_error(block: CodeBlockInfo) -> tuple[int, int, str]:
+    message = block.attributes["antsibull-other-error"]
+    exc = block.attributes.get("antsibull-other-exception")
+    line = block.row_offset + 1
+    col = block.col_offset + 1
+    if isinstance(exc, MarkedYAMLError) and exc.problem_mark:
+        # YAML's line/column are 0-based
+        if isinstance(exc.problem_mark.line, int):
+            line += exc.problem_mark.line
+        if isinstance(exc.problem_mark.column, int):
+            col += exc.problem_mark.column
+    return line, col, message
+
+
+def find_blocks(
+    *,
+    content: str,
+    path: Path,
+    root: Path | None = None,
+    errors: list[tuple[Path, int | None, int | None, str]],
+) -> list[tuple[CodeBlockInfo, AnsibleOutputDataExt]]:
+    blocks: list[tuple[CodeBlockInfo, AnsibleOutputDataExt]] = []
+    data: AnsibleOutputDataExt | None = None
+    for block in find_code_blocks(
+        content, path=path, root_prefix=root, extra_directives=_DIRECTIVES
+    ):
+        if block.language == _ANSIBLE_OUTPUT_DATA_IDENTIFIER:
+            if "antsibull-other-data" in block.attributes:
+                data = AnsibleOutputDataExt(
+                    data=block.attributes["antsibull-other-data"],
+                    line=block.row_offset + 1,
+                    col=block.col_offset + 1,
+                )
+            if "antsibull-other-error" in block.attributes:
+                line, col, message = _get_ansible_output_data_error(block)
+                errors.append((path, line, col, message))
+            continue
+        if block.language != "ansible-output":
+            continue
+        if data is None:
+            continue
+        block_data, data = data, None
+        if not block.directly_replacable_in_content:
+            errors.append(
+                (
+                    path,
+                    block.row_offset + 1,
+                    block.col_offset + 1,
+                    "Code block is not replacable",
+                )
+            )
+            continue
+        blocks.append((block, block_data))
+    return blocks
+
+
+def compute_code_block_content(
+    data: AnsibleOutputDataExt, *, collection_path: Path | None = None
+) -> list[str]:
+    flog = mlog.fields(func="compute_code_block_content")
+
+    flog.notice("Prepare environment")
+    env = os.environ.copy()
+    env.pop("ANSIBLE_FORCE_COLOR", None)
+    env["NO_COLOR"] = "true"
+    if collection_path is not None:
+        collections_path = env.get("ANSIBLE_COLLECTIONS_PATH") or ""
+        if collections_path:
+            collections_path = f"{collection_path}:{collections_path}"
+        else:
+            collections_path = f"{collection_path}"
+        env["ANSIBLE_COLLECTIONS_PATH"] = collections_path
+    env.update(data.data.env)
+
+    flog.notice("Prepare temporary directory")
+    with tempfile.TemporaryDirectory(prefix="antsibull-docs-output") as directory:
+        file = Path(directory) / "playbook.yml"
+        with open(file, "w", encoding="utf-8") as f:
+            f.write(data.data.playbook)
+
+        flog.notice("Run ansible-playbook")
+        command = ["ansible-playbook", "playbook.yml"]
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            cwd=str(directory),
+            env=env,
+            check=True,
+            encoding="utf-8",
+        )
+
+        flog.notice("Post-process result")
+        # Compute result lines
+        lines = [line.rstrip() for line in result.stdout.split("\n")]
+        first = 0
+        last = len(lines)
+        while first < last and not lines[first]:
+            first += 1
+        while first < last and not lines[last - 1]:
+            last -= 1
+        return lines[first:last]
+
+
+def _replace(
+    content_lines: list[str], *, block: CodeBlockInfo, new_content: list[str]
+) -> list[str]:
+    first_line = block.row_offset
+    last_line = first_line + block.content.count("\n") - 1
+    before = content_lines[:first_line]
+    after = content_lines[last_line + 1 :]
+    indent = " " * block.col_offset
+    new_lines = [f"{indent}{line}" if line else "" for line in new_content]
+    return before + new_lines + after
+
+
+def _apply_replacements(
+    content: str, replacements: list[tuple[CodeBlockInfo, list[str]]]
+) -> str:
+    content_lines = content.split("\n")
+
+    # Apply replacements sorted back to front
+    for block, new_content in sorted(
+        replacements, key=lambda entry: -entry[0].row_offset
+    ):
+        content_lines = _replace(content_lines, block=block, new_content=new_content)
+
+    # Ensure trailing newline
+    if content_lines and content_lines[-1]:
+        content_lines.append("")
+    return "\n".join(content_lines)
+
+
+def _compute_replacements(
+    content: str,
+    *,
+    path: Path,
+    root: Path | None = None,
+    errors: list[tuple[Path, int | None, int | None, str]],
+    collection_path: Path | None = None,
+) -> list[tuple[CodeBlockInfo, list[str]]]:
+    flog = mlog.fields(func="_compute_replacements")
+    flog.notice("Find code blocks in file")
+    try:
+        blocks = find_blocks(content=content, path=path, root=root, errors=errors)
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        errors.append((path, None, None, f"Error while finding code blocks: {exc}"))
+        return []
+
+    replacements: list[tuple[CodeBlockInfo, list[str]]] = []
+    for block, block_data in blocks:
+        flog.notice("Processing block at line {}", block.row_offset + 1)
+        try:
+            new_content = compute_code_block_content(
+                block_data, collection_path=collection_path
+            )
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            errors.append(
+                (
+                    path,
+                    block_data.line,
+                    block_data.col,
+                    f"Error while computing code block's expected contents: {exc}",
+                )
+            )
+            continue
+        old_content = block.content.split("\n")
+        if old_content and old_content[-1] == "":
+            old_content.pop()
+        if new_content != old_content:
+            replacements.append((block, new_content))
+    return replacements
+
+
+def process_file(
+    path: Path,
+    *,
+    root: Path | None = None,
+    errors: list[tuple[Path, int | None, int | None, str]],
+    collection_path: Path | None = None,
+) -> None:
+    """
+    Process RST file.
+
+    Note that this function must not be used in multiple threads at the same time!
+    """
+    flog = mlog.fields(func="process_file")
+
+    flog.notice("Load {}", path)
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            content = f.read()
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        errors.append((path, None, None, f"Error while reading content: {exc}"))
+        return
+
+    flog.notice("Compute replacements")
+    replacements = _compute_replacements(
+        content,
+        path=path,
+        root=root,
+        errors=errors,
+        collection_path=collection_path,
+    )
+    if not replacements:
+        return
+
+    flog.notice("Do replacements for {}", path)
+    content = _apply_replacements(content, replacements)
+
+    flog.notice("Write {}", path)
+    print(f"Write {path}...")
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(content)
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        errors.append((path, None, None, f"Error while writing content: {exc}"))
+
+
+def process_directory(
+    path: Path,
+    *,
+    errors: list[tuple[Path, int | None, int | None, str]],
+    collection_path: Path | None = None,
+) -> None:
+    try:
+        for dirpath, _, filenames in path.walk():
+            for filename in filenames:
+                if filename.endswith(".rst"):
+                    process_file(
+                        dirpath / filename,
+                        root=path,
+                        errors=errors,
+                        collection_path=collection_path,
+                    )
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        errors.append((path, None, None, f"Error while listing files: {exc}"))
+
+
+def run_ansible_output() -> int:
+    """
+    Lint collection documentation for inclusion into the collection's docsite.
+
+    :returns: A return code for the program.  See :func:`antsibull.cli.antsibull_docs.main` for
+        details on what each code means.
+    """
+    flog = mlog.fields(func="run_ansible_output")
+    flog.notice("Begin ansible-output rendering")
+
+    app_ctx = app_context.app_ctx.get()
+
+    paths: tuple[str, ...] = app_ctx.extra["paths"]
+
+    errors: list[tuple[Path, int | None, int | None, str]] = []
+    for path in paths:
+        path_obj = Path(path)
+        if path_obj.is_dir():
+            process_directory(path_obj, errors=errors)
+        elif path_obj.exists():
+            process_file(path_obj, errors=errors)
+        else:
+            errors.append((path_obj, None, None, "Does not exist"))
+
+    if errors:
+        print(f"\nFound {len(errors)} error{'' if len(errors) == 1 else 's'}:")
+        for error_path, line, col, error in sorted(
+            errors,
+            key=lambda entry: (str(entry[0]), entry[1] or 0, entry[2] or 0, entry[3]),
+        ):
+            prefix = f"{error_path}:{line or '-'}:{col or '-'}: "
+            error_lines = [error_line.rstrip() for error_line in error.split("\n")]
+            print(f"{prefix}{error_lines[0]}")
+            if len(error_lines) > 1:
+                prefix = "   "
+                for error_line in error_lines[1:]:
+                    if error_line:
+                        print(f"{prefix}{error_line}")
+                    else:
+                        print()
+
+    return 3 if len(errors) > 0 else 0

--- a/src/antsibull_docs/cli/doc_commands/ansible_output.py
+++ b/src/antsibull_docs/cli/doc_commands/ansible_output.py
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or
 # https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
-# SPDX-FileCopyrightText: 2024, Ansible Project
+# SPDX-FileCopyrightText: 2025, Ansible Project
 """Entrypoint to the antsibull-docs script."""
 
 from __future__ import annotations

--- a/src/antsibull_docs/cli/doc_commands/ansible_output.py
+++ b/src/antsibull_docs/cli/doc_commands/ansible_output.py
@@ -434,7 +434,9 @@ def process_file(
         return
 
     flog.notice("Do replacements for {}", path)
-    content, changed = _apply_replacements(content, replacements, path=path, errors=errors)
+    content, changed = _apply_replacements(
+        content, replacements, path=path, errors=errors
+    )
     if not changed:
         return
 

--- a/src/antsibull_docs/cli/doc_commands/ansible_output.py
+++ b/src/antsibull_docs/cli/doc_commands/ansible_output.py
@@ -16,7 +16,9 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
+import pydantic
 from antsibull_core.logging import log
+from antsibull_core.pydantic import get_formatted_error_messages
 from antsibull_docutils.rst_code_finder import (
     CodeBlockInfo,
     find_code_blocks,
@@ -94,6 +96,11 @@ def _get_ansible_output_data_error(block: CodeBlockInfo) -> tuple[int, int, str]
             line += exc.problem_mark.line
         if isinstance(exc.problem_mark.column, int):
             col += exc.problem_mark.column
+    if isinstance(exc, pydantic.ValidationError):
+        message = (
+            "Error while validating ansible-output-data directive's contents:\n"
+            + "\n".join(get_formatted_error_messages(exc))
+        )
     return line, col, message
 
 

--- a/src/antsibull_docs/cli/doc_commands/ansible_output.py
+++ b/src/antsibull_docs/cli/doc_commands/ansible_output.py
@@ -107,6 +107,15 @@ def _find_blocks(
         content, path=path, root_prefix=root, extra_directives=_DIRECTIVES
     ):
         if block.language == _ANSIBLE_OUTPUT_DATA_IDENTIFIER:
+            if data is not None:
+                errors.append(
+                    (
+                        path,
+                        data.line,
+                        data.col,
+                        "ansible-output-data directive not used",
+                    )
+                )
             if "antsibull-other-data" in block.attributes:
                 data = _AnsibleOutputDataExt(
                     data=block.attributes["antsibull-other-data"],
@@ -133,6 +142,15 @@ def _find_blocks(
             )
             continue
         blocks.append((block, block_data))
+    if data is not None:
+        errors.append(
+            (
+                path,
+                data.line,
+                data.col,
+                "ansible-output-data directive not used",
+            )
+        )
     return blocks
 
 

--- a/src/antsibull_docs/schemas/collection_config.py
+++ b/src/antsibull_docs/schemas/collection_config.py
@@ -17,6 +17,20 @@ class AnsibleOutputConfig(p.BaseModel):
     # Environment variables to inject for every ansible-output-data
     global_env: dict[str, str] = {}
 
+    @p.field_validator("global_env", mode="before")
+    @classmethod
+    def convert_dict_values(cls, obj):
+        """
+        Convert dictionary values to strings that have a unique string representation.
+        Values without a unique string representation (floats, booleans, ...)
+        are not converted.
+        """
+        if isinstance(obj, dict):
+            for k, v in obj.items():
+                if isinstance(v, int):
+                    obj[k] = str(v)
+        return obj
+
 
 class CollectionConfig(p.BaseModel):
     # Whether the collection uses flatmapping to flatten subdirectories in

--- a/src/antsibull_docs/schemas/collection_config.py
+++ b/src/antsibull_docs/schemas/collection_config.py
@@ -13,6 +13,11 @@ class ChangelogConfig(p.BaseModel):
     write_changelog: bool = False
 
 
+class AnsibleOutputConfig(p.BaseModel):
+    # Environment variables to inject for every ansible-output-data
+    global_env: dict[str, str] = {}
+
+
 class CollectionConfig(p.BaseModel):
     # Whether the collection uses flatmapping to flatten subdirectories in
     # `plugins/*/`.
@@ -24,3 +29,6 @@ class CollectionConfig(p.BaseModel):
 
     # Changelog configuration (added in version 2.10.0)
     changelog: ChangelogConfig = ChangelogConfig()
+
+    # ansible-output subcommand configuration (added in version 2.19.0)
+    ansible_output: AnsibleOutputConfig = AnsibleOutputConfig()

--- a/src/sphinx_antsibull_ext/directive_helper.py
+++ b/src/sphinx_antsibull_ext/directive_helper.py
@@ -30,15 +30,18 @@ class YAMLDirective(Directive, t.Generic[SchemaT], metaclass=abc.ABCMeta):
     def _run(self, content_str: str, content: SchemaT) -> list[nodes.Node]:
         pass
 
+    def _handle_error(self, message: str, from_exc: Exception) -> list[nodes.Node]:
+        raise self.error(message) from from_exc
+
     def run(self) -> list[nodes.Node]:
         self.assert_has_content()
         content_str = "\n".join(self.content)
         try:
             content = load_yaml_bytes(content_str.encode("utf-8"))
-        except Exception as exc:
-            raise self.error(
-                f"Error while parsing content of {self.name} as YAML: {exc}"
-            ) from exc
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            return self._handle_error(
+                f"Error while parsing content of {self.name} as YAML: {exc}", exc
+            )
         if self.wrap_as_data:
             content = {
                 "data": content,
@@ -46,7 +49,7 @@ class YAMLDirective(Directive, t.Generic[SchemaT], metaclass=abc.ABCMeta):
         try:
             content_obj = self.schema.model_validate(content)
         except p.ValidationError as exc:
-            raise self.error(
-                f"Error while parsing content of {self.name}: {exc}"
-            ) from exc
+            return self._handle_error(
+                f"Error while parsing content of {self.name}: {exc}", exc
+            )
         return self._run(content_str, content_obj)

--- a/src/sphinx_antsibull_ext/directives.py
+++ b/src/sphinx_antsibull_ext/directives.py
@@ -16,6 +16,7 @@ from sphinx import addnodes
 from .directive_helper import YAMLDirective
 from .nodes import link_button
 from .schemas.ansible_links import AnsibleLinks
+from .schemas.ansible_output_data import AnsibleOutputData
 
 
 class _OptionTypeLine(Directive):
@@ -71,9 +72,19 @@ class _Links(YAMLDirective[AnsibleLinks]):
         return [node]
 
 
+class _AnsibleOutputDataDirective(YAMLDirective[AnsibleOutputData]):
+    wrap_as_data = True
+    schema = AnsibleOutputData
+
+    def _run(self, content_str: str, content: AnsibleOutputData) -> list[nodes.Node]:
+        # This directive should produce no output. It is used in the ansible-output subcommand.
+        return []
+
+
 DIRECTIVES = {
     "ansible-option-type-line": _OptionTypeLine,
     "ansible-links": _Links,
+    "ansible-output-data": _AnsibleOutputDataDirective,
 }
 
 

--- a/src/sphinx_antsibull_ext/schemas/ansible_output_data.py
+++ b/src/sphinx_antsibull_ext/schemas/ansible_output_data.py
@@ -15,3 +15,17 @@ class AnsibleOutputData(p.BaseModel):
     env: dict[str, str] = {}
     prepend_lines: str = ""
     language: str = "ansible-output"
+
+    @p.field_validator("env", mode="before")
+    @classmethod
+    def convert_dict_values(cls, obj):
+        """
+        Convert dictionary values to strings that have a unique string representation.
+        Values without a unique string representation (floats, booleans, ...)
+        are not converted.
+        """
+        if isinstance(obj, dict):
+            for k, v in obj.items():
+                if isinstance(v, int):
+                    obj[k] = str(v)
+        return obj

--- a/src/sphinx_antsibull_ext/schemas/ansible_output_data.py
+++ b/src/sphinx_antsibull_ext/schemas/ansible_output_data.py
@@ -13,3 +13,5 @@ import pydantic as p
 class AnsibleOutputData(p.BaseModel):
     playbook: str
     env: dict[str, str] = {}
+    prepend_lines: str = ""
+    language: str = "ansible-output"

--- a/src/sphinx_antsibull_ext/schemas/ansible_output_data.py
+++ b/src/sphinx_antsibull_ext/schemas/ansible_output_data.py
@@ -1,0 +1,15 @@
+# Author: Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2025, Ansible Project
+"""Schema for ansible-output-data directive."""
+
+from __future__ import annotations
+
+import pydantic as p
+
+
+class AnsibleOutputData(p.BaseModel):
+    playbook: str
+    env: dict[str, str] = {}

--- a/tests/functional/test_ansible_output.py
+++ b/tests/functional/test_ansible_output.py
@@ -344,13 +344,9 @@ broken-meta-yaml.rst:5:15: Error while parsing content of ansible-output-data as
         3,
         r"""
 Found 1 error:
-broken-meta-schema.rst:4:5: Error while parsing content of ansible-output-data: 2 validation errors for AnsibleOutputData
-   playbook
-     Input should be a valid string [type=string_type, input_value=[], input_type=list]
-       For further information visit https://errors.pydantic.dev/2.10/v/string_type
-   env
-     Input should be a valid dictionary [type=dict_type, input_value=123, input_type=int]
-       For further information visit https://errors.pydantic.dev/2.10/v/dict_type
+broken-meta-schema.rst:4:5: Error while validating ansible-output-data directive's contents:
+   playbook: Input should be a valid string
+   env: Input should be a valid dictionary
 """,
     ),
     (

--- a/tests/functional/test_ansible_output.py
+++ b/tests/functional/test_ansible_output.py
@@ -217,7 +217,7 @@ ok: [localhost] => {
 
     env:
       ANSIBLE_STDOUT_CALLBACK: community.general.tasks_only
-      ANSIBLE_COLLECTIONS_TASKS_ONLY_COLUMN_WIDTH: "80"
+      ANSIBLE_COLLECTIONS_TASKS_ONLY_COLUMN_WIDTH: 80
     playbook: |-
       - hosts: localhost
         gather_facts: false
@@ -756,7 +756,15 @@ def test_ansible_output_check(
 
 
 EXPECTED_REPLACE_RESULTS: list[
-    tuple[str, str, AnsiblePlaybookSuccess | AnsiblePlaybookFailure | None, int, str, bool, str]
+    tuple[
+        str,
+        str,
+        AnsiblePlaybookSuccess | AnsiblePlaybookFailure | None,
+        int,
+        str,
+        bool,
+        str,
+    ]
 ] = [
     (
         "no-code-block.rst",
@@ -891,7 +899,7 @@ This produces:
 
     env:
       ANSIBLE_STDOUT_CALLBACK: community.general.tasks_only
-      ANSIBLE_COLLECTIONS_TASKS_ONLY_COLUMN_WIDTH: "80"
+      ANSIBLE_COLLECTIONS_TASKS_ONLY_COLUMN_WIDTH: 80
     playbook: |-
       - hosts: localhost
         gather_facts: false
@@ -947,7 +955,7 @@ ok: [localhost] => {
 
     env:
       ANSIBLE_STDOUT_CALLBACK: community.general.tasks_only
-      ANSIBLE_COLLECTIONS_TASKS_ONLY_COLUMN_WIDTH: "80"
+      ANSIBLE_COLLECTIONS_TASKS_ONLY_COLUMN_WIDTH: 80
     playbook: |-
       - hosts: localhost
         gather_facts: false

--- a/tests/functional/test_ansible_output.py
+++ b/tests/functional/test_ansible_output.py
@@ -407,82 +407,115 @@ foo
         "",
     ),
     (
-        "complex-diff.rst",
+        "language-and-prepend.rst",
         """
 .. ansible-output-data::
 
     playbook: ""
+    prepend_lines: |-
+      Hello
+      World!
+    language: bar
 
-.. code-block:: ansible-output
+.. code-block:: foo
 
-    1
-    2
-    3
-    4
-    5
-    6
-    7
-    8
-    9
-    10
-    11
-    11 again
-    12
-    13
-    14
-    15
-    16
-    17
-    18
-    19
-    20
+    foo
+
+.. code-block:: bar
+
+    Hello
+    World!
+    bar
+
+.. code-block:: baz
+
+    baz
 """,
         ["ansible-playbook", "playbook.yml"],
         {},
         """
-2
-4
-5
-6
-7
-8
-9
-10
-11
-12
-13
-14
-15
-16
-17
-eighteen
-nineteen
-20
+bar
 """,
-        3,
-        r"""
-Found 1 error:
-complex-diff.rst:8:5: Output would differ:
-   - 1
-     2
-   - 3
-     4
-     5
-   [... 4 lines skipped ...]
-     10
-     11
-   - 11 again
-     12
-     13
-   [... 2 lines skipped ...]
-     16
-     17
-   - 18
-   - 19
-   + eighteen
-   + nineteen
-     20
+        0,
+        "",
+    ),
+    (
+        "working-test.rst",
+        """
+Working with versions
+---------------------
+
+If you need to sort a list of version numbers, the Jinja ``sort`` filter is problematic. Since it sorts lexicographically, ``2.10`` will come before ``2.9``. To treat version numbers correctly, you can use the :ansplugin:`community.general.version_sort filter <community.general.version_sort#filter>`:
+
+.. code-block:: yaml+jinja
+
+    - name: Sort list by version number
+      debug:
+        var: ansible_versions | community.general.version_sort
+      vars:
+        ansible_versions:
+          - '2.8.0'
+          - '2.11.0'
+          - '2.7.0'
+          - '2.10.0'
+          - '2.9.0'
+
+This produces:
+
+.. ansible-output-data::
+
+    env:
+      ANSIBLE_STDOUT_CALLBACK: community.general.tasks_only
+      ANSIBLE_COLLECTIONS_TASKS_ONLY_COLUMN_WIDTH: "90"
+    playbook: |-
+      - hosts: localhost
+        gather_facts: false
+        tasks:
+          - name: Sort list by version number
+            debug:
+              var: ansible_versions | community.general.version_sort
+            vars:
+              ansible_versions:
+                - '2.8.0'
+                - '2.11.0'
+                - '2.7.0'
+                - '2.10.0'
+                - '2.9.0'
+
+.. code-block:: ansible-output
+
+    TASK [Sort list by version number] ********************************************************
+    ok: [localhost] => {
+        "ansible_versions | community.general.version_sort": [
+            "2.7.0",
+            "2.8.0",
+            "2.9.0",
+            "2.10.0",
+            "2.11.0"
+        ]
+    }
+
+.. versionadded: 2.2.0
 """,
+        ["ansible-playbook", "playbook.yml"],
+        {
+            "NO_COLOR": "true",
+            "ANSIBLE_STDOUT_CALLBACK": "community.general.tasks_only",
+            "ANSIBLE_COLLECTIONS_TASKS_ONLY_COLUMN_WIDTH": "90",
+        },
+        """TASK [Sort list by version number] ********************************************************
+ok: [localhost] => {
+    "ansible_versions | community.general.version_sort": [
+        "2.7.0",
+        "2.8.0",
+        "2.9.0",
+        "2.10.0",
+        "2.11.0"
+    ]
+}
+""",
+        0,
+        "",
     ),
 ]
 

--- a/tests/functional/test_ansible_output.py
+++ b/tests/functional/test_ansible_output.py
@@ -1102,7 +1102,7 @@ ok: [localhost] => {
         3,
         r"""
 Found 1 error:
-failing-test-in-table.rst:5:1: Code block is not replacable
+failing-test-in-table.rst:6:1: Code block is not replacable
 """,
         False,
         """

--- a/tests/functional/test_ansible_output.py
+++ b/tests/functional/test_ansible_output.py
@@ -1,0 +1,354 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import io
+from contextlib import contextmanager, redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from utils import change_cwd
+
+from antsibull_docs.cli.antsibull_docs import run
+
+
+@contextmanager
+def patch_ansible_playbook(
+    *,
+    expected_cmd: list[str],
+    expected_env: dict[str, str | None],
+    stdout: str = "",
+    stderr: str = "",
+) -> None:
+    class Result:
+        def __init__(self) -> None:
+            self.returncode = 0
+            self.stdout = stdout
+            self.stderr = stderr
+
+    def subprocess_run(
+        command,
+        *,
+        capture_output: bool,
+        cwd: str | Path,
+        env: dict[str, str],
+        check: bool,
+        encoding: str,
+    ) -> Result:
+        assert capture_output == True
+        assert cwd is not None
+        assert check is True
+        assert encoding == "utf-8"
+        for key, value in expected_env.items():
+            if value is None:
+                assert key not in env
+            else:
+                assert env[key] == value
+        assert command == expected_cmd
+        return Result()
+
+    with mock.patch(
+        "antsibull_docs.cli.doc_commands.ansible_output.subprocess.run",
+        subprocess_run,
+    ):
+        yield
+
+
+EXPECTED_CHECK_RESULTS: list[
+    tuple[str, str, list[str], dict[str, str | None], str, int, str]
+] = [
+    (
+        "no-code-block.rst",
+        """
+Working with versions
+---------------------
+
+Foo.
+""",
+        [],
+        {},
+        "",
+        0,
+        "",
+    ),
+    (
+        "no-data.rst",
+        """
+Working with versions
+---------------------
+
+.. code-block:: ansible-output
+
+    TASK [Sort list by version number] ********************************************************
+    ok: [localhost] => {
+        "ansible_versions | community.general.version_sort": [
+            "2.7.0",
+            "2.8.0",
+            "2.9.0",
+            "2.10.0",
+            "2.11.0"
+        ]
+    }
+
+.. versionadded: 2.2.0
+""",
+        [],
+        {},
+        "",
+        0,
+        "",
+    ),
+    (
+        "working-test.rst",
+        """
+Working with versions
+---------------------
+
+If you need to sort a list of version numbers, the Jinja ``sort`` filter is problematic. Since it sorts lexicographically, ``2.10`` will come before ``2.9``. To treat version numbers correctly, you can use the :ansplugin:`community.general.version_sort filter <community.general.version_sort#filter>`:
+
+.. code-block:: yaml+jinja
+
+    - name: Sort list by version number
+      debug:
+        var: ansible_versions | community.general.version_sort
+      vars:
+        ansible_versions:
+          - '2.8.0'
+          - '2.11.0'
+          - '2.7.0'
+          - '2.10.0'
+          - '2.9.0'
+
+This produces:
+
+.. ansible-output-data::
+
+    env:
+      ANSIBLE_STDOUT_CALLBACK: community.general.tasks_only
+      ANSIBLE_COLLECTIONS_TASKS_ONLY_COLUMN_WIDTH: "90"
+    playbook: |-
+      - hosts: localhost
+        gather_facts: false
+        tasks:
+          - name: Sort list by version number
+            debug:
+              var: ansible_versions | community.general.version_sort
+            vars:
+              ansible_versions:
+                - '2.8.0'
+                - '2.11.0'
+                - '2.7.0'
+                - '2.10.0'
+                - '2.9.0'
+
+.. code-block:: ansible-output
+
+    TASK [Sort list by version number] ********************************************************
+    ok: [localhost] => {
+        "ansible_versions | community.general.version_sort": [
+            "2.7.0",
+            "2.8.0",
+            "2.9.0",
+            "2.10.0",
+            "2.11.0"
+        ]
+    }
+
+.. versionadded: 2.2.0
+""",
+        ["ansible-playbook", "playbook.yml"],
+        {
+            "NO_COLOR": "true",
+            "ANSIBLE_STDOUT_CALLBACK": "community.general.tasks_only",
+            "ANSIBLE_COLLECTIONS_TASKS_ONLY_COLUMN_WIDTH": "90",
+        },
+        """TASK [Sort list by version number] ********************************************************
+ok: [localhost] => {
+    "ansible_versions | community.general.version_sort": [
+        "2.7.0",
+        "2.8.0",
+        "2.9.0",
+        "2.10.0",
+        "2.11.0"
+    ]
+}
+""",
+        0,
+        "",
+    ),
+    (
+        "modified-test.rst",
+        """
+.. ansible-output-data::
+
+    env:
+      ANSIBLE_STDOUT_CALLBACK: community.general.tasks_only
+      ANSIBLE_COLLECTIONS_TASKS_ONLY_COLUMN_WIDTH: "80"
+    playbook: |-
+      - hosts: localhost
+        gather_facts: false
+        tasks:
+          - name: Sort list by version number
+            debug:
+              var: ansible_versions | community.general.version_sort
+            vars:
+              ansible_versions:
+                - '2.8.0'
+                - '2.11.0'
+                - '2.7.0'
+                - '2.10.0'
+
+.. code-block:: ansible-output
+
+    TASK [Sort list by version number] ********************************************************
+    ok: [localhost] => {
+        "ansible_versions | community.general.version_sort": [
+            "2.7.0",
+            "2.8.0",
+            "2.9.0",
+            "2.10.0",
+            "2.11.0"
+        ]
+    }
+
+.. versionadded: 2.2.0
+""",
+        ["ansible-playbook", "playbook.yml"],
+        {
+            "NO_COLOR": "true",
+            "ANSIBLE_STDOUT_CALLBACK": "community.general.tasks_only",
+            "ANSIBLE_COLLECTIONS_TASKS_ONLY_COLUMN_WIDTH": "80",
+        },
+        """TASK [Sort list by version number] **********************************************
+ok: [localhost] => {
+    "ansible_versions | community.general.version_sort": [
+        "2.7.0",
+        "2.8.0",
+        "2.10.0",
+        "2.11.0"
+    ]
+}
+""",
+        3,
+        r"""
+Found 1 error:
+modified-test.rst:23:5: Output would differ:
+   - TASK [Sort list by version number] ********************************************************
+   ?                                                                                  ----------
+   + TASK [Sort list by version number] **********************************************
+     ok: [localhost] => {
+         "ansible_versions | community.general.version_sort": [
+             "2.7.0",
+             "2.8.0",
+   -         "2.9.0",
+             "2.10.0",
+             "2.11.0"
+   [... 2 lines skipped ...]
+""",
+    ),
+    (
+        "missing-test.rst",
+        """
+.. ansible-output-data::
+
+    env:
+      ANSIBLE_STDOUT_CALLBACK: community.general.tasks_only
+      ANSIBLE_COLLECTIONS_TASKS_ONLY_COLUMN_WIDTH: "90"
+    playbook: |-
+      - hosts: localhost
+        gather_facts: false
+        tasks:
+          - name: Sort list by version number
+            debug:
+              var: ansible_versions | community.general.version_sort
+            vars:
+              ansible_versions:
+                - '2.8.0'
+                - '2.11.0'
+                - '2.7.0'
+                - '2.10.0'
+                - '2.9.0'
+
+.. code-block:: ansible-output
+
+    ...
+""",
+        ["ansible-playbook", "playbook.yml"],
+        {
+            "NO_COLOR": "true",
+            "ANSIBLE_STDOUT_CALLBACK": "community.general.tasks_only",
+            "ANSIBLE_COLLECTIONS_TASKS_ONLY_COLUMN_WIDTH": "90",
+        },
+        """TASK [Sort list by version number] ********************************************************
+ok: [localhost] => {
+    "ansible_versions | community.general.version_sort": [
+        "2.7.0",
+        "2.8.0",
+        "2.9.0",
+        "2.10.0",
+        "2.11.0"
+    ]
+}
+""",
+        3,
+        r"""
+Found 1 error:
+missing-test.rst:24:5: Output would differ:
+   - ...
+   + TASK [Sort list by version number] ********************************************************
+   + ok: [localhost] => {
+   +     "ansible_versions | community.general.version_sort": [
+   +         "2.7.0",
+   +         "2.8.0",
+   +         "2.9.0",
+   +         "2.10.0",
+   +         "2.11.0"
+   +     ]
+   + }
+""",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "rst_filename, rst_content, ansible_playbook_expected_cmd, ansible_playbook_expected_env, ansible_playbook_output, expected_rc, expected_stdout",
+    EXPECTED_CHECK_RESULTS,
+    ids=[entry[0] for entry in EXPECTED_CHECK_RESULTS],
+)
+def test_ansible_output_check(
+    rst_filename: str,
+    rst_content: str,
+    ansible_playbook_expected_cmd: list[str],
+    ansible_playbook_expected_env: dict[str, str | None],
+    ansible_playbook_output: str,
+    expected_rc: int,
+    expected_stdout: str,
+    tmp_path: Path,
+):
+    command = [
+        "antsibull-docs",
+        "ansible-output",
+        "--check",
+        "--no-force-color",
+        rst_filename,
+    ]
+
+    (tmp_path / rst_filename).write_text(rst_content)
+
+    stdout = io.StringIO()
+    with change_cwd(tmp_path):
+        with redirect_stdout(stdout):
+            with patch_ansible_playbook(
+                expected_cmd=ansible_playbook_expected_cmd,
+                expected_env=ansible_playbook_expected_env,
+                stdout=ansible_playbook_output,
+            ):
+                actual_rc = run(command)
+    print(f"RC: {actual_rc}")
+    print("Stdout:")
+    print(stdout.getvalue())
+    assert actual_rc == expected_rc
+    assert stdout.getvalue() == expected_stdout

--- a/tests/functional/test_ansible_output.py
+++ b/tests/functional/test_ansible_output.py
@@ -310,6 +310,180 @@ missing-test.rst:24:5: Output would differ:
    + }
 """,
     ),
+    (
+        "broken-meta-yaml.rst",
+        """
+.. ansible-output-data::
+
+    env: {
+    playbook: |-
+      foo
+""",
+        [],
+        {},
+        "",
+        3,
+        r"""
+Found 1 error:
+broken-meta-yaml.rst:5:15: Error while parsing content of ansible-output-data as YAML: while scanning for the next token
+   found character that cannot start any token
+     in "<byte string>", line 2, column 11
+""",
+    ),
+    (
+        "broken-meta-schema.rst",
+        """
+.. ansible-output-data::
+
+    env: 123
+    playbook: []
+""",
+        [],
+        {},
+        "",
+        3,
+        r"""
+Found 1 error:
+broken-meta-schema.rst:4:5: Error while parsing content of ansible-output-data: 2 validation errors for AnsibleOutputData
+   playbook
+     Input should be a valid string [type=string_type, input_value=[], input_type=list]
+       For further information visit https://errors.pydantic.dev/2.10/v/string_type
+   env
+     Input should be a valid dictionary [type=dict_type, input_value=123, input_type=int]
+       For further information visit https://errors.pydantic.dev/2.10/v/dict_type
+""",
+    ),
+    (
+        "unused-ansible-output-data.rst",
+        """
+.. ansible-output-data::
+
+    playbook: ""
+
+.. ansible-output-data::
+
+    playbook: ""
+
+.. code-block:: ansible-output
+
+    foo
+
+.. ansible-output-data::
+
+    playbook: ""
+
+""",
+        ["ansible-playbook", "playbook.yml"],
+        {},
+        "foo\n",
+        3,
+        r"""
+Found 2 errors:
+unused-ansible-output-data.rst:4:5: ansible-output-data directive not used
+unused-ansible-output-data.rst:16:5: ansible-output-data directive not used
+""",
+    ),
+    (
+        "multiple-empty-lines.rst",
+        """
+.. ansible-output-data::
+
+    playbook: foo
+
+.. code-block:: ansible-output
+
+    foo
+""",
+        ["ansible-playbook", "playbook.yml"],
+        {},
+        """
+
+
+foo
+
+
+""",
+        0,
+        "",
+    ),
+    (
+        "complex-diff.rst",
+        """
+.. ansible-output-data::
+
+    playbook: ""
+
+.. code-block:: ansible-output
+
+    1
+    2
+    3
+    4
+    5
+    6
+    7
+    8
+    9
+    10
+    11
+    11 again
+    12
+    13
+    14
+    15
+    16
+    17
+    18
+    19
+    20
+""",
+        ["ansible-playbook", "playbook.yml"],
+        {},
+        """
+2
+4
+5
+6
+7
+8
+9
+10
+11
+12
+13
+14
+15
+16
+17
+eighteen
+nineteen
+20
+""",
+        3,
+        r"""
+Found 1 error:
+complex-diff.rst:8:5: Output would differ:
+   - 1
+     2
+   - 3
+     4
+     5
+   [... 4 lines skipped ...]
+     10
+     11
+   - 11 again
+     12
+     13
+   [... 2 lines skipped ...]
+     16
+     17
+   - 18
+   - 19
+   + eighteen
+   + nineteen
+     20
+""",
+    ),
 ]
 
 

--- a/tests/functional/test_ansible_output.py
+++ b/tests/functional/test_ansible_output.py
@@ -513,6 +513,84 @@ ok: [localhost] => {
         0,
         "",
     ),
+    (
+        "complex-diff.rst",
+        """
+.. ansible-output-data::
+
+    playbook: ""
+
+.. code-block:: ansible-output
+
+    1
+    2
+    3
+    4
+    5
+    6
+    7
+    8
+    9
+    10
+    11
+    11 again
+    12
+    13
+    14
+    15
+    16
+    17
+    18
+    19
+    20
+""",
+        ["ansible-playbook", "playbook.yml"],
+        {},
+        """
+2
+4
+5
+6
+7
+8
+9
+10
+11
+12
+13
+14
+15
+16
+17
+eighteen
+nineteen
+20
+""",
+        3,
+        r"""
+Found 1 error:
+complex-diff.rst:8:5: Output would differ:
+   - 1
+     2
+   - 3
+     4
+     5
+   [... 4 lines skipped ...]
+     10
+     11
+   - 11 again
+     12
+     13
+   [... 2 lines skipped ...]
+     16
+     17
+   - 18
+   - 19
+   + eighteen
+   + nineteen
+     20
+""",
+    ),
 ]
 
 

--- a/tests/functional/test_ansible_output.py
+++ b/tests/functional/test_ansible_output.py
@@ -753,3 +753,419 @@ def test_ansible_output_check(
     print(stdout.getvalue())
     assert actual_rc == expected_rc
     assert stdout.getvalue() == expected_stdout
+
+
+EXPECTED_REPLACE_RESULTS: list[
+    tuple[str, str, AnsiblePlaybookSuccess | AnsiblePlaybookFailure | None, int, str, bool, str]
+] = [
+    (
+        "no-code-block.rst",
+        """
+Working with versions
+---------------------
+
+Foo.
+""",
+        None,
+        0,
+        "",
+        False,
+        """
+Working with versions
+---------------------
+
+Foo.
+""",
+    ),
+    (
+        "working-test.rst",
+        """
+Working with versions
+---------------------
+
+This produces:
+
+.. ansible-output-data::
+
+    env:
+      ANSIBLE_STDOUT_CALLBACK: community.general.tasks_only
+      ANSIBLE_COLLECTIONS_TASKS_ONLY_COLUMN_WIDTH: "90"
+    playbook: |-
+      - hosts: localhost
+        gather_facts: false
+        tasks:
+          - name: Sort list by version number
+            debug:
+              var: ansible_versions | community.general.version_sort
+            vars:
+              ansible_versions:
+                - '2.8.0'
+                - '2.11.0'
+                - '2.7.0'
+                - '2.10.0'
+                - '2.9.0'
+
+.. code-block:: ansible-output
+
+    TASK [Sort list by version number] ********************************************************
+    ok: [localhost] => {
+        "ansible_versions | community.general.version_sort": [
+            "2.7.0",
+            "2.8.0",
+            "2.9.0",
+            "2.10.0",
+            "2.11.0"
+        ]
+    }
+
+.. versionadded: 2.2.0
+""",
+        AnsiblePlaybookSuccess(
+            ["ansible-playbook", "playbook.yml"],
+            {
+                "NO_COLOR": "true",
+                "ANSIBLE_STDOUT_CALLBACK": "community.general.tasks_only",
+                "ANSIBLE_COLLECTIONS_TASKS_ONLY_COLUMN_WIDTH": "90",
+            },
+            """TASK [Sort list by version number] ********************************************************
+ok: [localhost] => {
+    "ansible_versions | community.general.version_sort": [
+        "2.7.0",
+        "2.8.0",
+        "2.9.0",
+        "2.10.0",
+        "2.11.0"
+    ]
+}
+""",
+        ),
+        0,
+        "",
+        False,
+        """
+Working with versions
+---------------------
+
+This produces:
+
+.. ansible-output-data::
+
+    env:
+      ANSIBLE_STDOUT_CALLBACK: community.general.tasks_only
+      ANSIBLE_COLLECTIONS_TASKS_ONLY_COLUMN_WIDTH: "90"
+    playbook: |-
+      - hosts: localhost
+        gather_facts: false
+        tasks:
+          - name: Sort list by version number
+            debug:
+              var: ansible_versions | community.general.version_sort
+            vars:
+              ansible_versions:
+                - '2.8.0'
+                - '2.11.0'
+                - '2.7.0'
+                - '2.10.0'
+                - '2.9.0'
+
+.. code-block:: ansible-output
+
+    TASK [Sort list by version number] ********************************************************
+    ok: [localhost] => {
+        "ansible_versions | community.general.version_sort": [
+            "2.7.0",
+            "2.8.0",
+            "2.9.0",
+            "2.10.0",
+            "2.11.0"
+        ]
+    }
+
+.. versionadded: 2.2.0
+""",
+    ),
+    (
+        "modified-test.rst",
+        """
+.. ansible-output-data::
+
+    env:
+      ANSIBLE_STDOUT_CALLBACK: community.general.tasks_only
+      ANSIBLE_COLLECTIONS_TASKS_ONLY_COLUMN_WIDTH: "80"
+    playbook: |-
+      - hosts: localhost
+        gather_facts: false
+        tasks:
+          - name: Sort list by version number
+            debug:
+              var: ansible_versions | community.general.version_sort
+            vars:
+              ansible_versions:
+                - '2.8.0'
+                - '2.11.0'
+                - '2.7.0'
+                - '2.10.0'
+
+.. code-block:: ansible-output
+
+    TASK [Sort list by version number] ********************************************************
+    ok: [localhost] => {
+        "ansible_versions | community.general.version_sort": [
+            "2.7.0",
+            "2.8.0",
+            "2.9.0",
+            "2.10.0",
+            "2.11.0"
+        ]
+    }
+
+.. versionadded: 2.2.0
+""",
+        AnsiblePlaybookSuccess(
+            ["ansible-playbook", "playbook.yml"],
+            {
+                "NO_COLOR": "true",
+                "ANSIBLE_STDOUT_CALLBACK": "community.general.tasks_only",
+                "ANSIBLE_COLLECTIONS_TASKS_ONLY_COLUMN_WIDTH": "80",
+            },
+            """TASK [Sort list by version number] **********************************************
+ok: [localhost] => {
+    "ansible_versions | community.general.version_sort": [
+        "2.7.0",
+        "2.8.0",
+        "2.10.0",
+        "2.11.0"
+    ]
+}
+""",
+        ),
+        0,
+        "Write modified-test.rst...\n",
+        True,
+        """
+.. ansible-output-data::
+
+    env:
+      ANSIBLE_STDOUT_CALLBACK: community.general.tasks_only
+      ANSIBLE_COLLECTIONS_TASKS_ONLY_COLUMN_WIDTH: "80"
+    playbook: |-
+      - hosts: localhost
+        gather_facts: false
+        tasks:
+          - name: Sort list by version number
+            debug:
+              var: ansible_versions | community.general.version_sort
+            vars:
+              ansible_versions:
+                - '2.8.0'
+                - '2.11.0'
+                - '2.7.0'
+                - '2.10.0'
+
+.. code-block:: ansible-output
+
+    TASK [Sort list by version number] **********************************************
+    ok: [localhost] => {
+        "ansible_versions | community.general.version_sort": [
+            "2.7.0",
+            "2.8.0",
+            "2.10.0",
+            "2.11.0"
+        ]
+    }
+
+.. versionadded: 2.2.0
+""",
+    ),
+    (
+        "working-test-in-table.rst",
+        """
++----------------------------------------------------------------------+----------------------------------------------------------------+
+| .. ansible-output-data::                                             | .. code-block:: ansible-output                                 |
+|                                                                      |                                                                |
+|     env:                                                             |     TASK [Sort list by version number] *********************** |
+|       ANSIBLE_STDOUT_CALLBACK: community.general.tasks_only          |     ok: [localhost] => {                                       |
+|       ANSIBLE_COLLECTIONS_TASKS_ONLY_COLUMN_WIDTH: "57"              |         "ansible_versions | community.general.version_sort": [ |
+|     playbook: |-                                                     |             "2.7.0",                                           |
+|       - hosts: localhost                                             |             "2.8.0",                                           |
+|         gather_facts: false                                          |             "2.9.0",                                           |
+|         tasks:                                                       |             "2.10.0",                                          |
+|           - name: Sort list by version number                        |             "2.11.0"                                           |
+|             debug:                                                   |         ]                                                      |
+|               var: ansible_versions | community.general.version_sort |     }                                                          |
+|             vars:                                                    |                                                                |
+|               ansible_versions:                                      | .. versionadded: 2.2.0                                         |
+|                 - '2.8.0'                                            |                                                                |
+|                 - '2.11.0'                                           |                                                                |
+|                 - '2.7.0'                                            |                                                                |
+|                 - '2.10.0'                                           |                                                                |
+|                 - '2.9.0'                                            |                                                                |
++----------------------------------------------------------------------+----------------------------------------------------------------+
+""",
+        AnsiblePlaybookSuccess(
+            ["ansible-playbook", "playbook.yml"],
+            {
+                "NO_COLOR": "true",
+                "ANSIBLE_STDOUT_CALLBACK": "community.general.tasks_only",
+                "ANSIBLE_COLLECTIONS_TASKS_ONLY_COLUMN_WIDTH": "57",
+            },
+            """TASK [Sort list by version number] ***********************
+ok: [localhost] => {
+    "ansible_versions | community.general.version_sort": [
+        "2.7.0",
+        "2.8.0",
+        "2.9.0",
+        "2.10.0",
+        "2.11.0"
+    ]
+}
+""",
+        ),
+        0,
+        "",
+        False,
+        """
++----------------------------------------------------------------------+----------------------------------------------------------------+
+| .. ansible-output-data::                                             | .. code-block:: ansible-output                                 |
+|                                                                      |                                                                |
+|     env:                                                             |     TASK [Sort list by version number] *********************** |
+|       ANSIBLE_STDOUT_CALLBACK: community.general.tasks_only          |     ok: [localhost] => {                                       |
+|       ANSIBLE_COLLECTIONS_TASKS_ONLY_COLUMN_WIDTH: "57"              |         "ansible_versions | community.general.version_sort": [ |
+|     playbook: |-                                                     |             "2.7.0",                                           |
+|       - hosts: localhost                                             |             "2.8.0",                                           |
+|         gather_facts: false                                          |             "2.9.0",                                           |
+|         tasks:                                                       |             "2.10.0",                                          |
+|           - name: Sort list by version number                        |             "2.11.0"                                           |
+|             debug:                                                   |         ]                                                      |
+|               var: ansible_versions | community.general.version_sort |     }                                                          |
+|             vars:                                                    |                                                                |
+|               ansible_versions:                                      | .. versionadded: 2.2.0                                         |
+|                 - '2.8.0'                                            |                                                                |
+|                 - '2.11.0'                                           |                                                                |
+|                 - '2.7.0'                                            |                                                                |
+|                 - '2.10.0'                                           |                                                                |
+|                 - '2.9.0'                                            |                                                                |
++----------------------------------------------------------------------+----------------------------------------------------------------+
+""",
+    ),
+    (
+        "failing-test-in-table.rst",
+        """
++----------------------------------------------------------------------+----------------------------------------------------------------+
+| .. ansible-output-data::                                             | .. code-block:: ansible-output                                 |
+|                                                                      |                                                                |
+|     env:                                                             |     TASK [Sort list by version number] *********************** |
+|       ANSIBLE_STDOUT_CALLBACK: community.general.tasks_only          |     ok: [localhost] => {                                       |
+|       ANSIBLE_COLLECTIONS_TASKS_ONLY_COLUMN_WIDTH: "57"              |         "ansible_versions | community.general.version_sort": [ |
+|     playbook: |-                                                     |             "2.7.0",                                           |
+|       - hosts: localhost                                             |             "2.8.0",                                           |
+|         gather_facts: false                                          |             "2.9.0",                                           |
+|         tasks:                                                       |             "2.10.0",                                          |
+|           - name: Sort list by version number                        |             "2.11.0"                                           |
+|             debug:                                                   |         ]                                                      |
+|               var: ansible_versions | community.general.version_sort |     }                                                          |
+|             vars:                                                    |                                                                |
+|               ansible_versions:                                      | .. versionadded: 2.2.0                                         |
+|                 - '2.8.0'                                            |                                                                |
+|                 - '2.11.0'                                           |                                                                |
+|                 - '2.7.0'                                            |                                                                |
+|                 - '2.10.0'                                           |                                                                |
+|                 - '2.9.0'                                            |                                                                |
++----------------------------------------------------------------------+----------------------------------------------------------------+
+""",
+        AnsiblePlaybookSuccess(
+            ["ansible-playbook", "playbook.yml"],
+            {
+                "NO_COLOR": "true",
+                "ANSIBLE_STDOUT_CALLBACK": "community.general.tasks_only",
+                "ANSIBLE_COLLECTIONS_TASKS_ONLY_COLUMN_WIDTH": "57",
+            },
+            """TASK [Sort list by version number] ***********************
+ok: [localhost] => {
+    "ansible_versions | community.general.version_sort": [
+        "2.8.0",
+        "2.9.0",
+        "2.10.0",
+        "2.11.0"
+    ]
+}
+""",
+        ),
+        3,
+        r"""
+Found 1 error:
+failing-test-in-table.rst:5:1: Code block is not replacable
+""",
+        False,
+        """
++----------------------------------------------------------------------+----------------------------------------------------------------+
+| .. ansible-output-data::                                             | .. code-block:: ansible-output                                 |
+|                                                                      |                                                                |
+|     env:                                                             |     TASK [Sort list by version number] *********************** |
+|       ANSIBLE_STDOUT_CALLBACK: community.general.tasks_only          |     ok: [localhost] => {                                       |
+|       ANSIBLE_COLLECTIONS_TASKS_ONLY_COLUMN_WIDTH: "57"              |         "ansible_versions | community.general.version_sort": [ |
+|     playbook: |-                                                     |             "2.7.0",                                           |
+|       - hosts: localhost                                             |             "2.8.0",                                           |
+|         gather_facts: false                                          |             "2.9.0",                                           |
+|         tasks:                                                       |             "2.10.0",                                          |
+|           - name: Sort list by version number                        |             "2.11.0"                                           |
+|             debug:                                                   |         ]                                                      |
+|               var: ansible_versions | community.general.version_sort |     }                                                          |
+|             vars:                                                    |                                                                |
+|               ansible_versions:                                      | .. versionadded: 2.2.0                                         |
+|                 - '2.8.0'                                            |                                                                |
+|                 - '2.11.0'                                           |                                                                |
+|                 - '2.7.0'                                            |                                                                |
+|                 - '2.10.0'                                           |                                                                |
+|                 - '2.9.0'                                            |                                                                |
++----------------------------------------------------------------------+----------------------------------------------------------------+
+""",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "rst_filename, rst_content, ansible_playbook_command, expected_rc, expected_stdout, rst_updated, rst_new_content",
+    EXPECTED_REPLACE_RESULTS,
+    ids=[entry[0] for entry in EXPECTED_REPLACE_RESULTS],
+)
+def test_ansible_output_replace(
+    rst_filename: str,
+    rst_content: str,
+    ansible_playbook_command: AnsiblePlaybookSuccess | AnsiblePlaybookFailure | None,
+    expected_rc: int,
+    expected_stdout: str,
+    rst_updated: bool,
+    rst_new_content: str,
+    tmp_path: Path,
+):
+    command = [
+        "antsibull-docs",
+        "ansible-output",
+        "--no-force-color",
+        rst_filename,
+    ]
+
+    rst_path = tmp_path / rst_filename
+    rst_path.write_text(rst_content)
+    old_stat = rst_path.stat()
+
+    stdout = io.StringIO()
+    with change_cwd(tmp_path):
+        with redirect_stdout(stdout):
+            with patch_ansible_playbook(
+                ansible_playbook_command=ansible_playbook_command
+            ):
+                actual_rc = run(command)
+    print(f"RC: {actual_rc}")
+    print("Stdout:")
+    print(stdout.getvalue())
+    assert actual_rc == expected_rc
+    assert stdout.getvalue() == expected_stdout
+
+    new_stat = rst_path.stat()
+    if rst_updated:
+        assert old_stat != new_stat
+    else:
+        assert old_stat == new_stat
+    assert rst_path.read_text() == rst_new_content

--- a/tests/functional/test_docs_linting.py
+++ b/tests/functional/test_docs_linting.py
@@ -6,10 +6,11 @@ from __future__ import annotations
 
 import io
 import os
-from contextlib import contextmanager, redirect_stdout
+from contextlib import redirect_stdout
 
 import pytest
 from ansible_doc_caching import ansible_doc_cache
+from utils import change_cwd, update_environment
 
 from antsibull_docs.cli.antsibull_docs import run
 
@@ -3785,32 +3786,6 @@ TEST_CASES = [
         ],
     ),
 ]
-
-
-@contextmanager
-def change_cwd(directory: str):
-    old_dir = os.getcwd()
-    os.chdir(directory)
-    yield
-    os.chdir(old_dir)
-
-
-@contextmanager
-def update_environment(environment: dict[str, str | None]):
-    backup = {}
-    for k, v in environment.items():
-        if k in os.environ:
-            backup[k] = os.environ[k]
-        if v is not None:
-            os.environ[k] = v
-        elif k in os.environ:
-            del os.environ[k]
-    yield
-    for k in environment:
-        if k in backup:
-            os.environ[k] = backup[k]
-        elif k in os.environ:
-            del os.environ[k]
 
 
 @pytest.mark.parametrize(

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import os
 from contextlib import contextmanager
 from unittest import mock
 
@@ -19,3 +20,29 @@ def replace_antsibull_version(new_version=ANTSIBULL_DOCS_CI_VERSION):
         new_version,
     ):
         yield
+
+
+@contextmanager
+def change_cwd(directory: str) -> None:
+    old_dir = os.getcwd()
+    os.chdir(directory)
+    yield
+    os.chdir(old_dir)
+
+
+@contextmanager
+def update_environment(environment: dict[str, str | None]) -> None:
+    backup = {}
+    for k, v in environment.items():
+        if k in os.environ:
+            backup[k] = os.environ[k]
+        if v is not None:
+            os.environ[k] = v
+        elif k in os.environ:
+            del os.environ[k]
+    yield
+    for k in environment:
+        if k in backup:
+            os.environ[k] = backup[k]
+        elif k in os.environ:
+            del os.environ[k]


### PR DESCRIPTION
Instead of having to manually update example outputs in RST files, this allows to automatically generate these.

Ref: https://github.com/ansible-collections/community.general/pull/10347
