### PR TITLE
Sign release tags and release commits

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -230,7 +230,9 @@ def bump(session: nox.Session):
             str(fragment_file),
             external=True,
         )
-        session.run("git", "commit", "-m", f"Prepare {version}.", external=True)
+        session.run(
+            "git", "commit", "-m", f"Prepare {version}.", "--gpg-sign", external=True
+        )
     session.run("antsibull-changelog", "release")
     session.run(
         "git",
@@ -246,7 +248,9 @@ def bump(session: nox.Session):
         external=True,
     )
     install(session, ".")  # Smoke test
-    session.run("git", "commit", "-m", f"Release {version}.", external=True)
+    session.run(
+        "git", "commit", "-m", f"Release {version}.", "--gpg-sign", external=True
+    )
     session.run(
         "git",
         "tag",
@@ -270,7 +274,9 @@ def publish(session: nox.Session):
     session.run("hatch", "publish", *session.posargs)
     session.run("hatch", "version", "post")
     session.run("git", "add", "src/antsibull_docs/__init__.py", external=True)
-    session.run("git", "commit", "-m", "Post-release version bump.", external=True)
+    session.run(
+        "git", "commit", "-m", "Post-release version bump.", "--gpg-sign", external=True
+    )
 
 
 @nox.session

--- a/noxfile.py
+++ b/noxfile.py
@@ -251,6 +251,7 @@ def bump(session: nox.Session):
         "git",
         "tag",
         "-a",
+        "-s",
         "-m",
         f"antsibull-docs {version}",
         "--edit",


### PR DESCRIPTION
Make sure that the preparation, release, and post-release commits are signed. When tagging the release commit, also sign it.