### PR TITLE
Remove ansible._protomatter if it wasn't explicitly requested and has no content

### DIFF
--- a/changelogs/fragments/405-protomatter.yml
+++ b/changelogs/fragments/405-protomatter.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "Remove ``ansible._protomatter`` from the collection list if no plugins are found for it and it has not been explicitly added to the collection list
+     (https://github.com/ansible-community/antsibull-docs/pull/405)."

--- a/src/antsibull_docs/cli/doc_commands/_build.py
+++ b/src/antsibull_docs/cli/doc_commands/_build.py
@@ -344,7 +344,7 @@ def _add_deprecation_info(
             metadata.removal_ansible_major_version = meta.removal.major_version
 
 
-def generate_docs_for_all_collections(  # noqa: C901
+def generate_docs_for_all_collections(  # noqa: C901  # pylint: disable=too-many-branches
     venv: VenvRunner | FakeVenvRunner,
     collection_dir: str | None,
     dest_dir: str,
@@ -442,6 +442,18 @@ def generate_docs_for_all_collections(  # noqa: C901
     _remove_collections(
         plugin_info, collection_metadata, exclude_collection_names or []
     )
+    if (
+        "ansible._protomatter" in collection_metadata
+        and collection_names is None
+        and not any(
+            any(
+                plugin_name.startswith("ansible._protomatter.")
+                for plugin_name in plugins
+            )
+            for plugins in plugin_info.values()
+        )
+    ):
+        _remove_collections(plugin_info, collection_metadata, ["ansible._protomatter"])
 
     # Load collection routing information
     collection_routing = asyncio.run(load_all_collection_routing(collection_metadata))


### PR DESCRIPTION
Right now it shows up on the collection list for the official docsite, but has no content.
(The content is actively hidden by ansible-doc: https://github.com/ansible/ansible/blob/38823665858c57ffd1fbc08c6acbead20d339c51/lib/ansible/cli/doc.py#L799-L801)
