### PR TITLE
Do not redefine env-vars mentioned in envvar_directives

### DIFF
--- a/changelogs/fragments/471-env.yml
+++ b/changelogs/fragments/471-env.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "Do not re-define environment variables mentioned in a collection's config file's ``envvar_directives`` in the environment variable index
+     (https://github.com/ansible-community/antsibull-docs/pull/471)."

--- a/src/antsibull_docs/cli/doc_commands/_build.py
+++ b/src/antsibull_docs/cli/doc_commands/_build.py
@@ -35,6 +35,7 @@ from ...docs_parsing.routing import (
     remove_redirect_duplicates,
 )
 from ...env_variables import (
+    collect_docs_defined_envvars,
     collect_referable_envvars,
     collect_referenced_environment_variables,
     load_ansible_config,
@@ -725,6 +726,7 @@ def generate_docs_for_all_collections(  # noqa: C901  # pylint: disable=too-many
         _register_extra_docs(output, extra_docs_data, squash_hierarchy=squash_hierarchy)
 
     if output_format == OutputFormat.ANSIBLE_DOCSITE:
+        docs_defined_envvars = collect_docs_defined_envvars(collection_metadata)
         asyncio.run(
             output_environment_variables(
                 output,
@@ -733,6 +735,7 @@ def generate_docs_for_all_collections(  # noqa: C901  # pylint: disable=too-many
                 filename_generator=filename_generator,
                 squash_hierarchy=squash_hierarchy,
                 referable_envvars=referable_envvars,
+                docs_defined_envvars=docs_defined_envvars,
                 add_version=add_antsibull_docs_version,
             )
         )

--- a/src/antsibull_docs/data/docsite/ansible-docsite/list_of_env_variables.rst.j2
+++ b/src/antsibull_docs/data/docsite/ansible-docsite/list_of_env_variables.rst.j2
@@ -22,6 +22,9 @@ Environment variables used by the ansible-core configuration are documented in :
 
 {% for _, env_var in env_variables | dictsort %}
 .. envvar:: @{ env_var.name }@
+{%   if env_var.name in docs_defined_envvars %}
+   :no-index:
+{%   endif %}
 
 {%   for paragraph in env_var.description or [] %}
     @{ paragraph | replace('\n', '\n    ') | rst_ify(plugin_fqcn='', plugin_type='') | rst_indent(4) }@

--- a/src/antsibull_docs/env_variables.py
+++ b/src/antsibull_docs/env_variables.py
@@ -159,3 +159,18 @@ def collect_referable_envvars(
     for collection_meta in collection_metadata.values():
         referable_envvars.update(collection_meta.docs_config.envvar_directives)
     return referable_envvars
+
+
+def collect_docs_defined_envvars(
+    collection_metadata: Mapping[str, AnsibleCollectionMetadata],
+) -> set[str]:
+    """
+    :arg collection_metadata: A Mapping of collection names to collection metadata
+        objects.
+    :returns: A set of environment variables that are defined in collection extra
+        docs.
+    """
+    collection_envvars = set()
+    for collection_meta in collection_metadata.values():
+        collection_envvars.update(collection_meta.docs_config.envvar_directives)
+    return collection_envvars

--- a/src/antsibull_docs/write_docs/indexes.py
+++ b/src/antsibull_docs/write_docs/indexes.py
@@ -248,6 +248,7 @@ async def output_environment_variables(
     filename_generator: FilenameGenerator,
     squash_hierarchy: bool = False,
     referable_envvars: set[str] | None = None,
+    docs_defined_envvars: set[str] | None = None,
     add_version: bool = True,
 ) -> None:
     """
@@ -259,6 +260,8 @@ async def output_environment_variables(
                            Undefined behavior if documentation for multiple collections are
                            created.
     :kwarg referable_envvars: Optional set of environment variables that can be referenced.
+    :kwarg docs_defined_envvars: Optional set of environment variables that are already defined
+        in collection extra docs.
     :kwarg output_format: The output format to use.
     :kwarg add_version: If set to ``False``, will not insert antsibull-docs' version into
         the generated files.
@@ -290,6 +293,7 @@ async def output_environment_variables(
         env_var_list_tmpl,
         index_file,
         env_variables=env_variables,
+        docs_defined_envvars=docs_defined_envvars or set(),
         add_version=add_version,
     )
 


### PR DESCRIPTION
This bug currently causes CI in https://github.com/ansible-collections/community.docker/pull/1299 to fail.