### PR TITLE
Take advantage of Git repos when copying collection directories

### DIFF
--- a/changelogs/fragments/438-lint-copying.yml
+++ b/changelogs/fragments/438-lint-copying.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - "When copying collections to a temporary directory for reading their documentation with ansible-doc,
+     detect whether they are part of Git repositories, and if yes, do not copy ignored files
+     (https://github.com/ansible-community/antsibull-docs/pull/438)."


### PR DESCRIPTION
This speeds up linting quite a lot for me, since it doesn't copies the large `.nox` subdirectory.