### PR TITLE
ansible-output subcommand: add --config parameter

### DIFF
--- a/changelogs/fragments/410-config.yml
+++ b/changelogs/fragments/410-config.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Add ``--config`` parameter to the ``ansible-output`` subcommand to allow specifying a config file when not in collection mode (https://github.com/ansible-community/antsibull-docs/pull/410)."

--- a/docs/ansible-output.md
+++ b/docs/ansible-output.md
@@ -429,6 +429,31 @@ $ antsibull-docs ansible-output /path/to/directory-with-rst-files
 
 If the provided path is a directory, it will recursively look for `.rst` files in it.
 
+You can pass a path to a config file with `--config /path/to/config.yaml`.
+You can use the keys that are described as part of `ansible_output` in [the following section](#collection-usage).
+
+This can look as follows:
+```yaml
+---
+# Configuration for 'antsibull-docs ansible-output'
+
+# Insert definitions into 'env' for every ansible-output-data directive
+global_env:
+  ANSIBLE_STDOUT_CALLBACK: community.general.tasks_only
+  ANSIBLE_COLLECTIONS_TASKS_ONLY_NUMBER_OF_COLUMNS: 80
+
+# Global post-processors for Ansible output
+global_postprocessors:
+  # Keys are the names that can be referenced in ansible-output-data directives
+  reformat-yaml:
+    # For CLI tools, you can specify a command that accepts input on stdin
+    # and outputs the result on stdout:
+    command:
+      - python
+      - "-m"
+      - pyaml
+```
+
 ## Collection usage
 
 If you run `antsibull-docs ansible-output` without a path, it assumes that you are in a collection's root directory.

--- a/src/antsibull_docs/cli/antsibull_docs.py
+++ b/src/antsibull_docs/cli/antsibull_docs.py
@@ -863,6 +863,11 @@ def parse_args(program_name: str, args: list[str]) -> argparse.Namespace:
         help="Force enable or disable color in diffs when using --check."
         " By default decides on whether stdout is a tty or not.",
     )
+    ansible_output_parser.add_argument(
+        "--config",
+        help="Path to config file. Can only be specified when at least one path"
+        " has been provided to ansible-output.",
+    )
 
     # This must come after all parser setup
     if HAS_ARGCOMPLETE:


### PR DESCRIPTION
This is only available when not in collection mode (there the collections' docs config is used).

This can be useful for using this in https://github.com/ansible/ansible-documentation.